### PR TITLE
Add league and year filters to dashboard

### DIFF
--- a/clutch_dashboard.py
+++ b/clutch_dashboard.py
@@ -3,11 +3,32 @@ import pandas as pd
 import plotly.express as px
 
 # Load the clutch data
-df = pd.read_csv("clutch_summary.csv", index_col='player_name')
+df = pd.read_csv("clutch_summary.csv")
+
+# Normalize possible column names
+if "season" in df.columns and "year" not in df.columns:
+    df.rename(columns={"season": "year"}, inplace=True)
+
+# Determine which column describes the league. Prefer the readable name
+# if present, otherwise fall back to the numeric identifier.
+league_col = "league" if "league" in df.columns else "league_id" if "league_id" in df.columns else None
+
+df.set_index("player_name", inplace=True)
 
 st.set_page_config(page_title="Clutch Player Dashboard", layout="wide")
 st.title("🧠 Clutch Score Dashboard")
 st.markdown("Visualizing late-game goals and assists under pressure (Minute ≥ 76).")
+
+# Dropdown filters for league and year
+league_options = sorted(df[league_col].dropna().unique()) if league_col else []
+league = st.selectbox("League", ["All"] + list(league_options))
+if league != "All" and league_col:
+    df = df[df[league_col] == league]
+
+year_options = sorted(df["year"].dropna().unique()) if "year" in df.columns else []
+year = st.selectbox("Year", ["All"] + list(year_options))
+if year != "All" and "year" in df.columns:
+    df = df[df["year"] == year]
 
 # Show top N players
 top_n = st.slider("Show Top N Players", min_value=5, max_value=50, value=10)

--- a/fetch_clutch_data.py
+++ b/fetch_clutch_data.py
@@ -73,7 +73,7 @@ def get_events(fixture_id: int) -> List[dict]:
 
 
 async def fetch_events_async(
-    fixture_ids: List[int], league: str, season: int
+    fixture_ids: List[int], league_id: int, league: str, season: int
 ) -> List[dict]:
     """Fetch events concurrently using httpx."""
     events: List[dict] = []
@@ -97,6 +97,7 @@ async def fetch_events_async(
             for e in data:
                 e["fixture_id"] = fid
                 e["league"] = league
+                e["league_id"] = league_id
                 e["season"] = season
                 events.append(e)
 
@@ -119,7 +120,7 @@ def main(use_async: bool = False) -> None:
 
             if use_async:
                 events = asyncio.run(
-                    fetch_events_async(fixture_ids, league_name, season)
+                    fetch_events_async(fixture_ids, league_id, league_name, season)
                 )
                 all_events.extend(events)
             else:
@@ -132,6 +133,7 @@ def main(use_async: bool = False) -> None:
                         for e in events:
                             e["fixture_id"] = fixture_id
                             e["league"] = league_name
+                            e["league_id"] = league_id
                             e["season"] = season
                             all_events.append(e)
                         time.sleep(THROTTLE)

--- a/process_clutch.py
+++ b/process_clutch.py
@@ -29,20 +29,38 @@ assists['Clutch_Goal'] = 0
 assists['Clutch_Assist'] = 1
 
 clutch_df = pd.concat([goals, assists])
-clutch_df = clutch_df[['player_name', 'fixture_id', 'Clutch_Goal', 'Clutch_Assist']]
+# Preserve both league name and ID so downstream consumers can show readable
+# options yet still filter by the underlying identifier if needed.
+clutch_df = clutch_df[
+    [
+        'player_name',
+        'fixture_id',
+        'league',
+        'league_id',
+        'season',
+        'Clutch_Goal',
+        'Clutch_Assist',
+    ]
+]
 
 # Step 5: Group and summarize
-summary = clutch_df.groupby('player_name').agg({
-    'fixture_id': 'nunique',
-    'Clutch_Goal': 'sum',
-    'Clutch_Assist': 'sum'
-}).rename(columns={
-    'fixture_id': 'Clutch_Matches'
-})
+summary = (
+    clutch_df.groupby(['player_name', 'league', 'league_id', 'season'])
+    .agg(
+        {
+            'fixture_id': 'nunique',
+            'Clutch_Goal': 'sum',
+            'Clutch_Assist': 'sum',
+        }
+    )
+    .rename(columns={'fixture_id': 'Clutch_Matches'})
+    .reset_index()
+)
 
+summary.rename(columns={'season': 'year'}, inplace=True)
 summary['Clutch_Score'] = summary['Clutch_Goal'] * 3 + summary['Clutch_Assist'] * 2
 summary['Score_per_Match'] = summary['Clutch_Score'] / summary['Clutch_Matches']
 summary = summary.sort_values('Clutch_Score', ascending=False)
 
-summary.to_csv("clutch_summary.csv")
-print("✅ clutch_summary.csv generated with", summary.shape[0], "players")
+summary.to_csv("clutch_summary.csv", index=False)
+print("✅ clutch_summary.csv generated with", summary.shape[0], "rows")


### PR DESCRIPTION
## Summary
- Include league name alongside ID in the clutch summary for readable filtering
- Populate dashboard league selector from available league column to show all leagues

## Testing
- `python -m py_compile clutch_dashboard.py process_clutch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eae0e5da08322aa6607eb5a5217f5