### PR TITLE
Add robust API retrieval with retries and async support

### DIFF
--- a/fetch_clutch_data.py
+++ b/fetch_clutch_data.py
@@ -1,8 +1,14 @@
 import os
-import requests
 import time
+import asyncio
+from typing import List
+
 import pandas as pd
+import requests
+import httpx
 from dotenv import load_dotenv
+from requests.adapters import HTTPAdapter, Retry
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 load_dotenv()
 API_KEY = os.getenv("RAPIDAPI_KEY")
@@ -17,36 +23,82 @@ HEADERS = {
 LEAGUE_ID = 39  # English Premier League
 SEASON = 2023
 
-def get_fixtures(league_id, season):
+# Configure a requests session with retry and exponential backoff
+RETRY_STRATEGY = Retry(
+    total=5,
+    backoff_factor=1,
+    status_forcelist=[429, 500, 502, 503, 504],
+    allowed_methods=["GET"],
+)
+SESSION = requests.Session()
+ADAPTER = HTTPAdapter(max_retries=RETRY_STRATEGY)
+SESSION.mount("https://", ADAPTER)
+SESSION.mount("http://", ADAPTER)
+
+# Pause between requests (seconds) to respect API rate limits
+THROTTLE = 1
+
+def get_fixtures(league_id: int, season: int) -> List[int]:
     url = f"https://{HOST}/v3/fixtures"
     params = {"league": league_id, "season": season}
-    res = requests.get(url, headers=HEADERS, params=params)
+    res = SESSION.get(url, headers=HEADERS, params=params)
     res.raise_for_status()
     fixtures = res.json()['response']
     return [f['fixture']['id'] for f in fixtures]
 
-def get_events(fixture_id):
+@retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=1, max=10), reraise=True)
+def get_events(fixture_id: int) -> List[dict]:
     url = f"https://{HOST}/v3/fixtures/events"
     params = {"fixture": fixture_id}
-    res = requests.get(url, headers=HEADERS, params=params)
+    res = SESSION.get(url, headers=HEADERS, params=params)
     res.raise_for_status()
     return res.json()['response']
 
-def main():
+async def fetch_events_async(fixture_ids: List[int]) -> List[dict]:
+    """Fetch events concurrently using httpx."""
+    events: List[dict] = []
+    sem = asyncio.Semaphore(5)
+    async with httpx.AsyncClient() as client:
+
+        @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=1, max=10), reraise=True)
+        async def _get(fixture_id: int):
+            async with sem:
+                url = f"https://{HOST}/v3/fixtures/events"
+                params = {"fixture": fixture_id}
+                res = await client.get(url, headers=HEADERS, params=params)
+                res.raise_for_status()
+                await asyncio.sleep(THROTTLE)
+                data = res.json()['response']
+            for e in data:
+                e['fixture_id'] = fixture_id
+                events.append(e)
+
+        tasks = [asyncio.create_task(_get(fid)) for fid in fixture_ids]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for fid, result in zip(fixture_ids, results):
+            if isinstance(result, Exception):
+                print(f"Failed for fixture {fid}: {result}")
+    return events
+
+
+def main(use_async: bool = False) -> None:
     fixture_ids = get_fixtures(LEAGUE_ID, SEASON)
     print(f"Found {len(fixture_ids)} fixtures.")
 
-    all_events = []
-    for i, fixture_id in enumerate(fixture_ids):
-        print(f"[{i+1}/{len(fixture_ids)}] Fetching events for match {fixture_id}")
-        try:
-            events = get_events(fixture_id)
-            for e in events:
-                e['fixture_id'] = fixture_id
-                all_events.append(e)
-            time.sleep(1)  # Respect rate limit
-        except Exception as ex:
-            print(f"Failed for fixture {fixture_id}: {ex}")
+    if use_async:
+        all_events = asyncio.run(fetch_events_async(fixture_ids))
+    else:
+        all_events: List[dict] = []
+        for i, fixture_id in enumerate(fixture_ids):
+            print(f"[{i+1}/{len(fixture_ids)}] Fetching events for match {fixture_id}")
+            try:
+                events = get_events(fixture_id)
+                for e in events:
+                    e['fixture_id'] = fixture_id
+                    all_events.append(e)
+                time.sleep(THROTTLE)
+            except Exception as ex:
+                print(f"Failed for fixture {fixture_id}: {ex}")
 
     # Convert to DataFrame and save
     df = pd.json_normalize(all_events)
@@ -54,4 +106,15 @@ def main():
     print("✅ Saved events_raw.csv")
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fetch match events")
+    parser.add_argument(
+        "--async",
+        dest="use_async",
+        action="store_true",
+        help="Fetch events concurrently using httpx",
+    )
+
+    args = parser.parse_args()
+    main(use_async=args.use_async)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ python-dotenv==1.1.1
 pytz==2025.2
 referencing==0.36.2
 requests==2.32.4
+httpx==0.27.0
 rpds-py==0.26.0
 six==1.17.0
 smmap==5.0.2

--- a/test_api.py
+++ b/test_api.py
@@ -13,11 +13,16 @@ headers = {
     "X-RapidAPI-Host": "api-football-v1.p.rapidapi.com"
 }
 
-response = requests.get(url, headers=headers)
+def main():
+    response = requests.get(url, headers=headers)
 
-if response.status_code == 200:
-    data = response.json()
-    print("✅ API call successful. Sample data:")
-    print(data['response'][0])
-else:
-    print("❌ API call failed:", response.status_code, response.text)
+    if response.status_code == 200:
+        data = response.json()
+        print("✅ API call successful. Sample data:")
+        print(data['response'][0])
+    else:
+        print("❌ API call failed:", response.status_code, response.text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add requests Retry adapter and tenacity-based retries
- add optional async event fetching via httpx
- throttle requests to respect API limits
- wrap API example in `test_api.py` with a main guard
- add httpx to requirements

## Testing
- `python -m py_compile fetch_clutch_data.py clutch_dashboard.py process_clutch.py test_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c11fd19dc83228ebe454d61508a1a