### PR TITLE
Add league and year filters to dashboard

### DIFF
--- a/clutch_dashboard.py
+++ b/clutch_dashboard.py
@@ -3,11 +3,34 @@ import pandas as pd
 import plotly.express as px
 
 # Load the clutch data
-df = pd.read_csv("clutch_summary.csv", index_col='player_name')
+df = pd.read_csv("clutch_summary.csv", index_col="player_name")
+
+# Normalize possible column names
+if "season" in df.columns and "year" not in df.columns:
+    df.rename(columns={"season": "year"}, inplace=True)
+
+# Ensure league and year columns exist so dropdowns always render
+if "league" not in df.columns:
+    df["league"] = "All"
+if "year" not in df.columns:
+    df["year"] = "All"
 
 st.set_page_config(page_title="Clutch Player Dashboard", layout="wide")
 st.title("🧠 Clutch Score Dashboard")
 st.markdown("Visualizing late-game goals and assists under pressure (Minute ≥ 76).")
+
+# Dropdown filters for league and year
+league = st.selectbox(
+    "League", ["All"] + sorted([l for l in df["league"].unique() if l != "All"]), index=0
+)
+if league != "All":
+    df = df[df["league"] == league]
+
+year = st.selectbox(
+    "Year", ["All"] + sorted([y for y in df["year"].unique() if y != "All"]), index=0
+)
+if year != "All":
+    df = df[df["year"] == year]
 
 # Show top N players
 top_n = st.slider("Show Top N Players", min_value=5, max_value=50, value=10)


### PR DESCRIPTION
## Summary
- Normalize dataset columns and ensure league/year fields exist
- Add Streamlit selectboxes for league and year with inclusive "All" option

## Testing
- `python -m py_compile clutch_dashboard.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eae0e5da08322aa6607eb5a5217f5