### PR TITLE
Switch processing and dashboard to SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 clutch_factor/
 __pycache__/
 .env
+
+clutch.db

--- a/clutch_dashboard.py
+++ b/clutch_dashboard.py
@@ -1,15 +1,20 @@
+import sqlite3
 import streamlit as st
 import pandas as pd
 import plotly.express as px
 
-# Load the clutch data
-
-df = pd.read_csv("clutch_summary.csv")
+DB_PATH = "clutch.db"
 
 
-# Normalize possible column names
-if "season" in df.columns and "year" not in df.columns:
-    df.rename(columns={"season": "year"}, inplace=True)
+@st.cache_data
+def load_data() -> pd.DataFrame:
+    """Return the clutch summary table from the SQLite database."""
+    with sqlite3.connect(DB_PATH) as conn:
+        df = pd.read_sql_query("SELECT * FROM clutch_summary", conn)
+    return df
+
+
+df = load_data()
 
 
 # Determine which column describes the league. Prefer the readable name

--- a/clutch_summary.csv
+++ b/clutch_summary.csv
@@ -1,2939 +1,4236 @@
-player_name,team_name,league,year,Clutch_Matches,Clutch_Goal,Clutch_Assist,Clutch_Score,Score_per_Match
-K. Benzema,Real Madrid,La Liga,2021,10,11,0,33,3.3
-A. Sørloth,Atletico Madrid,La Liga,2024,8,9,0,27,3.375
-A. Delort,Nice,Ligue 1,2021,7,8,0,24,3.4285714285714284
-Mohamed Salah,Liverpool,Premier League,2024,8,8,0,24,3.0
-K. Mbappé,Paris Saint Germain,Ligue 1,2022,8,8,0,24,3.0
-N. Füllkrug,Werder Bremen,Bundesliga,2022,7,8,0,24,3.4285714285714284
-K. Mbappé,Paris Saint Germain,Ligue 1,2023,8,8,0,24,3.0
-A. Diallo,Manchester United,Premier League,2024,5,7,0,21,4.2
-A. Lacazette,Lyon,Ligue 1,2022,5,7,0,21,4.2
-Cristhian Stuani,Girona,La Liga,2023,6,7,0,21,3.5
-Pedro,Lazio,Serie A,2024,6,7,0,21,3.5
-Robert Lewandowski,Barcelona,La Liga,2023,5,7,0,21,4.2
-L. Martínez,Inter,Serie A,2023,5,7,0,21,4.2
-S. Guirassy,VfB Stuttgart,Bundesliga,2023,5,7,0,21,4.2
-M. Arnautović,Bologna,Serie A,2021,7,7,0,21,3.0
-T. Kleindienst,FC Heidenheim,Bundesliga,2023,6,7,0,21,3.5
-Vinícius Júnior,Real Madrid,La Liga,2021,6,6,0,18,3.0
-F. Balogun,Reims,Ligue 1,2022,6,6,0,18,3.0
-A. Kramarić,1899 Hoffenheim,Bundesliga,2023,5,6,0,18,3.6
-C. Nkunku,RB Leipzig,Bundesliga,2022,6,6,0,18,3.0
-Ferran Torres,Barcelona,La Liga,2024,5,6,0,18,3.6
-Iago Aspas,Celta Vigo,La Liga,2024,6,6,0,18,3.0
-J. David,Lille,Ligue 1,2022,6,6,0,18,3.0
-H. Kane,Bayern Munich,Bundesliga,2023,6,6,0,18,3.0
-G. Mikautadze,Lyon,Ligue 1,2024,6,6,0,18,3.0
-H. Kane,Bayern München,Bundesliga,2024,5,6,0,18,3.6
-E. Haaland,Manchester City,Premier League,2023,6,6,0,18,3.0
-E. Haaland,Borussia Dortmund,Bundesliga,2021,6,6,0,18,3.0
-Son Heung-Min,Tottenham,Premier League,2023,6,6,0,18,3.0
-Lautaro Martínez,Inter,Serie A,2022,5,6,0,18,3.6
-A. Pinamonti,Empoli,Serie A,2021,5,6,0,18,3.6
-L. Stindl,Borussia Monchengladbach,Bundesliga,2022,5,6,0,18,3.6
-Rodrigo Muniz,Fulham,Premier League,2024,6,6,0,18,3.0
-T. Kleindienst,Borussia Mönchengladbach,Bundesliga,2024,6,6,0,18,3.0
-A. Modeste,FC Koln,Bundesliga,2021,6,6,0,18,3.0
-J. David,Lille,Ligue 1,2024,6,6,0,18,3.0
-Joselu,Espanyol,La Liga,2022,6,6,0,18,3.0
-C. Stuani,Girona,La Liga,2024,6,6,0,18,3.0
-Alexander Sørloth,Villarreal,La Liga,2023,6,6,0,18,3.0
-R. Orsolini,Bologna,Serie A,2022,5,5,0,15,3.0
-A. Belotti,Torino,Serie A,2021,3,5,0,15,5.0
-N. Okafor,AC Milan,Serie A,2023,5,5,0,15,3.0
-O. Dembélé,Paris Saint Germain,Ligue 1,2024,4,5,0,15,3.75
-H. Kane,Tottenham,Premier League,2022,5,5,0,15,3.0
-K. Havertz,Arsenal,Premier League,2023,5,5,0,15,3.0
-K. Mbappé,Real Madrid,La Liga,2024,5,5,0,15,3.0
-D. Lukébakio,Sevilla,La Liga,2024,5,5,0,15,3.0
-M. Dembélé,Lyon,Ligue 1,2021,5,5,0,15,3.0
-R. Lewandowski,Barcelona,La Liga,2022,5,5,0,15,3.0
-E. Demirović,VfB Stuttgart,Bundesliga,2024,5,5,0,15,3.0
-E. Haaland,Manchester City,Premier League,2022,5,5,0,15,3.0
-Gonçalo Ramos,Paris Saint Germain,Ligue 1,2023,5,5,0,15,3.0
-G. Reyna,Borussia Dortmund,Bundesliga,2022,5,5,0,15,3.0
-R. Sterling,Manchester City,Premier League,2021,5,5,0,15,3.0
-M. Arambarri,Getafe,La Liga,2024,4,5,0,15,3.75
-Son Heung-Min,Tottenham,Premier League,2021,5,5,0,15,3.0
-C. Stuani,Girona,La Liga,2022,5,5,0,15,3.0
-Joselu,Alaves,La Liga,2021,4,5,0,15,3.75
-J. Mateta,Crystal Palace,Premier League,2024,5,5,0,15,3.0
-B. Dia,Salernitana,Serie A,2022,5,5,0,15,3.0
-M. Bülter,FC Schalke 04,Bundesliga,2022,5,5,0,15,3.0
-D. Criscito,Genoa,Serie A,2021,5,5,0,15,3.0
-Mohamed Salah,Liverpool,Premier League,2022,5,5,0,15,3.0
-Mohamed Salah,Liverpool,Premier League,2023,5,5,0,15,3.0
-A. Gouiri,Nice,Ligue 1,2021,4,5,0,15,3.75
-R. Lewandowski,Bayern Munich,Bundesliga,2021,5,5,0,15,3.0
-D. Núñez,Liverpool,Premier League,2023,4,5,0,15,3.75
-M. Rashford,Manchester United,Premier League,2022,5,5,0,15,3.0
-F. Chiesa,Juventus,Serie A,2023,5,5,0,15,3.0
-W. Ben Yedder,Monaco,Ligue 1,2021,5,5,0,15,3.0
-W. Ben Yedder,Monaco,Ligue 1,2022,4,5,0,15,3.75
-L. Openda,Lens,Ligue 1,2022,4,5,0,15,3.75
-S. Guirassy,Borussia Dortmund,Bundesliga,2024,4,5,0,15,3.75
-Borja Mayoral,Getafe,La Liga,2023,4,4,0,12,3.0
-Oihan Sancet,Athletic Club,La Liga,2024,4,4,0,12,3.0
-J. Bellingham,Real Madrid,La Liga,2024,4,4,0,12,3.0
-P. Harres,Holstein Kiel,Bundesliga,2024,3,4,0,12,4.0
-N. Jackson,Chelsea,Premier League,2023,3,4,0,12,4.0
-H. Wilson,Fulham,Premier League,2024,3,4,0,12,4.0
-A. Dovbyk,AS Roma,Serie A,2024,4,4,0,12,3.0
-I. Salah,Rennes,Ligue 1,2023,3,4,0,12,4.0
-N. Viola,Cagliari,Serie A,2023,4,4,0,12,3.0
-N. Füllkrug,Borussia Dortmund,Bundesliga,2023,4,4,0,12,3.0
-W. Zaha,Crystal Palace,Premier League,2021,3,4,0,12,4.0
-Borja Iglesias,Real Betis,La Liga,2022,4,4,0,12,3.0
-Omar Marmoush,Eintracht Frankfurt,Bundesliga,2023,4,4,0,12,3.0
-G. Simeone,Napoli,Serie A,2022,4,4,0,12,3.0
-M. Tel,Bayern Munich,Bundesliga,2022,4,4,0,12,3.0
-C. Wilson,Newcastle,Premier League,2022,4,4,0,12,3.0
-M. Terrier,Rennes,Ligue 1,2021,4,4,0,12,3.0
-M. Tel,Bayern Munich,Bundesliga,2023,4,4,0,12,3.0
-R. Mahrez,Manchester City,Premier League,2021,4,4,0,12,3.0
-R. Lukaku,AS Roma,Serie A,2023,4,4,0,12,3.0
-D. McNeil,Everton,Premier League,2022,3,4,0,12,4.0
-R. Lukaku,Inter,Serie A,2022,4,4,0,12,3.0
-José Luis Morales,Villarreal,La Liga,2022,3,4,0,12,4.0
-M. Thuram,Inter,Serie A,2024,4,4,0,12,3.0
-M. Vecino,Lazio,Serie A,2023,4,4,0,12,3.0
-M. Thuram,Inter,Serie A,2023,4,4,0,12,3.0
-M. Niang,Empoli,Serie A,2023,4,4,0,12,3.0
-M. Rashford,Manchester United,Premier League,2021,4,4,0,12,3.0
-R. Falcao,Rayo Vallecano,La Liga,2021,4,4,0,12,3.0
-M. Pašalić,Atalanta,Serie A,2021,4,4,0,12,3.0
-T. Savanier,Montpellier,Ligue 1,2022,4,4,0,12,3.0
-Juanmi,Real Betis,La Liga,2021,4,4,0,12,3.0
-M. Kean,Fiorentina,Serie A,2024,4,4,0,12,3.0
-J. Wind,VfL Wolfsburg,Bundesliga,2024,3,4,0,12,4.0
-R. Cherki,Lyon,Ligue 1,2024,4,4,0,12,3.0
-A. Griezmann,Atletico Madrid,La Liga,2024,4,4,0,12,3.0
-Matheus Cunha,Wolves,Premier League,2024,4,4,0,12,3.0
-C. Palmer,Chelsea,Premier League,2024,4,4,0,12,3.0
-C. Morris,Luton,Premier League,2023,4,4,0,12,3.0
-B. Mbeumo,Brentford,Premier League,2023,4,4,0,12,3.0
-J. Gittens,Borussia Dortmund,Bundesliga,2024,4,4,0,12,3.0
-Mohamed Salah,Liverpool,Premier League,2021,4,4,0,12,3.0
-Jorge Molina,Granada CF,La Liga,2021,4,4,0,12,3.0
-R. Højlund,Manchester United,Premier League,2023,4,4,0,12,3.0
-K. Schlotterbeck,Vfl Bochum,Bundesliga,2023,4,4,0,12,3.0
-K. Onisiwo,FSV Mainz 05,Bundesliga,2022,4,4,0,12,3.0
-Jude Bellingham,Real Madrid,La Liga,2023,4,4,0,12,3.0
-D. Rice,Arsenal,Premier League,2023,4,4,0,12,3.0
-L. Blas,Nantes,Ligue 1,2022,4,4,0,12,3.0
-A. Lacazette,Lyon,Ligue 1,2023,4,4,0,12,3.0
-E. Emegha,Strasbourg,Ligue 1,2023,4,4,0,12,3.0
-Kike García,Alaves,La Liga,2024,3,4,0,12,4.0
-A. Sánchez,Marseille,Ligue 1,2022,4,4,0,12,3.0
-A. Thomasson,Strasbourg,Ligue 1,2021,4,4,0,12,3.0
-D. Zapata,Torino,Serie A,2023,4,4,0,12,3.0
-S. Adingra,Brighton,Premier League,2023,3,4,0,12,4.0
-Luis Alberto,Lazio,Serie A,2022,4,4,0,12,3.0
-A. Mac Allister,Brighton,Premier League,2022,4,4,0,12,3.0
-Rafael Leão,AC Milan,Serie A,2022,3,4,0,12,4.0
-M. Dabbur,1899 Hoffenheim,Bundesliga,2022,4,4,0,12,3.0
-S. Machino,Holstein Kiel,Bundesliga,2024,4,4,0,12,3.0
-Lucas Paquetá,Lyon,Ligue 1,2021,4,4,0,12,3.0
-S. Guirassy,Rennes,Ligue 1,2021,3,4,0,12,4.0
-Lucas Boyé,Granada CF,La Liga,2023,4,4,0,12,3.0
-T. Abraham,AS Roma,Serie A,2022,4,4,0,12,3.0
-Son Heung-Min,Tottenham,Premier League,2022,3,4,0,12,4.0
-L. Jović,AC Milan,Serie A,2023,4,4,0,12,3.0
-E. Choupo-Moting,Bayern Munich,Bundesliga,2021,4,4,0,12,3.0
-L. Muriel,Atalanta,Serie A,2021,4,4,0,12,3.0
-L. Messi,Paris Saint Germain,Ligue 1,2022,3,4,0,12,4.0
-A. Semenyo,Bournemouth,Premier League,2024,4,4,0,12,3.0
-L. Suárez,Atletico Madrid,La Liga,2021,3,4,0,12,4.0
-L. Pellegrini,AS Roma,Serie A,2021,4,4,0,12,3.0
-L. Jović,Fiorentina,Serie A,2022,4,4,0,12,3.0
-Á. Correa,Atletico Madrid,La Liga,2024,4,4,0,12,3.0
-S. Mounié,Stade Brestois 29,Ligue 1,2021,4,4,0,12,3.0
-Gonçalo Ramos,Paris Saint Germain,Ligue 1,2024,3,4,0,12,4.0
-O. Watkins,Aston Villa,Premier League,2023,4,4,0,12,3.0
-H. Barnes,Leicester,Premier League,2022,4,4,0,12,3.0
-H. Diallo,Strasbourg,Ligue 1,2022,4,4,0,12,3.0
-Y. Wissa,Brentford,Premier League,2021,4,4,0,12,3.0
-Y. Wissa,Brentford,Premier League,2022,4,4,0,12,3.0
-G. Rutter,1899 Hoffenheim,Bundesliga,2021,3,3,0,9,3.0
-Álvaro Morata,Atletico Madrid,La Liga,2022,2,3,0,9,4.5
-A. Adli,Bayer Leverkusen,Bundesliga,2023,3,3,0,9,3.0
-Y. Wissa,Brentford,Premier League,2024,3,3,0,9,3.0
-Y. Moukoko,Borussia Dortmund,Bundesliga,2022,3,3,0,9,3.0
-H. Diallo,Strasbourg,Ligue 1,2021,3,3,0,9,3.0
-H. Barnes,Newcastle,Premier League,2023,2,3,0,9,4.5
-Gorka Guruzeta,Athletic Club,La Liga,2024,3,3,0,9,3.0
-G. Ilenikhena,Monaco,Ligue 1,2024,2,3,0,9,4.5
-O. Óskarsson,Real Sociedad,La Liga,2024,2,3,0,9,4.5
-O. Édouard,Crystal Palace,Premier League,2021,2,3,0,9,4.5
-O. Watkins,Aston Villa,Premier League,2022,3,3,0,9,3.0
-O. Watkins,Aston Villa,Premier League,2021,3,3,0,9,3.0
-O. Vilhelmsson,SV Darmstadt 98,Bundesliga,2023,3,3,0,9,3.0
-C. Akpom,Lille,Ligue 1,2024,3,3,0,9,3.0
-Bruno Fernandes,Manchester United,Premier League,2023,3,3,0,9,3.0
-Álex Baena,Villarreal,La Liga,2022,2,3,0,9,4.5
-Á. Di María,Paris Saint Germain,Ligue 1,2021,3,3,0,9,3.0
-A. Ayew,LE Havre,Ligue 1,2023,2,3,0,9,4.5
-Á. Correa,Atletico Madrid,La Liga,2021,3,3,0,9,3.0
-G. Simeone,Verona,Serie A,2021,3,3,0,9,3.0
-Gonçalo Guedes,Valencia,La Liga,2021,3,3,0,9,3.0
-L. Martínez,Inter,Serie A,2024,3,3,0,9,3.0
-S. Skrzybski,Holstein Kiel,Bundesliga,2024,2,3,0,9,4.5
-S. Milinković-Savić,Lazio,Serie A,2022,3,3,0,9,3.0
-S. Milinković-Savić,Lazio,Serie A,2021,3,3,0,9,3.0
-S. Michel,Union Berlin,Bundesliga,2022,2,3,0,9,4.5
-S. McTominay,Manchester United,Premier League,2023,2,3,0,9,4.5
-S. Mavididi,Montpellier,Ligue 1,2022,3,3,0,9,3.0
-Sergio Canales,Real Betis,La Liga,2021,3,3,0,9,3.0
-L. Trossard,Arsenal,Premier League,2023,3,3,0,9,3.0
-Darder,Espanyol,La Liga,2022,3,3,0,9,3.0
-L. Sané,Bayern München,Bundesliga,2024,3,3,0,9,3.0
-L. Samardžić,Udinese,Serie A,2023,3,3,0,9,3.0
-A. Rabiot,Marseille,Ligue 1,2024,3,3,0,9,3.0
-A. Rabiot,Juventus,Serie A,2022,2,3,0,9,4.5
-A. Pinamonti,Genoa,Serie A,2024,3,3,0,9,3.0
-E. Buendía,Aston Villa,Premier League,2022,3,3,0,9,3.0
-L. Openda,RB Leipzig,Bundesliga,2023,3,3,0,9,3.0
-E. Adebayo,Luton,Premier League,2023,3,3,0,9,3.0
-Douglas Luiz,Aston Villa,Premier League,2023,3,3,0,9,3.0
-Dodi Lukebakio,Sevilla,La Liga,2023,3,3,0,9,3.0
-Diogo Jota,Liverpool,Premier League,2023,3,3,0,9,3.0
-L. Pavoletti,Cagliari,Serie A,2023,2,3,0,9,4.5
-Lucas Pérez,Cadiz,La Liga,2022,3,3,0,9,3.0
-S. Katompa Mvumpa,VfB Stuttgart,Bundesliga,2023,3,3,0,9,3.0
-S. Katompa Mvumpa,VfB Stuttgart,Bundesliga,2022,3,3,0,9,3.0
-A. Sánchez,Inter,Serie A,2021,3,3,0,9,3.0
-S. Gnabry,Bayern München,Bundesliga,2024,3,3,0,9,3.0
-Dani Olmo,Barcelona,La Liga,2024,3,3,0,9,3.0
-Lee Jae-Sung,FSV Mainz 05,Bundesliga,2023,2,3,0,9,4.5
-Sávio,Girona,La Liga,2023,2,3,0,9,4.5
-Son Heung-Min,Tottenham,Premier League,2024,3,3,0,9,3.0
-A. Nordin,Saint Etienne,Ligue 1,2021,3,3,0,9,3.0
-Sobrino,Cadiz,La Liga,2021,3,3,0,9,3.0
-L. Bailey,Aston Villa,Premier League,2023,3,3,0,9,3.0
-E. Dennis,Watford,Premier League,2021,3,3,0,9,3.0
-E. Demirović,FC Augsburg,Bundesliga,2023,3,3,0,9,3.0
-L. Ajorque,Stade Brestois 29,Ligue 1,2024,3,3,0,9,3.0
-Lautaro Martínez,Inter,Serie A,2021,3,3,0,9,3.0
-Lamine Yamal,Barcelona,La Liga,2024,3,3,0,9,3.0
-L. de Jong,Barcelona,La Liga,2021,3,3,0,9,3.0
-L. Waldschmidt,VfL Wolfsburg,Bundesliga,2022,3,3,0,9,3.0
-S. Fofana,Lens,Ligue 1,2021,3,3,0,9,3.0
-S. El Shaarawy,AS Roma,Serie A,2021,3,3,0,9,3.0
-S. Bergwijn,Tottenham,Premier League,2021,2,3,0,9,4.5
-S. Mané,Liverpool,Premier League,2021,2,3,0,9,4.5
-Lucas Vázquez,Real Madrid,La Liga,2022,3,3,0,9,3.0
-D. Zakaria,Monaco,Ligue 1,2024,3,3,0,9,3.0
-D. Welbeck,Brighton,Premier League,2021,3,3,0,9,3.0
-D. Vlahović,Juventus,Serie A,2024,3,3,0,9,3.0
-D. Vlahović,Juventus,Serie A,2023,3,3,0,9,3.0
-Rúben Neves,Wolves,Premier League,2021,3,3,0,9,3.0
-Rodrygo,Real Madrid,La Liga,2022,3,3,0,9,3.0
-Rodrigo,Leeds,Premier League,2022,3,3,0,9,3.0
-Rodri,Manchester City,Premier League,2023,3,3,0,9,3.0
-Roberto Firmino,Liverpool,Premier League,2022,3,3,0,9,3.0
-Richarlison,Tottenham,Premier League,2024,3,3,0,9,3.0
-S. Giménez,AC Milan,Serie A,2024,3,3,0,9,3.0
-M. Bayo,LE Havre,Ligue 1,2023,2,3,0,9,4.5
-M. Bayo,Clermont Foot,Ligue 1,2021,3,3,0,9,3.0
-D. Undav,VfB Stuttgart,Bundesliga,2024,3,3,0,9,3.0
-D. Undav,VfB Stuttgart,Bundesliga,2023,3,3,0,9,3.0
-A. Mitrović,Fulham,Premier League,2022,3,3,0,9,3.0
-A. Milik,Marseille,Ligue 1,2021,3,3,0,9,3.0
-A. Milik,Juventus,Serie A,2022,3,3,0,9,3.0
-T. Coulibaly,VfB Stuttgart,Bundesliga,2022,3,3,0,9,3.0
-K. Stöger,Vfl Bochum,Bundesliga,2023,3,3,0,9,3.0
-E. Guessand,Nice,Ligue 1,2023,3,3,0,9,3.0
-K. Nakamura,Reims,Ligue 1,2024,3,3,0,9,3.0
-D. Szoboszlai,RB Leipzig,Bundesliga,2022,3,3,0,9,3.0
-D. Solanke,Tottenham,Premier League,2024,3,3,0,9,3.0
-M. Antonio,West Ham,Premier League,2021,2,3,0,9,4.5
-M. Amoura,VfL Wolfsburg,Bundesliga,2024,3,3,0,9,3.0
-Raphinha,Barcelona,La Liga,2024,3,3,0,9,3.0
-Abdón Prats,Mallorca,La Liga,2023,2,3,0,9,4.5
-Rafael Leão,AC Milan,Serie A,2021,3,3,0,9,3.0
-D. Solanke,Bournemouth,Premier League,2023,3,3,0,9,3.0
-D. Ouattara,Bournemouth,Premier League,2024,3,3,0,9,3.0
-D. Origi,Liverpool,Premier League,2021,3,3,0,9,3.0
-E. Nwaneri,Arsenal,Premier League,2024,3,3,0,9,3.0
-Jubal,Auxerre,Ligue 1,2024,2,3,0,9,4.5
-T. Pukki,Norwich,Premier League,2021,3,3,0,9,3.0
-A. Lozano,Cadiz,La Liga,2021,3,3,0,9,3.0
-A. Lookman,Atalanta,Serie A,2024,3,3,0,9,3.0
-K. Mbappé,Paris Saint Germain,Ligue 1,2021,3,3,0,9,3.0
-K. Gameiro,Strasbourg,Ligue 1,2022,3,3,0,9,3.0
-T. Koopmeiners,Atalanta,Serie A,2022,3,3,0,9,3.0
-M. Ducksch,Werder Bremen,Bundesliga,2022,3,3,0,9,3.0
-R. Piccoli,Lecce,Serie A,2023,3,3,0,9,3.0
-Anastasios Douvikas,Celta Vigo,La Liga,2023,3,3,0,9,3.0
-R. Orsolini,Bologna,Serie A,2024,3,3,0,9,3.0
-M. Destro,Genoa,Serie A,2021,2,3,0,9,4.5
-M. Depay,Barcelona,La Liga,2021,3,3,0,9,3.0
-D. Mosquera,Verona,Serie A,2024,3,3,0,9,3.0
-D. Malen,Borussia Dortmund,Bundesliga,2023,3,3,0,9,3.0
-R. Kolo Muani,Paris Saint Germain,Ligue 1,2023,3,3,0,9,3.0
-Ante Budimir,Osasuna,La Liga,2023,3,3,0,9,3.0
-Ansu Fati,Barcelona,La Liga,2022,3,3,0,9,3.0
-M. Greenwood,Marseille,Ligue 1,2024,3,3,0,9,3.0
-D. Maldini,Monza,Serie A,2023,3,3,0,9,3.0
-D. Lukébakio,Hertha Berlin,Bundesliga,2022,3,3,0,9,3.0
-M. Fofana,Lyon,Ligue 1,2024,3,3,0,9,3.0
-M. Fofana,Lyon,Ligue 1,2023,3,3,0,9,3.0
-M. El Haddadi,Leganes,La Liga,2024,3,3,0,9,3.0
-D. Frattesi,Inter,Serie A,2023,3,3,0,9,3.0
-M. Ingvartsen,FSV Mainz 05,Bundesliga,2022,3,3,0,9,3.0
-A. Kalimuendo,Rennes,Ligue 1,2024,3,3,0,9,3.0
-T. Souček,West Ham,Premier League,2023,3,3,0,9,3.0
-T. Savanier,Montpellier,Ligue 1,2021,3,3,0,9,3.0
-João Pedro,Brighton,Premier League,2024,3,3,0,9,3.0
-João Pedro,Brighton,Premier League,2023,3,3,0,9,3.0
-E. Wahi,Montpellier,Ligue 1,2022,3,3,0,9,3.0
-E. Smith Rowe,Arsenal,Premier League,2021,3,3,0,9,3.0
-João Félix,Atletico Madrid,La Liga,2022,2,3,0,9,4.5
-José Luis Morales,Villarreal,La Liga,2023,3,3,0,9,3.0
-K. Benzema,Real Madrid,La Liga,2022,2,3,0,9,4.5
-E. Rashani,Clermont Foot,Ligue 1,2021,2,3,0,9,4.5
-M. Ingvartsen,FSV Mainz 05,Bundesliga,2021,3,3,0,9,3.0
-R. Højlund,Atalanta,Serie A,2022,3,3,0,9,3.0
-M. Pantović,VfL BOCHUM,Bundesliga,2021,3,3,0,9,3.0
-D. Dumfries,Inter,Serie A,2024,3,3,0,9,3.0
-D. Ciofani,Cremonese,Serie A,2022,3,3,0,9,3.0
-M. Retegui,Atalanta,Serie A,2024,3,3,0,9,3.0
-M. Pessina,Monza,Serie A,2023,3,3,0,9,3.0
-A. Isak,Newcastle,Premier League,2023,3,3,0,9,3.0
-A. Isak,Newcastle,Premier League,2022,3,3,0,9,3.0
-J. Ramsey,Aston Villa,Premier League,2021,3,3,0,9,3.0
-F. Bonazzoli,Salernitana,Serie A,2021,3,3,0,9,3.0
-J. Ward-Prowse,Southampton,Premier League,2022,3,3,0,9,3.0
-J. Ward-Prowse,Southampton,Premier League,2021,3,3,0,9,3.0
-J. Vásquez,Genoa,Serie A,2024,3,3,0,9,3.0
-J. Vardy,Leicester,Premier League,2021,3,3,0,9,3.0
-E. Ünal,Getafe,La Liga,2022,3,3,0,9,3.0
-Jorginho,Chelsea,Premier League,2021,3,3,0,9,3.0
-M. Thuram,Borussia Monchengladbach,Bundesliga,2022,3,3,0,9,3.0
-M. Terrier,Rennes,Ligue 1,2022,3,3,0,9,3.0
-Carlos Soler,Valencia,La Liga,2021,3,3,0,9,3.0
-Matheus Cunha,Wolves,Premier League,2023,3,3,0,9,3.0
-R. Bentancur,Tottenham,Premier League,2022,2,3,0,9,4.5
-B. Bourigeaud,Rennes,Ligue 1,2023,3,3,0,9,3.0
-Marcos Llorente,Atletico Madrid,La Liga,2023,3,3,0,9,3.0
-Marco Asensio,Real Madrid,La Liga,2022,3,3,0,9,3.0
-M. Đurić,Verona,Serie A,2023,3,3,0,9,3.0
-B. Dia,Villarreal,La Liga,2021,3,3,0,9,3.0
-Pere Milla,Espanyol,La Liga,2024,3,3,0,9,3.0
-Pere Milla,Elche,La Liga,2021,3,3,0,9,3.0
-Mikel Oyarzabal,Real Sociedad,La Liga,2021,3,3,0,9,3.0
-C. Summerville,Leeds,Premier League,2022,3,3,0,9,3.0
-Melero,Levante,La Liga,2021,3,3,0,9,3.0
-C. Immobile,Lazio,Serie A,2021,3,3,0,9,3.0
-Muniain,Athletic Club,La Liga,2021,3,3,0,9,3.0
-Mostafa Mohamed,Nantes,Ligue 1,2024,3,3,0,9,3.0
-Mostafa Mohamed,Nantes,Ligue 1,2022,3,3,0,9,3.0
-F. Wirtz,Bayer Leverkusen,Bundesliga,2023,2,3,0,9,4.5
-Vedat Muriqi,Mallorca,La Liga,2023,3,3,0,9,3.0
-V. Osimhen,Napoli,Serie A,2021,3,3,0,9,3.0
-V. Muriqi,Mallorca,La Liga,2024,3,3,0,9,3.0
-J. Durán,Aston Villa,Premier League,2024,3,3,0,9,3.0
-J. Durán,Aston Villa,Premier League,2023,2,3,0,9,4.5
-J. Musiala,Bayern München,Bundesliga,2024,3,3,0,9,3.0
-J. Mateta,Crystal Palace,Premier League,2023,3,3,0,9,3.0
-F. Honorat,Stade Brestois 29,Ligue 1,2021,3,3,0,9,3.0
-J. Maddison,Leicester,Premier League,2021,3,3,0,9,3.0
-Morales,Levante,La Liga,2021,3,3,0,9,3.0
-C. Pulišić,AC Milan,Serie A,2023,3,3,0,9,3.0
-C. Palmer,Chelsea,Premier League,2023,3,3,0,9,3.0
-C. Nkunku,RB Leipzig,Bundesliga,2021,3,3,0,9,3.0
-N. Maupay,Brighton,Premier League,2021,3,3,0,9,3.0
-B. Mbeumo,Brentford,Premier League,2022,3,3,0,9,3.0
-B. Johnson,Nottingham Forest,Premier League,2022,3,3,0,9,3.0
-P. Schick,Bayer Leverkusen,Bundesliga,2021,3,3,0,9,3.0
-P. Nebel,FSV Mainz 05,Bundesliga,2024,3,3,0,9,3.0
-Ayoze Pérez,Villarreal,La Liga,2024,3,3,0,9,3.0
-A. Gigović,Holstein Kiel,Bundesliga,2024,3,3,0,9,3.0
-A. Garnacho,Manchester United,Premier League,2024,3,3,0,9,3.0
-A. Garnacho,Manchester United,Premier League,2022,3,3,0,9,3.0
-Fábio Silva,Las Palmas,La Liga,2024,3,3,0,9,3.0
-I. Toney,Brentford,Premier League,2021,2,3,0,9,4.5
-J. Brandt,Borussia Dortmund,Bundesliga,2022,3,3,0,9,3.0
-J. Bowen,West Ham,Premier League,2021,3,3,0,9,3.0
-J. Ayew,Leicester,Premier League,2024,3,3,0,9,3.0
-J. David,Lille,Ligue 1,2023,2,3,0,9,4.5
-J. Cajuste,Reims,Ligue 1,2022,3,3,0,9,3.0
-P. Foden,Manchester City,Premier League,2024,3,3,0,9,3.0
-P. Dybala,AS Roma,Serie A,2022,3,3,0,9,3.0
-Beto,Udinese,Serie A,2021,3,3,0,9,3.0
-Bernardo Silva,Manchester City,Premier League,2023,3,3,0,9,3.0
-B. Šeško,RB Leipzig,Bundesliga,2023,2,3,0,9,4.5
-N. Krstović,Lecce,Serie A,2023,3,3,0,9,3.0
-N. Jackson,Villarreal,La Liga,2022,3,3,0,9,3.0
-N. González,Fiorentina,Serie A,2022,3,3,0,9,3.0
-C. Gallagher,Crystal Palace,Premier League,2021,3,3,0,9,3.0
-C. Gakpo,Liverpool,Premier League,2023,3,3,0,9,3.0
-X. Chavalerin,Estac Troyes,Ligue 1,2022,3,3,0,9,3.0
-Willian José,Real Betis,La Liga,2021,3,3,0,9,3.0
-W. Saïd,Lens,Ligue 1,2023,3,3,0,9,3.0
-I. Koné,Lorient,Ligue 1,2022,3,3,0,9,3.0
-Hwang Ui-Jo,Bordeaux,Ligue 1,2021,3,3,0,9,3.0
-J. Alvarez,Atletico Madrid,La Liga,2024,3,3,0,9,3.0
-W. McKennie,Juventus,Serie A,2021,3,3,0,9,3.0
-O. McBurnie,Sheffield Utd,Premier League,2023,3,3,0,9,3.0
-Borja Mayoral,Getafe,La Liga,2024,3,3,0,9,3.0
-Borja Mayoral,Getafe,La Liga,2022,3,3,0,9,3.0
-Borja Iglesias,Real Betis,La Liga,2021,3,3,0,9,3.0
-Omar Marmoush,Eintracht Frankfurt,Bundesliga,2024,3,3,0,9,3.0
-O. Burke,Werder Bremen,Bundesliga,2024,3,3,0,9,3.0
-C. De Ketelaere,Atalanta,Serie A,2023,3,3,0,9,3.0
-C. Baumgartner,RB Leipzig,Bundesliga,2023,3,3,0,9,3.0
-C. Bakambu,Marseille,Ligue 1,2021,3,3,0,9,3.0
-N. Woltemade,VfB Stuttgart,Bundesliga,2024,3,3,0,9,3.0
-Gerard Moreno,Villarreal,La Liga,2022,3,3,0,9,3.0
-G. Scamacca,Sassuolo,Serie A,2021,3,3,0,9,3.0
-G. Laborde,Rennes,Ligue 1,2021,3,3,0,9,3.0
-Gabriel Martinelli,Arsenal,Premier League,2023,2,3,0,9,4.5
-Gabriel Martinelli,Arsenal,Premier League,2022,3,3,0,9,3.0
-İ. Gündoğan,Manchester City,Premier League,2021,1,2,0,6,6.0
-A. Abdi,Nice,Ligue 1,2024,2,2,0,6,3.0
-G. Álvarez,Getafe,La Liga,2022,2,2,0,6,3.0
-G. Laborde,Nice,Ligue 1,2022,2,2,0,6,3.0
-G. Lapadula,Cagliari,Serie A,2023,2,2,0,6,3.0
-G. Lo Celso,Real Betis,La Liga,2024,2,2,0,6,3.0
-G. Maggiore,Salernitana,Serie A,2023,2,2,0,6,3.0
-Gerard Moreno,Villarreal,La Liga,2021,2,2,0,6,3.0
-Gerard Moreno,Villarreal,La Liga,2023,2,2,0,6,3.0
-Gerard Moreno,Villarreal,La Liga,2024,2,2,0,6,3.0
-Y. Poulsen,RB Leipzig,Bundesliga,2024,2,2,0,6,3.0
-Y. Poulsen,RB Leipzig,Bundesliga,2023,2,2,0,6,3.0
-Y. Poulsen,RB Leipzig,Bundesliga,2022,2,2,0,6,3.0
-Y. Moukoko,Borussia Dortmund,Bundesliga,2023,2,2,0,6,3.0
-Y. Herrera,Girona,La Liga,2022,2,2,0,6,3.0
-Y. En-Nesyri,Sevilla,La Liga,2022,2,2,0,6,3.0
-Gonçalo Paciência,Vfl Bochum,Bundesliga,2023,2,2,0,6,3.0
-H. Ekitike,Reims,Ligue 1,2021,2,2,0,6,3.0
-H. Barnes,Newcastle,Premier League,2024,2,2,0,6,3.0
-Gorka Guruzeta,Athletic Club,La Liga,2022,2,2,0,6,3.0
-G. Isaksen,Lazio,Serie A,2024,2,2,0,6,3.0
-G. Hirst,Ipswich,Premier League,2024,2,2,0,6,3.0
-G. Gineitis,Torino,Serie A,2024,2,2,0,6,3.0
-G. Fabbian,Bologna,Serie A,2023,2,2,0,6,3.0
-Y. Asprilla,Girona,La Liga,2024,2,2,0,6,3.0
-A. Doucouré,Everton,Premier League,2021,2,2,0,6,3.0
-Borja Mayoral,Getafe,La Liga,2021,2,2,0,6,3.0
-Beto,Udinese,Serie A,2022,2,2,0,6,3.0
-Omar Marmoush,VfB Stuttgart,Bundesliga,2021,2,2,0,6,3.0
-Oihan Sancet,Athletic Club,La Liga,2023,2,2,0,6,3.0
-P. Jansson,Brentford,Premier League,2021,2,2,0,6,3.0
-O. Burke,Werder Bremen,Bundesliga,2022,2,2,0,6,3.0
-C. Coady,Wolves,Premier League,2021,2,2,0,6,3.0
-C. Biraghi,Fiorentina,Serie A,2022,2,2,0,6,3.0
-C. Baumgartner,1899 Hoffenheim,Bundesliga,2021,1,2,0,6,6.0
-C. Bakambu,Real Betis,La Liga,2024,2,2,0,6,3.0
-Nuno Tavares,Marseille,Ligue 1,2022,2,2,0,6,3.0
-Neymar,Paris Saint Germain,Ligue 1,2021,2,2,0,6,3.0
-N. Zaniolo,Aston Villa,Premier League,2023,2,2,0,6,3.0
-N. Weiper,FSV Mainz 05,Bundesliga,2022,2,2,0,6,3.0
-O. Édouard,Crystal Palace,Premier League,2023,2,2,0,6,3.0
-C. Antwi-Adjei,Vfl Bochum,Bundesliga,2023,2,2,0,6,3.0
-C. Immobile,Lazio,Serie A,2022,2,2,0,6,3.0
-N. Vlašić,Torino,Serie A,2024,2,2,0,6,3.0
-N. Tagliafico,Lyon,Ligue 1,2023,2,2,0,6,3.0
-C. Gómez,Rennes,Ligue 1,2024,2,2,0,6,3.0
-C. Gytkjær,Venezia,Serie A,2024,2,2,0,6,3.0
-C. Gallagher,Chelsea,Premier League,2023,2,2,0,6,3.0
-C. Ekuban,Genoa,Serie A,2023,2,2,0,6,3.0
-C. Dessers,Cremonese,Serie A,2022,2,2,0,6,3.0
-N. Schmidt,Werder Bremen,Bundesliga,2022,2,2,0,6,3.0
-N. Paz,Como,Serie A,2024,2,2,0,6,3.0
-N. O'Reilly,Manchester City,Premier League,2024,2,2,0,6,3.0
-N. Molina,Udinese,Serie A,2021,2,2,0,6,3.0
-N. Mbuku,Reims,Ligue 1,2021,2,2,0,6,3.0
-P. Bamford,Leeds,Premier League,2021,2,2,0,6,3.0
-P. Aubameyang,Marseille,Ligue 1,2023,2,2,0,6,3.0
-Brais Méndez,Celta Vigo,La Liga,2021,2,2,0,6,3.0
-P. Foden,Manchester City,Premier League,2023,2,2,0,6,3.0
-P. Foden,Manchester City,Premier League,2021,2,2,0,6,3.0
-P. Dybala,Juventus,Serie A,2021,2,2,0,6,3.0
-P. Dybala,AS Roma,Serie A,2023,2,2,0,6,3.0
-Beto,Everton,Premier League,2023,2,2,0,6,3.0
-Bernardo Silva,Manchester City,Premier League,2021,2,2,0,6,3.0
-Bebé,Rayo Vallecano,La Liga,2023,2,2,0,6,3.0
-Barrenetxea,Real Sociedad,La Liga,2022,2,2,0,6,3.0
-N. Matić,AS Roma,Serie A,2022,2,2,0,6,3.0
-N. Kalinić,Verona,Serie A,2021,2,2,0,6,3.0
-N. González,Fiorentina,Serie A,2023,2,2,0,6,3.0
-N. González,Fiorentina,Serie A,2021,2,2,0,6,3.0
-N. Fekir,Real Betis,La Liga,2022,2,2,0,6,3.0
-C. Kouamé,Fiorentina,Serie A,2023,2,2,0,6,3.0
-C. Itten,SpVgg Greuther Furth,Bundesliga,2021,2,2,0,6,3.0
-C. Immobile,Lazio,Serie A,2023,2,2,0,6,3.0
-C. Pulišić,AC Milan,Serie A,2024,2,2,0,6,3.0
-Memphis Depay,Atletico Madrid,La Liga,2023,2,2,0,6,3.0
-N. Edjouma,Toulouse,Ligue 1,2024,2,2,0,6,3.0
-Myrto Uzuni,Granada CF,La Liga,2023,2,2,0,6,3.0
-C. Nørgaard,Brentford,Premier League,2024,2,2,0,6,3.0
-Pedro,Lazio,Serie A,2022,2,2,0,6,3.0
-Paulinho,Bayer Leverkusen,Bundesliga,2021,1,2,0,6,6.0
-B. Saka,Arsenal,Premier League,2022,2,2,0,6,3.0
-B. Saka,Arsenal,Premier League,2021,2,2,0,6,3.0
-B. Mbeumo,Brentford,Premier League,2024,2,2,0,6,3.0
-B. Hollerbach,Union Berlin,Bundesliga,2024,2,2,0,6,3.0
-Pablo Torre,Barcelona,La Liga,2024,1,2,0,6,6.0
-Pablo Fornals,West Ham,Premier League,2021,2,2,0,6,3.0
-P. Schick,Bayer Leverkusen,Bundesliga,2024,2,2,0,6,3.0
-P. Onuachu,Southampton,Premier League,2024,2,2,0,6,3.0
-P. Groß,Brighton,Premier League,2022,2,2,0,6,3.0
-R. Andrich,Bayer Leverkusen,Bundesliga,2023,2,2,0,6,3.0
-Portu,Girona,La Liga,2023,2,2,0,6,3.0
-Philippe Coutinho,Barcelona,La Liga,2021,2,2,0,6,3.0
-B. Embolo,Monaco,Ligue 1,2022,2,2,0,6,3.0
-B. Embolo,Borussia Monchengladbach,Bundesliga,2021,2,2,0,6,3.0
-B. Dieng,Lorient,Ligue 1,2023,2,2,0,6,3.0
-B. Dieng,Angers,Ligue 1,2024,2,2,0,6,3.0
-B. Diakité,Lille,Ligue 1,2023,2,2,0,6,3.0
-B. Dia,Salernitana,Serie A,2023,1,2,0,6,6.0
-B. De Cordova-Reid,Fulham,Premier League,2023,2,2,0,6,3.0
-R. Del Castillo,Stade Brestois 29,Ligue 1,2023,2,2,0,6,3.0
-Mikel Vesga,Athletic Club,La Liga,2022,2,2,0,6,3.0
-Mikel Oyarzabal,Real Sociedad,La Liga,2023,2,2,0,6,3.0
-Mikel Merino,Real Sociedad,La Liga,2023,2,2,0,6,3.0
-Mikel Merino,Arsenal,Premier League,2024,1,2,0,6,6.0
-C. Wilson,Newcastle,Premier League,2023,2,2,0,6,3.0
-B. Bourigeaud,Rennes,Ligue 1,2022,2,2,0,6,3.0
-B. Barcola,Paris Saint Germain,Ligue 1,2024,2,2,0,6,3.0
-B. Barcola,Lyon,Ligue 1,2022,2,2,0,6,3.0
-Matheus Cunha,Atletico Madrid,La Liga,2021,2,2,0,6,3.0
-Martín Zubimendi,Real Sociedad,La Liga,2023,2,2,0,6,3.0
-Marquinhos,Paris Saint Germain,Ligue 1,2021,2,2,0,6,3.0
-Marco Asensio,Aston Villa,Premier League,2024,2,2,0,6,3.0
-Marc Cardona,Las Palmas,La Liga,2023,2,2,0,6,3.0
-Carlos Benavídez,Alaves,La Liga,2023,2,2,0,6,3.0
-C. Ünder,Marseille,Ligue 1,2021,2,2,0,6,3.0
-C. Wood,Nottingham Forest,Premier League,2023,2,2,0,6,3.0
-M. Ødegaard,Arsenal,Premier League,2022,2,2,0,6,3.0
-M. Ødegaard,Arsenal,Premier League,2021,2,2,0,6,3.0
-M. Weiser,Werder Bremen,Bundesliga,2024,2,2,0,6,3.0
-M. Vecino,Lazio,Serie A,2024,2,2,0,6,3.0
-R. Aït-Nouri,Wolves,Premier League,2024,2,2,0,6,3.0
-D. Bakwa,Strasbourg,Ligue 1,2024,2,2,0,6,3.0
-M. Thorsby,Sampdoria,Serie A,2021,2,2,0,6,3.0
-M. Svanberg,VfL Wolfsburg,Bundesliga,2024,2,2,0,6,3.0
-Cristiano Ronaldo,Manchester United,Premier League,2021,2,2,0,6,3.0
-M. Solomon,Fulham,Premier League,2022,2,2,0,6,3.0
-M. Simon,Nantes,Ligue 1,2022,2,2,0,6,3.0
-M. Simon,Nantes,Ligue 1,2021,2,2,0,6,3.0
-R. Cabella,Lille,Ligue 1,2022,2,2,0,6,3.0
-R. Borré,Eintracht Frankfurt,Bundesliga,2022,2,2,0,6,3.0
-R. Barkley,Nice,Ligue 1,2022,1,2,0,6,6.0
-R. Barkley,Luton,Premier League,2023,2,2,0,6,3.0
-R. Barkley,Aston Villa,Premier League,2024,2,2,0,6,3.0
-R. Baku,VfL Wolfsburg,Bundesliga,2022,2,2,0,6,3.0
-B. Cristante,AS Roma,Serie A,2024,2,2,0,6,3.0
-B. Cristante,AS Roma,Serie A,2023,2,2,0,6,3.0
-B. Brahimi,Nice,Ligue 1,2022,2,2,0,6,3.0
-D. Doekhi,Union Berlin,Bundesliga,2022,2,2,0,6,3.0
-D. Calvert-Lewin,Everton,Premier League,2021,2,2,0,6,3.0
-M. O'Riley,Brighton,Premier League,2024,2,2,0,6,3.0
-M. Mount,Chelsea,Premier League,2021,1,2,0,6,6.0
-M. Lopez,Sassuolo,Serie A,2021,2,2,0,6,3.0
-M. Satriano,Stade Brestois 29,Ligue 1,2023,2,2,0,6,3.0
-M. Sahi,Strasbourg,Ligue 1,2023,2,2,0,6,3.0
-M. Richter,Hertha Berlin,Bundesliga,2022,2,2,0,6,3.0
-M. Reus,Borussia Dortmund,Bundesliga,2023,2,2,0,6,3.0
-M. Reus,Borussia Dortmund,Bundesliga,2021,2,2,0,6,3.0
-M. Politano,Napoli,Serie A,2023,2,2,0,6,3.0
-M. Pjaca,Torino,Serie A,2021,2,2,0,6,3.0
-D. Caligiuri,FC Augsburg,Bundesliga,2021,2,2,0,6,3.0
-D. Brooks,Bournemouth,Premier League,2024,2,2,0,6,3.0
-D. Berardi,Sassuolo,Serie A,2023,2,2,0,6,3.0
-D. Berardi,Sassuolo,Serie A,2022,1,2,0,6,6.0
-R. Hack,Borussia Monchengladbach,Bundesliga,2023,1,2,0,6,6.0
-R. Gosens,Inter,Serie A,2022,2,2,0,6,3.0
-Ayoze Pérez,Leicester,Premier League,2021,1,2,0,6,6.0
-Aurélio Buta,Eintracht Frankfurt,Bundesliga,2022,2,2,0,6,3.0
-Assane Diao,Como,Serie A,2024,2,2,0,6,3.0
-Asier Villalibre,Athletic Club,La Liga,2021,2,2,0,6,3.0
-Arthur Cabral,Fiorentina,Serie A,2022,2,2,0,6,3.0
-Arkaitz Mariezkurrena,Real Sociedad,La Liga,2024,2,2,0,6,3.0
-R. Falcao,Rayo Vallecano,La Liga,2022,2,2,0,6,3.0
-R. Dōan,SC Freiburg,Bundesliga,2022,2,2,0,6,3.0
-R. Doan,SC Freiburg,Bundesliga,2024,1,2,0,6,6.0
-R. Lukaku,Chelsea,Premier League,2021,2,2,0,6,3.0
-M. Olise,Crystal Palace,Premier League,2022,2,2,0,6,3.0
-D. Drexler,FC Schalke 04,Bundesliga,2022,2,2,0,6,3.0
-D. Downs,1.FC Köln,Bundesliga,2023,2,2,0,6,3.0
-D. Doué,Rennes,Ligue 1,2022,2,2,0,6,3.0
-M. El Idrissy,Ajaccio,Ligue 1,2022,2,2,0,6,3.0
-M. Kömür,FC Augsburg,Bundesliga,2024,2,2,0,6,3.0
-M. Kudus,West Ham,Premier League,2023,2,2,0,6,3.0
-M. Kovačić,Manchester City,Premier League,2024,2,2,0,6,3.0
-D. Ings,Aston Villa,Premier League,2021,2,2,0,6,3.0
-D. Huseinbašić,FC Koln,Bundesliga,2022,2,2,0,6,3.0
-D. Gray,Everton,Premier League,2022,2,2,0,6,3.0
-M. Jensen,Brentford,Premier League,2022,2,2,0,6,3.0
-M. Icardi,Paris Saint Germain,Ligue 1,2021,2,2,0,6,3.0
-M. Hummels,Borussia Dortmund,Bundesliga,2023,2,2,0,6,3.0
-M. Guéhi,Crystal Palace,Premier League,2024,2,2,0,6,3.0
-M. Guilavogui,Lens,Ligue 1,2023,2,2,0,6,3.0
-M. Guilavogui,FC St. Pauli,Bundesliga,2024,2,2,0,6,3.0
-M. Pessina,Monza,Serie A,2022,2,2,0,6,3.0
-R. Healey,Toulouse,Ligue 1,2022,2,2,0,6,3.0
-R. Hamouma,Saint Etienne,Ligue 1,2021,2,2,0,6,3.0
-R. Kristensen,Leeds,Premier League,2022,2,2,0,6,3.0
-R. Kolo Muani,Paris Saint Germain,Ligue 1,2024,2,2,0,6,3.0
-R. Kolo Muani,Nantes,Ligue 1,2021,2,2,0,6,3.0
-Arda Güler,Real Madrid,La Liga,2023,2,2,0,6,3.0
-Antonio Puertas,Granada CF,La Liga,2021,2,2,0,6,3.0
-Antoine Griezmann,Atletico Madrid,La Liga,2023,2,2,0,6,3.0
-Ansu Fati,Barcelona,La Liga,2021,2,2,0,6,3.0
-R. Kolo Muani,Eintracht Frankfurt,Bundesliga,2022,2,2,0,6,3.0
-R. Schmid,Werder Bremen,Bundesliga,2024,2,2,0,6,3.0
-M. Gregoritsch,FC Augsburg,Bundesliga,2021,2,2,0,6,3.0
-M. Gibbs-White,Nottingham Forest,Premier League,2023,2,2,0,6,3.0
-D. Malen,Borussia Dortmund,Bundesliga,2021,2,2,0,6,3.0
-D. Ljubičić,FC Koln,Bundesliga,2022,2,2,0,6,3.0
-D. Kulusevski,Tottenham,Premier League,2024,2,2,0,6,3.0
-M. Gabbiadini,Sampdoria,Serie A,2021,2,2,0,6,3.0
-M. Folorunsho,Verona,Serie A,2023,2,2,0,6,3.0
-Alexsandro Ribeiro,Lille,Ligue 1,2022,2,2,0,6,3.0
-R. Orsolini,Bologna,Serie A,2023,2,2,0,6,3.0
-R. Orsolini,Bologna,Serie A,2021,2,2,0,6,3.0
-R. Malinovskyi,Atalanta,Serie A,2021,2,2,0,6,3.0
-R. Lukaku,Napoli,Serie A,2024,2,2,0,6,3.0
-Richarlison,Everton,Premier League,2021,2,2,0,6,3.0
-M. Diaby,Bayer Leverkusen,Bundesliga,2021,2,2,0,6,3.0
-M. Depay,Atletico Madrid,La Liga,2022,2,2,0,6,3.0
-M. Dembélé,Lyon,Ligue 1,2022,2,2,0,6,3.0
-D. Okereke,Cremonese,Serie A,2022,2,2,0,6,3.0
-D. O'Shea,Burnley,Premier League,2023,2,2,0,6,3.0
-D. Núñez,Liverpool,Premier League,2024,1,2,0,6,6.0
-D. McNeil,Everton,Premier League,2023,2,2,0,6,3.0
-M. Daramy,Reims,Ligue 1,2023,2,2,0,6,3.0
-M. Grüll,Werder Bremen,Bundesliga,2024,2,2,0,6,3.0
-R. Lewandowski,Barcelona,La Liga,2024,2,2,0,6,3.0
-Rafael Leão,AC Milan,Serie A,2024,2,2,0,6,3.0
-Rafa Mir,Sevilla,La Liga,2021,2,2,0,6,3.0
-R. Sessegnon,Fulham,Premier League,2024,2,2,0,6,3.0
-S. Azmoun,Bayer Leverkusen,Bundesliga,2022,2,2,0,6,3.0
-M. Dabbur,1899 Hoffenheim,Bundesliga,2021,2,2,0,6,3.0
-M. Cornet,Burnley,Premier League,2021,2,2,0,6,3.0
-M. Camara,Stade Brestois 29,Ligue 1,2024,2,2,0,6,3.0
-M. Camara,Stade Brestois 29,Ligue 1,2022,2,2,0,6,3.0
-D. Payet,Marseille,Ligue 1,2021,2,2,0,6,3.0
-M. Brescianini,Atalanta,Serie A,2024,2,2,0,6,3.0
-M. Braithwaite,Espanyol,La Liga,2022,2,2,0,6,3.0
-M. Boadu,Monaco,Ligue 1,2021,2,2,0,6,3.0
-M. Blažič,Angers,Ligue 1,2022,2,2,0,6,3.0
-R. Sallai,SC Freiburg,Bundesliga,2023,2,2,0,6,3.0
-R. Piccoli,Empoli,Serie A,2022,2,2,0,6,3.0
-R. Piccoli,Cagliari,Serie A,2024,2,2,0,6,3.0
-A. Waris,Strasbourg,Ligue 1,2021,2,2,0,6,3.0
-Rodri,Manchester City,Premier League,2021,2,2,0,6,3.0
-Richarlison,Tottenham,Premier League,2023,2,2,0,6,3.0
-D. Vlahović,Fiorentina,Serie A,2021,2,2,0,6,3.0
-D. Verde,Spezia,Serie A,2021,2,2,0,6,3.0
-M. Aramu,Venezia,Serie A,2021,2,2,0,6,3.0
-M. Antonio,West Ham,Premier League,2022,2,2,0,6,3.0
-M. Almirón,Newcastle,Premier League,2022,2,2,0,6,3.0
-M. Dahoud,Borussia Dortmund,Bundesliga,2021,2,2,0,6,3.0
-Renato Sanches,Paris Saint Germain,Ligue 1,2022,2,2,0,6,3.0
-Raúl de Tomás,Espanyol,La Liga,2021,2,2,0,6,3.0
-Raúl García,Osasuna,La Liga,2024,2,2,0,6,3.0
-Raúl García,Osasuna,La Liga,2023,2,2,0,6,3.0
-Raphinha,Barcelona,La Liga,2022,2,2,0,6,3.0
-Randy Nteka,Rayo Vallecano,La Liga,2024,1,2,0,6,6.0
-Alberto Moleiro,Las Palmas,La Liga,2024,2,2,0,6,3.0
-S. Chukwueze,Villarreal,La Liga,2021,2,2,0,6,3.0
-S. Chukwueze,AC Milan,Serie A,2024,2,2,0,6,3.0
-S. Castro,Bologna,Serie A,2024,2,2,0,6,3.0
-S. Bahoken,Angers,Ligue 1,2021,2,2,0,6,3.0
-M'Bala Nzola,Fiorentina,Serie A,2023,2,2,0,6,3.0
-Léo Scienza,1. FC Heidenheim,Bundesliga,2024,2,2,0,6,3.0
-Luis Rioja,Alaves,La Liga,2023,2,2,0,6,3.0
-Luis Alberto,Lazio,Serie A,2021,2,2,0,6,3.0
-D. Zapata,Atalanta,Serie A,2021,2,2,0,6,3.0
-D. Welbeck,Brighton,Premier League,2023,2,2,0,6,3.0
-D. Welbeck,Brighton,Premier League,2022,2,2,0,6,3.0
-Lucas Vázquez,Real Madrid,La Liga,2021,2,2,0,6,3.0
-M. Beier,1899 Hoffenheim,Bundesliga,2023,2,2,0,6,3.0
-Roger Martí,Levante,La Liga,2021,2,2,0,6,3.0
-Abdón Prats,Mallorca,La Liga,2021,2,2,0,6,3.0
-A. Zaroury,Lens,Ligue 1,2024,2,2,0,6,3.0
-A. Sima,Stade Brestois 29,Ligue 1,2024,1,2,0,6,6.0
-A. Semenyo,Bournemouth,Premier League,2023,2,2,0,6,3.0
-S. Gnabry,Bayern Munich,Bundesliga,2022,2,2,0,6,3.0
-S. Sohm,Parma,Serie A,2024,2,2,0,6,3.0
-Lucas Ocampos,Sevilla,La Liga,2023,2,2,0,6,3.0
-Lee Kang-In,Paris Saint Germain,Ligue 1,2024,2,2,0,6,3.0
-Lee Kang-In,Mallorca,La Liga,2022,2,2,0,6,3.0
-Daniel Carvajal,Real Madrid,La Liga,2023,2,2,0,6,3.0
-Dani Parejo,Villarreal,La Liga,2022,2,2,0,6,3.0
-L. Waldschmidt,1.FC Köln,Bundesliga,2023,2,2,0,6,3.0
-M. Akliouche,Monaco,Ligue 1,2024,2,2,0,6,3.0
-S. El Shaarawy,AS Roma,Serie A,2023,2,2,0,6,3.0
-S. El Shaarawy,AS Roma,Serie A,2022,2,2,0,6,3.0
-A. Truffert,Rennes,Ligue 1,2021,1,2,0,6,6.0
-A. Touré,Le Havre,Ligue 1,2024,2,2,0,6,3.0
-A. Tameze,Verona,Serie A,2021,2,2,0,6,3.0
-S. Pierotti,Lecce,Serie A,2024,2,2,0,6,3.0
-A. Salama,Angers,Ligue 1,2022,2,2,0,6,3.0
-A. Saelemaekers,Bologna,Serie A,2023,2,2,0,6,3.0
-A. Sabiri,Sampdoria,Serie A,2021,2,2,0,6,3.0
-S. Michel,Union Berlin,Bundesliga,2021,2,2,0,6,3.0
-S. Mavididi,Montpellier,Ligue 1,2021,2,2,0,6,3.0
-L. Suárez,Granada CF,La Liga,2021,2,2,0,6,3.0
-L. Stassin,Saint Etienne,Ligue 1,2024,2,2,0,6,3.0
-L. Sernicola,Cremonese,Serie A,2022,2,2,0,6,3.0
-Denis Suárez,Celta Vigo,La Liga,2021,2,2,0,6,3.0
-L. Samardžić,Udinese,Serie A,2022,2,2,0,6,3.0
-L. Samardžić,Udinese,Serie A,2021,2,2,0,6,3.0
-L. Pellegrini,AS Roma,Serie A,2023,2,2,0,6,3.0
-S. Khaoui,Clermont Foot,Ligue 1,2022,2,2,0,6,3.0
-S. Kalajdzic,Wolves,Premier League,2023,2,2,0,6,3.0
-S. Kalajdzic,VfB Stuttgart,Bundesliga,2021,2,2,0,6,3.0
-L. Díaz,Liverpool,Premier League,2023,2,2,0,6,3.0
-L. Dunk,Brighton,Premier League,2023,2,2,0,6,3.0
-L. Camara,Monaco,Ligue 1,2024,2,2,0,6,3.0
-L. Boyé,Elche,La Liga,2022,2,2,0,6,3.0
-L. Bonucci,Juventus,Serie A,2021,2,2,0,6,3.0
-L. Blas,Rennes,Ligue 1,2024,2,2,0,6,3.0
-L. Paredes,AS Roma,Serie A,2023,2,2,0,6,3.0
-L. Openda,RB Leipzig,Bundesliga,2024,2,2,0,6,3.0
-L. Nmecha,VfL Wolfsburg,Bundesliga,2024,1,2,0,6,6.0
-L. Nmecha,VfL Wolfsburg,Bundesliga,2022,2,2,0,6,3.0
-E. Bardhi,Levante,La Liga,2021,2,2,0,6,3.0
-Diogo Jota,Liverpool,Premier League,2024,2,2,0,6,3.0
-Diogo Jota,Liverpool,Premier League,2021,2,2,0,6,3.0
-L. Trossard,Brighton,Premier League,2021,2,2,0,6,3.0
-S. Rudy,1899 Hoffenheim,Bundesliga,2021,2,2,0,6,3.0
-S. Polter,FC Schalke 04,Bundesliga,2022,2,2,0,6,3.0
-Sergio Arribas,Almeria,La Liga,2023,2,2,0,6,3.0
-Sergio Akieme,Reims,Ligue 1,2023,2,2,0,6,3.0
-Sergi Roberto,Barcelona,La Liga,2023,2,2,0,6,3.0
-Sergi Guardiola,Rayo Vallecano,La Liga,2021,2,2,0,6,3.0
-A. Rebić,AC Milan,Serie A,2021,2,2,0,6,3.0
-Saúl Coco,Torino,Serie A,2024,2,2,0,6,3.0
-S. Tigges,Borussia Dortmund,Bundesliga,2021,2,2,0,6,3.0
-S. Tigges,1.FC Köln,Bundesliga,2023,2,2,0,6,3.0
-S. Sow,Saint Etienne,Ligue 1,2021,2,2,0,6,3.0
-S. Soumano,Lorient,Ligue 1,2021,2,2,0,6,3.0
-T. Anjorin,Empoli,Serie A,2024,2,2,0,6,3.0
-L. Majer,Rennes,Ligue 1,2021,2,2,0,6,3.0
-E. Ben Seghir,Monaco,Ligue 1,2024,1,2,0,6,6.0
-L. Goretzka,Bayern Munich,Bundesliga,2023,2,2,0,6,3.0
-L. Ferguson,Bologna,Serie A,2023,2,2,0,6,3.0
-L. Ferguson,Bologna,Serie A,2022,2,2,0,6,3.0
-T. Abraham,AS Roma,Serie A,2021,2,2,0,6,3.0
-Soldado,Levante,La Liga,2021,2,2,0,6,3.0
-A. Ounahi,Angers,Ligue 1,2021,2,2,0,6,3.0
-A. Onaiwu,Toulouse,Ligue 1,2022,2,2,0,6,3.0
-A. Nordin,Montpellier,Ligue 1,2024,2,2,0,6,3.0
-Sergio León,Valladolid,La Liga,2022,2,2,0,6,3.0
-T. Lemar,Atletico Madrid,La Liga,2021,2,2,0,6,3.0
-L. Berry,Luton,Premier League,2023,2,2,0,6,3.0
-E. Emegha,Strasbourg,Ligue 1,2024,2,2,0,6,3.0
-E. Elmas,Napoli,Serie A,2023,2,2,0,6,3.0
-E. Elmas,Napoli,Serie A,2022,2,2,0,6,3.0
-E. Džeko,Inter,Serie A,2021,2,2,0,6,3.0
-E. Delprato,Parma,Serie A,2024,2,2,0,6,3.0
-L. Alario,Bayer Leverkusen,Bundesliga,2021,2,2,0,6,3.0
-Kike Pérez,Elche,La Liga,2021,1,2,0,6,6.0
-Sergio Camello,Rayo Vallecano,La Liga,2022,2,2,0,6,3.0
-T. Kubo,Real Sociedad,La Liga,2022,2,2,0,6,3.0
-T. Henry,Venezia,Serie A,2021,2,2,0,6,3.0
-T. Douvikas,Celta Vigo,La Liga,2024,2,2,0,6,3.0
-A. Marušić,Lazio,Serie A,2024,2,2,0,6,3.0
-T. Barry,Villarreal,La Liga,2024,2,2,0,6,3.0
-T. Bakayoko,Lorient,Ligue 1,2023,2,2,0,6,3.0
-T. Awoniyi,Nottingham Forest,Premier League,2023,2,2,0,6,3.0
-T. Reijnders,AC Milan,Serie A,2024,2,2,0,6,3.0
-K. Yıldız,Juventus,Serie A,2024,2,2,0,6,3.0
-K. Toko-Ekambi,Lyon,Ligue 1,2021,2,2,0,6,3.0
-K. Thuram-Ulien,Nice,Ligue 1,2021,2,2,0,6,3.0
-K. Schade,SC Freiburg,Bundesliga,2021,2,2,0,6,3.0
-K. Schade,Brentford,Premier League,2024,2,2,0,6,3.0
-E. Gyasi,Spezia,Serie A,2021,2,2,0,6,3.0
-E. Ferguson,Brighton,Premier League,2022,2,2,0,6,3.0
-T. Alexander-Arnold,Liverpool,Premier League,2023,2,2,0,6,3.0
-A. Lookman,Atalanta,Serie A,2022,2,2,0,6,3.0
-A. Laïdouni,Union Berlin,Bundesliga,2022,2,2,0,6,3.0
-A. Lacazette,Lyon,Ligue 1,2024,2,2,0,6,3.0
-T. Minamino,Liverpool,Premier League,2021,2,2,0,6,3.0
-T. Lemperle,FC Koln,Bundesliga,2021,2,2,0,6,3.0
-T. Čvančara,Borussia Monchengladbach,Bundesliga,2023,2,2,0,6,3.0
-E. Löwen,VfL BOCHUM,Bundesliga,2021,2,2,0,6,3.0
-E. Lamela,Sevilla,La Liga,2022,2,2,0,6,3.0
-E. Lamela,Sevilla,La Liga,2021,2,2,0,6,3.0
-E. Haaland,Manchester City,Premier League,2024,2,2,0,6,3.0
-K. Havertz,Chelsea,Premier League,2022,2,2,0,6,3.0
-K. Havertz,Chelsea,Premier League,2021,2,2,0,6,3.0
-K. Havertz,Arsenal,Premier League,2024,2,2,0,6,3.0
-K. Davis,Udinese,Serie A,2024,2,2,0,6,3.0
-K. Coman,Bayern München,Bundesliga,2024,2,2,0,6,3.0
-Kike,Osasuna,La Liga,2021,2,2,0,6,3.0
-Jota Silva,Nottingham Forest,Premier League,2024,2,2,0,6,3.0
-K. Coman,Bayern Munich,Bundesliga,2021,2,2,0,6,3.0
-K. Behrens,Union Berlin,Bundesliga,2021,2,2,0,6,3.0
-K. Ajer,Brentford,Premier League,2023,2,2,0,6,3.0
-E. Rashani,Clermont Foot,Ligue 1,2023,1,2,0,6,6.0
-E. Ponce,Elche,La Liga,2022,2,2,0,6,3.0
-E. Palacios,Bayer Leverkusen,Bundesliga,2023,2,2,0,6,3.0
-E. Palacios,Bayer Leverkusen,Bundesliga,2021,2,2,0,6,3.0
-Jørgen Strand Larsen,Celta Vigo,La Liga,2023,2,2,0,6,3.0
-Junior Messias,AC Milan,Serie A,2022,2,2,0,6,3.0
-Julen Lobete,Real Sociedad,La Liga,2021,2,2,0,6,3.0
-K. Mitoma,Brighton,Premier League,2024,2,2,0,6,3.0
-T. Moffi,Nice,Ligue 1,2023,1,2,0,6,6.0
-T. Moffi,Lorient,Ligue 1,2021,2,2,0,6,3.0
-A. Martial,Manchester United,Premier League,2022,1,2,0,6,6.0
-A. Mac Allister,Brighton,Premier League,2021,2,2,0,6,3.0
-T. Weah,Lille,Ligue 1,2021,2,2,0,6,3.0
-A. Lacazette,Arsenal,Premier League,2021,2,2,0,6,3.0
-A. Kramarić,1899 Hoffenheim,Bundesliga,2022,2,2,0,6,3.0
-A. Kalimuendo,Rennes,Ligue 1,2023,2,2,0,6,3.0
-A. Januzaj,Las Palmas,La Liga,2024,2,2,0,6,3.0
-A. Jallow,Metz,Ligue 1,2023,2,2,0,6,3.0
-A. Iwobi,Fulham,Premier League,2024,2,2,0,6,3.0
-A. Iwobi,Fulham,Premier League,2023,2,2,0,6,3.0
-T. Savanier,Montpellier,Ligue 1,2023,2,2,0,6,3.0
-V. Janelt,Brentford,Premier League,2022,2,2,0,6,3.0
-João Pedro,Watford,Premier League,2021,2,2,0,6,3.0
-João Félix,Chelsea,Premier League,2022,2,2,0,6,3.0
-E. Zhegrova,Lille,Ligue 1,2022,1,2,0,6,6.0
-E. Wahi,Lens,Ligue 1,2023,2,2,0,6,3.0
-João Félix,Atletico Madrid,La Liga,2021,2,2,0,6,3.0
-João Cancelo,Barcelona,La Liga,2023,2,2,0,6,3.0
-J. Vardy,Leicester,Premier League,2022,2,2,0,6,3.0
-J. Thielmann,FC Koln,Bundesliga,2022,2,2,0,6,3.0
-J. Thielmann,FC Koln,Bundesliga,2021,2,2,0,6,3.0
-Josan Ferrández,Elche,La Liga,2021,2,2,0,6,3.0
-F. Anguissa,Napoli,Serie A,2024,2,2,0,6,3.0
-F. Acerbi,Lazio,Serie A,2021,2,2,0,6,3.0
-Evanilson,Bournemouth,Premier League,2024,2,2,0,6,3.0
-Elustondo,Real Sociedad,La Liga,2021,2,2,0,6,3.0
-E. Ünal,Bournemouth,Premier League,2024,2,2,0,6,3.0
-E. Ávila,Osasuna,La Liga,2021,2,2,0,6,3.0
-Jorge de Frutos,Rayo Vallecano,La Liga,2023,2,2,0,6,3.0
-Joan Jordán,Alaves,La Liga,2024,2,2,0,6,3.0
-Javier Guerra,Valencia,La Liga,2023,2,2,0,6,3.0
-Javi Puado,Espanyol,La Liga,2021,2,2,0,6,3.0
-Juanmi Latasa,Getafe,La Liga,2023,2,2,0,6,3.0
-T. Werner,Tottenham,Premier League,2023,2,2,0,6,3.0
-J. Stage,Werder Bremen,Bundesliga,2023,2,2,0,6,3.0
-F. Honorat,Borussia Mönchengladbach,Bundesliga,2024,2,2,0,6,3.0
-F. Forestieri,Udinese,Serie A,2021,2,2,0,6,3.0
-F. Dele-Bashiru,Lazio,Serie A,2024,2,2,0,6,3.0
-J. Siebatcheu,Borussia Monchengladbach,Bundesliga,2023,2,2,0,6,3.0
-J. Schöppner,1. FC Heidenheim,Bundesliga,2024,2,2,0,6,3.0
-J. Sancho,Chelsea,Premier League,2024,2,2,0,6,3.0
-J. Ryerson,Borussia Dortmund,Bundesliga,2023,2,2,0,6,3.0
-J. Porozo,Estac Troyes,Ligue 1,2022,2,2,0,6,3.0
-J. Pohjanpalo,Venezia,Serie A,2024,2,2,0,6,3.0
-J. Álvarez,Manchester City,Premier League,2023,2,2,0,6,3.0
-J. Zirkzee,Bologna,Serie A,2023,2,2,0,6,3.0
-F. Balogun,Monaco,Ligue 1,2023,1,2,0,6,6.0
-F. Ayé,Auxerre,Ligue 1,2024,2,2,0,6,3.0
-J. Ward-Prowse,West Ham,Premier League,2023,2,2,0,6,3.0
-J. Veretout,Marseille,Ligue 1,2022,2,2,0,6,3.0
-V. Castellanos,Lazio,Serie A,2024,2,2,0,6,3.0
-A. Isak,Newcastle,Premier League,2024,2,2,0,6,3.0
-A. Hložek,1899 Hoffenheim,Bundesliga,2024,2,2,0,6,3.0
-A. Haïdara,RB Leipzig,Bundesliga,2021,2,2,0,6,3.0
-V. Boniface,Bayer Leverkusen,Bundesliga,2023,2,2,0,6,3.0
-Unai Gómez,Athletic Club,La Liga,2023,2,2,0,6,3.0
-U. Sadiq,Valencia,La Liga,2024,2,2,0,6,3.0
-Toni Martínez,Alaves,La Liga,2024,2,2,0,6,3.0
-Tiago Tomás,VfL Wolfsburg,Bundesliga,2024,2,2,0,6,3.0
-Tiago Tomás,VfB Stuttgart,Bundesliga,2022,2,2,0,6,3.0
-Tiago Tomás,VfB Stuttgart,Bundesliga,2021,2,2,0,6,3.0
-Tetê,Lyon,Ligue 1,2021,2,2,0,6,3.0
-Vinícius Júnior,Real Madrid,La Liga,2024,2,2,0,6,3.0
-J. Stones,Manchester City,Premier League,2024,2,2,0,6,3.0
-J. Stanišić,Bayer Leverkusen,Bundesliga,2023,2,2,0,6,3.0
-J. Stage,Werder Bremen,Bundesliga,2024,2,2,0,6,3.0
-J. Haberer,SC Freiburg,Bundesliga,2021,2,2,0,6,3.0
-J. Gelhardt,Leeds,Premier League,2021,2,2,0,6,3.0
-J. Frimpong,Bayer Leverkusen,Bundesliga,2023,2,2,0,6,3.0
-J. Odgaard,Bologna,Serie A,2023,2,2,0,6,3.0
-J. O'Brien,Everton,Premier League,2024,2,2,0,6,3.0
-J. Musiala,Bayern Munich,Bundesliga,2022,2,2,0,6,3.0
-J. Musiala,Bayern Munich,Bundesliga,2021,2,2,0,6,3.0
-F. Magri,Toulouse,Ligue 1,2024,2,2,0,6,3.0
-F. Magri,Toulouse,Ligue 1,2023,2,2,0,6,3.0
-F. Kostić,Eintracht Frankfurt,Bundesliga,2021,2,2,0,6,3.0
-F. Kainz,1.FC Köln,Bundesliga,2023,2,2,0,6,3.0
-J. Maddison,Tottenham,Premier League,2024,2,2,0,6,3.0
-J. Lingard,Manchester United,Premier League,2021,2,2,0,6,3.0
-J. Koundé,Sevilla,La Liga,2021,2,2,0,6,3.0
-J. Strand Larsen,Wolves,Premier League,2024,2,2,0,6,3.0
-V. Grifo,SC Freiburg,Bundesliga,2022,2,2,0,6,3.0
-A. Hahn,FC Augsburg,Bundesliga,2022,2,2,0,6,3.0
-A. Groeneveld,Villarreal,La Liga,2021,2,2,0,6,3.0
-A. Gouiri,Rennes,Ligue 1,2023,2,2,0,6,3.0
-A. Gordon,Everton,Premier League,2021,2,2,0,6,3.0
-V. Osimhen,Napoli,Serie A,2023,2,2,0,6,3.0
-V. Osimhen,Napoli,Serie A,2022,2,2,0,6,3.0
-V. Muriqi,Mallorca,La Liga,2022,2,2,0,6,3.0
-W. Orban,RB Leipzig,Bundesliga,2021,2,2,0,6,3.0
-J. Kluivert,Bournemouth,Premier League,2024,2,2,0,6,3.0
-J. Kluivert,Bournemouth,Premier League,2023,2,2,0,6,3.0
-J. King,Watford,Premier League,2021,1,2,0,6,6.0
-F. Ohene-Gyan,AS Roma,Serie A,2021,1,2,0,6,6.0
-F. Moumbagna,Marseille,Ligue 1,2023,2,2,0,6,3.0
-J. Hofmann,Borussia Monchengladbach,Bundesliga,2021,2,2,0,6,3.0
-J. Hinshelwood,Brighton,Premier League,2024,2,2,0,6,3.0
-J. Harrison,Leeds,Premier League,2021,2,2,0,6,3.0
-J. Bellegarde,Wolves,Premier League,2023,2,2,0,6,3.0
-J. David,Lille,Ligue 1,2021,2,2,0,6,3.0
-J. Dasilva,Brentford,Premier League,2022,2,2,0,6,3.0
-J. Correa,Inter,Serie A,2021,1,2,0,6,6.0
-J. Cajuste,Reims,Ligue 1,2021,2,2,0,6,3.0
-F. Wirtz,Bayer Leverkusen,Bundesliga,2021,2,2,0,6,3.0
-F. Valverde,Real Madrid,La Liga,2022,2,2,0,6,3.0
-F. Thauvin,Udinese,Serie A,2024,2,2,0,6,3.0
-F. Tardieu,Estac Troyes,Ligue 1,2021,2,2,0,6,3.0
-F. Tait,Rennes,Ligue 1,2021,2,2,0,6,3.0
-F. Sotoca,Lens,Ligue 1,2022,2,2,0,6,3.0
-F. Sotoca,Lens,Ligue 1,2021,2,2,0,6,3.0
-J. Bruun Larsen,1899 Hoffenheim,Bundesliga,2024,2,2,0,6,3.0
-J. Kluivert,Valencia,La Liga,2022,2,2,0,6,3.0
-Valery,Mallorca,La Liga,2024,2,2,0,6,3.0
-V. van Dijk,Liverpool,Premier League,2024,2,2,0,6,3.0
-Isco,Real Betis,La Liga,2023,2,2,0,6,3.0
-Iago Aspas,Celta Vigo,La Liga,2021,2,2,0,6,3.0
-I. Williams,Athletic Club,La Liga,2024,2,2,0,6,3.0
-I. Toney,Brentford,Premier League,2022,2,2,0,6,3.0
-I. Sarr,Crystal Palace,Premier League,2024,2,2,0,6,3.0
-J. Brownhill,Burnley,Premier League,2023,2,2,0,6,3.0
-J. Brown,Luton,Premier League,2023,2,2,0,6,3.0
-J. Briand,Bordeaux,Ligue 1,2021,1,2,0,6,6.0
-J. Boëtius,FSV Mainz 05,Bundesliga,2021,2,2,0,6,3.0
-J. Bowen,West Ham,Premier League,2024,2,2,0,6,3.0
-Fernandinho,Manchester City,Premier League,2021,2,2,0,6,3.0
-Fabián Ruiz,Napoli,Serie A,2021,2,2,0,6,3.0
-Fabinho,Liverpool,Premier League,2021,2,2,0,6,3.0
-J. Boga,Nice,Ligue 1,2023,2,2,0,6,3.0
-J. Bijol,Udinese,Serie A,2022,2,2,0,6,3.0
-J. Beste,FC Heidenheim,Bundesliga,2023,2,2,0,6,3.0
-W. Odobert,Estac Troyes,Ligue 1,2022,2,2,0,6,3.0
-W. Khazri,Saint Etienne,Ligue 1,2021,2,2,0,6,3.0
-W. Geubbels,Nantes,Ligue 1,2021,2,2,0,6,3.0
-A. Finnbogason,FC Augsburg,Bundesliga,2021,2,2,0,6,3.0
-A. Ezzalzouli,Osasuna,La Liga,2022,2,2,0,6,3.0
-A. Engels,FC Augsburg,Bundesliga,2023,2,2,0,6,3.0
-W. Endo,VfB Stuttgart,Bundesliga,2022,2,2,0,6,3.0
-W. Cyprien,Nantes,Ligue 1,2021,2,2,0,6,3.0
-W. Ben Yedder,Monaco,Ligue 1,2023,2,2,0,6,3.0
-Y. Carrasco,Atletico Madrid,La Liga,2021,2,2,0,6,3.0
-J. Aidoo,Celta Vigo,La Liga,2022,2,2,0,6,3.0
-J. Aholou,Strasbourg,Ligue 1,2022,1,2,0,6,6.0
-Fábio Carvalho,Liverpool,Premier League,2022,2,2,0,6,3.0
-Fábio Carvalho,Brentford,Premier League,2024,2,2,0,6,3.0
-Francisco Conceição,Juventus,Serie A,2024,2,2,0,6,3.0
-Ferran Torres,Barcelona,La Liga,2023,2,2,0,6,3.0
-Williot Swedberg,Celta Vigo,La Liga,2023,2,2,0,6,3.0
-Willian José,Real Betis,La Liga,2023,2,2,0,6,3.0
-Willian,Fulham,Premier League,2023,2,2,0,6,3.0
-Williams,Athletic Club,La Liga,2021,2,2,0,6,3.0
-W. Swedberg,Celta Vigo,La Liga,2024,2,2,0,6,3.0
-W. Orbán,RB Leipzig,Bundesliga,2022,2,2,0,6,3.0
-Z. Ferhat,Angers,Ligue 1,2024,2,2,0,6,3.0
-I. Pussetto,Udinese,Serie A,2021,2,2,0,6,3.0
-I. Ganago,Lens,Ligue 1,2021,2,2,0,6,3.0
-I. Bebou,1899 Hoffenheim,Bundesliga,2023,2,2,0,6,3.0
-Hugo Duro,Valencia,La Liga,2023,2,2,0,6,3.0
-Hugo Duro,Valencia,La Liga,2021,1,2,0,6,6.0
-Hermoso,Atletico Madrid,La Liga,2021,2,2,0,6,3.0
-H. Çalhanoğlu,Inter,Serie A,2023,2,2,0,6,3.0
-H. Traorè,Sassuolo,Serie A,2021,2,2,0,6,3.0
-H. Tabaković,1899 Hoffenheim,Bundesliga,2024,2,2,0,6,3.0
-Gerson,Marseille,Ligue 1,2021,2,2,0,6,3.0
-G. Rutter,Brighton,Premier League,2024,2,2,0,6,3.0
-G. Raspadori,Sassuolo,Serie A,2021,2,2,0,6,3.0
-G. Raspadori,Napoli,Serie A,2023,2,2,0,6,3.0
-G. Raspadori,Napoli,Serie A,2022,2,2,0,6,3.0
-G. Perrin,Auxerre,Ligue 1,2021,2,2,0,6,3.0
-Álvaro Negredo,Cadiz,La Liga,2021,2,2,0,6,3.0
-Álvaro Morata,Atletico Madrid,La Liga,2023,2,2,0,6,3.0
-A. Adams,Montpellier,Ligue 1,2023,2,2,0,6,3.0
-İlkay Gündoğan,Barcelona,La Liga,2023,2,2,0,6,3.0
-H. Elliott,Liverpool,Premier League,2023,2,2,0,6,3.0
-Z. Aboukhlal,Toulouse,Ligue 1,2024,2,2,0,6,3.0
-Youssef En-Nesyri,Sevilla,La Liga,2023,2,2,0,6,3.0
-A. Candreva,Sampdoria,Serie A,2021,2,2,0,6,3.0
-A. Candreva,Salernitana,Serie A,2022,2,2,0,6,3.0
-Y. Wissa,Brentford,Premier League,2023,2,2,0,6,3.0
-Bruno Guimarães,Newcastle,Premier League,2024,2,2,0,6,3.0
-Bruno Guimarães,Newcastle,Premier League,2023,2,2,0,6,3.0
-Bruno Guimarães,Newcastle,Premier League,2022,2,2,0,6,3.0
-Bruno Guimarães,Newcastle,Premier League,2021,2,2,0,6,3.0
-Bruno Fernandes,Manchester United,Premier League,2024,2,2,0,6,3.0
-Bruno Fernandes,Manchester United,Premier League,2021,2,2,0,6,3.0
-P. Cutrone,Como,Serie A,2024,2,2,0,6,3.0
-Éderson,Atalanta,Serie A,2023,2,2,0,6,3.0
-Álex Moreno,Real Betis,La Liga,2021,2,2,0,6,3.0
-Álex Grimaldo,Bayer Leverkusen,Bundesliga,2023,2,2,0,6,3.0
-Álex Berenguer,Athletic Club,La Liga,2023,2,2,0,6,3.0
-Á. Correa,Atletico Madrid,La Liga,2022,2,2,0,6,3.0
-A. Barák,Verona,Serie A,2021,2,2,0,6,3.0
-Zito Luvumbo,Cagliari,Serie A,2023,2,2,0,6,3.0
-Z. Çelik,Lille,Ligue 1,2021,2,2,0,6,3.0
-Z. Ibrahimović,AC Milan,Serie A,2021,2,2,0,6,3.0
-0                         A. Petagna,Napoli,Serie A,2021,1,1,0,3,3.0
-0                         K. Benzema,Real Madrid,La Liga,2022,1,1,0,3,3.0
-1                         F. Wirtz,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-1                         L. Colombo,Lecce,Serie A,2022,1,1,0,3,3.0
-1                         M. Bayo,Lille,Ligue 1,2022,1,1,0,3,3.0
-1                         M. Bayo,Lille,Ligue 1,2024,1,1,0,3,3.0
-2                         M. Bülter,FC Schalke 04,Bundesliga,2022,1,1,0,3,3.0
-3                         Arthur,Fiorentina,Serie A,2023,1,1,0,3,3.0
-3                         E. Touré,Atalanta,Serie A,2023,1,1,0,3,3.0
-A. Budimir,Osasuna,La Liga,2021,1,1,0,3,3.0
-A. Broja,Chelsea,Premier League,2022,1,1,0,3,3.0
-A. Bonny,Parma,Serie A,2024,1,1,0,3,3.0
-A. Boakye,Saint Etienne,Ligue 1,2024,1,1,0,3,3.0
-A. Bianco,Monza,Serie A,2024,1,1,0,3,3.0
-A. Bernede,Verona,Serie A,2024,1,1,0,3,3.0
-A. Ben Slimane,Luton,Premier League,2023,1,1,0,3,3.0
-A. Belotti,Como,Serie A,2024,1,1,0,3,3.0
-A. Belotti,AS Roma,Serie A,2023,1,1,0,3,3.0
-A. Beck,1. FC Heidenheim,Bundesliga,2024,1,1,0,3,3.0
-A. Bastoni,Inter,Serie A,2023,1,1,0,3,3.0
-A. Barák,Fiorentina,Serie A,2023,1,1,0,3,3.0
-A. Ayew,Le Havre,Ligue 1,2024,1,1,0,3,3.0
-Zito Luvumbo,Cagliari,Serie A,2024,1,1,0,3,3.0
-Z. Savva,Torino,Serie A,2023,1,1,0,3,3.0
-Z. Davitashvili,Saint Etienne,Ligue 1,2024,1,1,0,3,3.0
-G. Zappa,Cagliari,Serie A,2024,1,1,0,3,3.0
-G. Xhaka,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-G. Xhaka,Arsenal,Premier League,2022,1,1,0,3,3.0
-G. Wijnaldum,Paris Saint Germain,Ligue 1,2021,1,1,0,3,3.0
-G. Wijnaldum,AS Roma,Serie A,2022,1,1,0,3,3.0
-G. Simeone,Napoli,Serie A,2024,1,1,0,3,3.0
-G. Simeone,Napoli,Serie A,2023,1,1,0,3,3.0
-G. Scalvini,Atalanta,Serie A,2021,1,1,0,3,3.0
-G. Rutter,1899 Hoffenheim,Bundesliga,2022,1,1,0,3,3.0
-G. Rodríguez,Barcelona,La Liga,2022,1,1,0,3,3.0
-G. Raspadori,Napoli,Serie A,2024,1,1,0,3,3.0
-G. Perrin,Auxerre,Ligue 1,2022,1,1,0,3,3.0
-G. Pereiro,Cagliari,Serie A,2021,1,1,0,3,3.0
-G. Orban,Lyon,Ligue 1,2023,1,1,0,3,3.0
-G. Mikautadze,Metz,Ligue 1,2023,1,1,0,3,3.0
-0                         D. Zappacosta,Atalanta,Serie A,2023,1,1,0,3,3.0
-Gabriel Strefezza,Lecce,Serie A,2023,1,1,0,3,3.0
-Gabriel Strefezza,Lecce,Serie A,2022,1,1,0,3,3.0
-G. Mancini,AS Roma,Serie A,2023,1,1,0,3,3.0
-G. Magnani,Empoli,Serie A,2022,1,1,0,3,3.0
-G. Maggiore,Spezia,Serie A,2021,1,1,0,3,3.0
-G. Lo Celso,Villarreal,La Liga,2022,1,1,0,3,3.0
-G. Lo Celso,Villarreal,La Liga,2021,1,1,0,3,3.0
-G. Lloris,Le Havre,Ligue 1,2024,1,1,0,3,3.0
-G. Leoni,Parma,Serie A,2024,1,1,0,3,3.0
-G. Laborde,Rennes,Ligue 1,2022,1,1,0,3,3.0
-G. Kyriakopoulos,Inter,Serie A,2024,1,1,0,3,3.0
-G. Kyei,Clermont Foot,Ligue 1,2022,1,1,0,3,3.0
-Gabriel Strefezza,Como,Serie A,2024,1,1,0,3,3.0
-Gabriel Magalhães,Arsenal,Premier League,2022,1,1,0,3,3.0
-Gabriel Jesus                                  1,Arsenal,Premier League,2023,1,1,0,3,3.0
-Gabriel Jesus,Manchester City,Premier League,2021,1,1,0,3,3.0
-G. Holtmann,VfL Bochum,Bundesliga,2024,1,1,0,3,3.0
-G. Hein,Metz,Ligue 1,2024,1,1,0,3,3.0
-G. Hanley,Norwich,Premier League,2021,1,1,0,3,3.0
-G. Gudmundsson,Lille,Ligue 1,2023,1,1,0,3,3.0
-G. Gaetano,Napoli,Serie A,2023,1,1,0,3,3.0
-G. Gaetano,Napoli,Serie A,2022,1,1,0,3,3.0
-G. Ferrari,Sassuolo,Serie A,2023,1,1,0,3,3.0
-G. Ferrari,Sassuolo,Serie A,2021,1,1,0,3,3.0
-G. Fabbian,Bologna,Serie A,2024,1,1,0,3,3.0
-Gonçalo Paciência,Eintracht Frankfurt,Bundesliga,2021,1,1,0,3,3.0
-Gonçalo Paciência,Celta Vigo,La Liga,2022,1,1,0,3,3.0
-Gonçalo Guedes,Wolves,Premier League,2024,1,1,0,3,3.0
-Gonçalo Guedes,Villarreal,La Liga,2023,1,1,0,3,3.0
-Gonzalo Verdú,Elche,La Liga,2022,1,1,0,3,3.0
-Gonzalo Escalante,Cadiz,La Liga,2023,1,1,0,3,3.0
-Germán Pezzella,Real Betis,La Liga,2023,1,1,0,3,3.0
-H. Mkhitaryan,AS Roma,Serie A,2021,1,1,0,3,3.0
-H. Mendes,Marseille,Ligue 1,2021,1,1,0,3,3.0
-H. Meister,Rennes,Ligue 1,2024,1,1,0,3,3.0
-H. Maguire,Manchester United,Premier League,2023,1,1,0,3,3.0
-H. Lozano,Napoli,Serie A,2022,1,1,0,3,3.0
-H. Lozano,Napoli,Serie A,2021,1,1,0,3,3.0
-H. Kane,Tottenham,Premier League,2021,1,1,0,3,3.0
-H. Guirassy,Nantes,Ligue 1,2024,1,1,0,3,3.0
-H. Ekitiké,Eintracht Frankfurt,Bundesliga,2024,1,1,0,3,3.0
-H. Ekitike,Paris Saint Germain,Ligue 1,2022,1,1,0,3,3.0
-H. Diarra,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-H. Boudaoui,Nice,Ligue 1,2021,1,1,0,3,3.0
-H. Barnes,Leicester,Premier League,2021,1,1,0,3,3.0
-H. Aouar,Lyon,Ligue 1,2021,1,1,0,3,3.0
-G. Konan,Reims,Ligue 1,2021,1,1,0,3,3.0
-G. Isaksen,Lazio,Serie A,2023,1,1,0,3,3.0
-Hwang Hee-Chan,Wolves,Premier League,2021,1,1,0,3,3.0
-Hugo Álvarez,Celta Vigo,La Liga,2024,1,1,0,3,3.0
-Hugo Novoa,RB Leipzig,Bundesliga,2022,1,1,0,3,3.0
-Hugo Novoa,RB Leipzig,Bundesliga,2021,1,1,0,3,3.0
-Hugo Guillamón,Valencia,La Liga,2022,1,1,0,3,3.0
-Hugo Duro,Valencia,La Liga,2024,1,1,0,3,3.0
-Hugo Bueno,Liverpool,Premier League,2023,1,1,0,3,3.0
-Hernani,Parma,Serie A,2024,1,1,0,3,3.0
-Hermoso,Atletico Madrid,La Liga,2022,1,1,0,3,3.0
-H. Šabanović,Angers,Ligue 1,2022,1,1,0,3,3.0
-H. Çalhanoğlu,Inter,Serie A,2024,1,1,0,3,3.0
-H. Ziyech,Chelsea,Premier League,2021,1,1,0,3,3.0
-H. Wolf,Borussia Monchengladbach,Bundesliga,2022,1,1,0,3,3.0
-H. Traoré,Auxerre,Ligue 1,2024,1,1,0,3,3.0
-H. Ojediran,Lens,Ligue 1,2024,1,1,0,3,3.0
-H. Mkhitaryan,Inter,Serie A,2022,1,1,0,3,3.0
-G. Busio,Venezia,Serie A,2021,1,1,0,3,3.0
-G. Bonaventura,Fiorentina,Serie A,2023,1,1,0,3,3.0
-G. Bonaventura,Fiorentina,Serie A,2022,1,1,0,3,3.0
-G. Bonaventura,Fiorentina,Serie A,2021,1,1,0,3,3.0
-G. Bello,VfL BOCHUM,Bundesliga,2021,1,1,0,3,3.0
-I. Cissoko,Toulouse,Ligue 1,2023,1,1,0,3,3.0
-I. Cardona,Stade Brestois 29,Ligue 1,2021,1,1,0,3,3.0
-I. Cardona,Saint Etienne,Ligue 1,2024,1,1,0,3,3.0
-I. Cardona,Saint Etienne,Ligue 1,2023,1,1,0,3,3.0
-I. Cardona,FC Augsburg,Bundesliga,2022,1,1,0,3,3.0
-I. Bennacer,AC Milan,Serie A,2021,1,1,0,3,3.0
-I. Belfodil,Hertha Berlin,Bundesliga,2021,1,1,0,3,3.0
-I. Bebou,1899 Hoffenheim,Bundesliga,2022,1,1,0,3,3.0
-I. Bebou,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-I. Balliu,Cadiz,La Liga,2022,1,1,0,3,3.0
-Hwang Hee-Chan,Wolves,Premier League,2024,1,1,0,3,3.0
-I. Koné,Lorient,Ligue 1,2021,1,1,0,3,3.0
-I. Kebbal,Reims,Ligue 1,2021,1,1,0,3,3.0
-I. Ilić,Torino,Serie A,2023,1,1,0,3,3.0
-I. Ilić,Torino,Serie A,2022,1,1,0,3,3.0
-I. Gueye,Everton,Premier League,2023,1,1,0,3,3.0
-G. Earthy,West Ham,Premier League,2023,1,1,0,3,3.0
-G. Di Lorenzo,Napoli,Serie A,2022,1,1,0,3,3.0
-G. Defrel,Sassuolo,Serie A,2021,1,1,0,3,3.0
-G. Charpentier,Parma,Serie A,2024,1,1,0,3,3.0
-G. Charbonnier,Auxerre,Ligue 1,2021,1,1,0,3,3.0
-G. Castrovilli,Fiorentina,Serie A,2021,1,1,0,3,3.0
-G. Castro,Arminia Bielefeld,Bundesliga,2021,1,1,0,3,3.0
-G. Carrillo,Elche,La Liga,2021,1,1,0,3,3.0
-G. Caprari,Verona,Serie A,2021,1,1,0,3,3.0
-G. Caprari,Monza,Serie A,2022,1,1,0,3,3.0
-G. Busio,Venezia,Serie A,2024,1,1,0,3,3.0
-I. Success,Udinese,Serie A,2023,1,1,0,3,3.0
-I. Sissoko,Saint Etienne,Ligue 1,2024,1,1,0,3,3.0
-I. Sarr,Watford,Premier League,2021,1,1,0,3,3.0
-I. Sarr,Marseille,Ligue 1,2023,1,1,0,3,3.0
-I. Sané,Metz,Ligue 1,2023,1,1,0,3,3.0
-I. Salah,Stade Brestois 29,Ligue 1,2024,1,1,0,3,3.0
-I. Rakitić,Sevilla,La Liga,2022,1,1,0,3,3.0
-I. Rakitić,Sevilla,La Liga,2021,1,1,0,3,3.0
-I. Perišić,Inter,Serie A,2021,1,1,0,3,3.0
-I. Niane,Metz,Ligue 1,2021,1,1,0,3,3.0
-I. Niane,Angers,Ligue 1,2024,1,1,0,3,3.0
-I. Nestorovski,Udinese,Serie A,2022,1,1,0,3,3.0
-I. Ndiaye,Everton,Premier League,2024,1,1,0,3,3.0
-I. Monterisi,Frosinone,Serie A,2023,1,1,0,3,3.0
-I. Mbaye,Paris Saint Germain,Ligue 1,2024,1,1,0,3,3.0
-I. Maatsen,Borussia Dortmund,Bundesliga,2023,1,1,0,3,3.0
-Ismaila Ciss,Rayo Vallecano,La Liga,2023,1,1,0,3,3.0
-Isi Palazón,Rayo Vallecano,La Liga,2023,1,1,0,3,3.0
-Isi Palazón,Rayo Vallecano,La Liga,2021,1,1,0,3,3.0
-Isco,Real Madrid,La Liga,2021,1,1,0,3,3.0
-Isco,Real Betis,La Liga,2024,1,1,0,3,3.0
-Iker Muñoz,Osasuna,La Liga,2023,1,1,0,3,3.0
-Iker Muniain,Athletic Club,La Liga,2023,1,1,0,3,3.0
-Iker Bravo,Udinese,Serie A,2024,1,1,0,3,3.0
-Ibañez,AS Roma,Serie A,2022,1,1,0,3,3.0
-Iago Aspas,Celta Vigo,La Liga,2023,1,1,0,3,3.0
-Iago Aspas,Celta Vigo,La Liga,2022,1,1,0,3,3.0
-I. Williams,Athletic Club,La Liga,2022,1,1,0,3,3.0
-I. Wadji,Saint Etienne,Ligue 1,2023,1,1,0,3,3.0
-I. Ugbo,Estac Troyes,Ligue 1,2022,1,1,0,3,3.0
-I. Toney,Brentford,Premier League,2023,1,1,0,3,3.0
-I. Sulemana,Atalanta,Serie A,2024,1,1,0,3,3.0
-Iñaki Williams,Athletic Club,La Liga,2023,1,1,0,3,3.0
-Iván Sánchez,Valladolid,La Liga,2024,1,1,0,3,3.0
-Iván Martín,Girona,La Liga,2023,1,1,0,3,3.0
-Iván Martín,Girona,La Liga,2022,1,1,0,3,3.0
-Ivan Rakitić,Sevilla,La Liga,2023,1,1,0,3,3.0
-Ismaily,Lille,Ligue 1,2022,1,1,0,3,3.0
-G. Altare,Lazio,Serie A,2024,1,1,0,3,3.0
-G. Altare,Cagliari,Serie A,2021,1,1,0,3,3.0
-Fábio Vieira,Arsenal,Premier League,2023,1,1,0,3,3.0
-Fred,Manchester United,Premier League,2022,1,1,0,3,3.0
-Fred,Manchester United,Premier League,2021,1,1,0,3,3.0
-Fran García,Rayo Vallecano,La Liga,2022,1,1,0,3,3.0
-Florian Lejeune,Rayo Vallecano,La Liga,2023,1,1,0,3,3.0
-Florian Lejeune,Barcelona,La Liga,2023,1,1,0,3,3.0
-Fidel,Elche,La Liga,2021,1,1,0,3,3.0
-Ferran Torres,Manchester City,Premier League,2021,1,1,0,3,3.0
-J. Bellingham,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-J. Bellingham,Borussia Dortmund,Bundesliga,2021,1,1,0,3,3.0
-J. Bellegarde,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-J. Bellegarde,Strasbourg,Ligue 1,2021,1,1,0,3,3.0
-J. Ayew,Crystal Palace,Premier League,2023,1,1,0,3,3.0
-J. Ayew,Crystal Palace,Premier League,2022,1,1,0,3,3.0
-J. Asoro,Metz,Ligue 1,2023,1,1,0,3,3.0
-J. Antiste,Sassuolo,Serie A,2022,1,1,0,3,3.0
-J. Anthony,Bournemouth,Premier League,2022,1,1,0,3,3.0
-J. Andersen,Crystal Palace,Premier League,2023,1,1,0,3,3.0
-J. Andersen,Brighton,Premier League,2021,1,1,0,3,3.0
-J. Allevinah,Clermont Foot,Ligue 1,2023,1,1,0,3,3.0
-J. Allevinah,Clermont Foot,Ligue 1,2022,1,1,0,3,3.0
-J. Allevinah,Clermont Foot,Ligue 1,2021,1,1,0,3,3.0
-J. Aholou,Strasbourg,Ligue 1,2021,1,1,0,3,3.0
-J.  McGinn,Aston Villa,Premier League,2021,1,1,0,3,3.0
-J. Brandt,Borussia Dortmund,Bundesliga,2021,1,1,0,3,3.0
-J. Bogle,Sheffield Utd,Premier League,2023,1,1,0,3,3.0
-Ferran Torres,Barcelona,La Liga,2022,1,1,0,3,3.0
-Fernando Calero,Espanyol,La Liga,2024,1,1,0,3,3.0
-Fermín López,Barcelona,La Liga,2024,1,1,0,3,3.0
-Fermín López,Barcelona,La Liga,2023,1,1,0,3,3.0
-Fer Niño,Mallorca,La Liga,2021,1,1,0,3,3.0
-Felipe Anderson,Lazio,Serie A,2022,1,1,0,3,3.0
-Felipe Anderson,Lazio,Serie A,2021,1,1,0,3,3.0
-Felipe,Atletico Madrid,La Liga,2021,1,1,0,3,3.0
-Fabián Ruiz,Paris Saint Germain,Ligue 1,2023,1,1,0,3,3.0
-Fabián Ruiz,Paris Saint Germain,Ligue 1,2022,1,1,0,3,3.0
-F. de Jong,Barcelona,La Liga,2024,1,1,0,3,3.0
-F. de Jong,Barcelona,La Liga,2021,1,1,0,3,3.0
-F. Wirtz,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-J. Bijol,Como,Serie A,2024,1,1,0,3,3.0
-J. Burkardt,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-J. Bruun Larsen,Burnley,Premier League,2023,1,1,0,3,3.0
-F. Valverde,Real Madrid,La Liga,2024,1,1,0,3,3.0
-F. Tsadjout,Cremonese,Serie A,2022,1,1,0,3,3.0
-F. Tomori,AC Milan,Serie A,2023,1,1,0,3,3.0
-F. Tait,Rennes,Ligue 1,2022,1,1,0,3,3.0
-F. Schär,Newcastle,Premier League,2024,1,1,0,3,3.0
-F. Schär,Newcastle,Premier League,2023,1,1,0,3,3.0
-F. Santander,Bologna,Serie A,2021,1,1,0,3,3.0
-F. Sacko,Montpellier,Ligue 1,2022,1,1,0,3,3.0
-J. Bruun Larsen,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-J. Brownhill,Burnley,Premier League,2021,1,1,0,3,3.0
-J. Brekalo,Torino,Serie A,2021,1,1,0,3,3.0
-J. Branthwaite,Everton,Premier League,2023,1,1,0,3,3.0
-J. Brandt,Borussia Dortmund,Bundesliga,2024,1,1,0,3,3.0
-J. Brandt,Borussia Dortmund,Bundesliga,2023,1,1,0,3,3.0
-J. Dossou,Clermont Foot,Ligue 1,2022,1,1,0,3,3.0
-J. Dossou,Clermont Foot,Ligue 1,2021,1,1,0,3,3.0
-J. Doku,Rennes,Ligue 1,2022,1,1,0,3,3.0
-J. Doku,Rennes,Ligue 1,2021,1,1,0,3,3.0
-J. Doku,Manchester City,Premier League,2024,1,1,0,3,3.0
-J. Doku,Manchester City,Premier League,2023,1,1,0,3,3.0
-J. Diehl,VfB Stuttgart,Bundesliga,2024,1,1,0,3,3.0
-J. Denayer,Lyon,Ligue 1,2021,1,1,0,3,3.0
-J. Cuadrado,Juventus,Serie A,2021,1,1,0,3,3.0
-J. Correa,Inter,Serie A,2022,1,1,0,3,3.0
-J. Corona,Sevilla,La Liga,2022,1,1,0,3,3.0
-J. Cork,Burnley,Premier League,2021,1,1,0,3,3.0
-J. Clauss,Lens,Ligue 1,2021,1,1,0,3,3.0
-J. Cajuste,Ipswich,Premier League,2024,1,1,0,3,3.0
-J. Bynoe-Gittens,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-J. Burkardt,FSV Mainz 05,Bundesliga,2023,1,1,0,3,3.0
-J. Guilavogui,VfL Wolfsburg,Bundesliga,2022,1,1,0,3,3.0
-J. Guilavogui,1899 Hoffenheim,Bundesliga,2022,1,1,0,3,3.0
-J. Greaves,Ipswich,Premier League,2024,1,1,0,3,3.0
-J. Grealish,Manchester City,Premier League,2023,1,1,0,3,3.0
-J. Gradit,Lens,Ligue 1,2023,1,1,0,3,3.0
-J. Gradit,Lens,Ligue 1,2022,1,1,0,3,3.0
-J. Giraudon,Lille,Ligue 1,2021,1,1,0,3,3.0
-J. Giménez,Atletico Madrid,La Liga,2022,1,1,0,3,3.0
-J. Gastien,Clermont Foot,Ligue 1,2022,1,1,0,3,3.0
-J. Frimpong,Bayer Leverkusen,Bundesliga,2022,1,1,0,3,3.0
-J. Foyth,Villarreal,La Liga,2022,1,1,0,3,3.0
-J. Enciso,Brighton,Premier League,2022,1,1,0,3,3.0
-J. Ekkelenkamp,Hertha Berlin,Bundesliga,2021,1,1,0,3,3.0
-J. Ekhator,Genoa,Serie A,2024,1,1,0,3,3.0
-J. Eggestein,FC St. Pauli,Bundesliga,2024,1,1,0,3,3.0
-J. Draxler,Paris Saint Germain,Ligue 1,2021,1,1,0,3,3.0
-F. Neuhaus,Borussia Monchengladbach,Bundesliga,2023,1,1,0,3,3.0
-F. Mollet,Nantes,Ligue 1,2023,1,1,0,3,3.0
-F. Mollet,Montpellier,Ligue 1,2021,1,1,0,3,3.0
-J. Iličić,Atalanta,Serie A,2021,1,1,0,3,3.0
-J. Ikoné,Lille,Ligue 1,2021,1,1,0,3,3.0
-J. Ikoné,Fiorentina,Serie A,2023,1,1,0,3,3.0
-J. Ikoné,Fiorentina,Serie A,2022,1,1,0,3,3.0
-J. Idzes,Venezia,Serie A,2024,1,1,0,3,3.0
-J. Hofmann,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-J. Hauge,Eintracht Frankfurt,Bundesliga,2021,1,1,0,3,3.0
-J. Harrison,Leeds,Premier League,2022,1,1,0,3,3.0
-J. Haberer,Union Berlin,Bundesliga,2023,1,1,0,3,3.0
-J. Gvardiol,RB Leipzig,Bundesliga,2022,1,1,0,3,3.0
-J. Gvardiol,RB Leipzig,Bundesliga,2021,1,1,0,3,3.0
-J. Gvardiol,Manchester City,Premier League,2024,1,1,0,3,3.0
-J. Gvardiol,Manchester City,Premier League,2023,1,1,0,3,3.0
-J. Kimmich,Bayern Munich,Bundesliga,2022,1,1,0,3,3.0
-J. Karlsson,Bologna,Serie A,2024,1,1,0,3,3.0
-J. Joronen,Verona,Serie A,2024,1,1,0,3,3.0
-J. Ito,Reims,Ligue 1,2023,1,1,0,3,3.0
-J. Ito,Reims,Ligue 1,2022,1,1,0,3,3.0
-F. Sacko,Marseille,Ligue 1,2023,1,1,0,3,3.0
-F. Russo,Mallorca,La Liga,2021,1,1,0,3,3.0
-F. Rieder,VfB Stuttgart,Bundesliga,2024,1,1,0,3,3.0
-F. Rieder,Rennes,Ligue 1,2023,1,1,0,3,3.0
-F. Passlack,Borussia Dortmund,Bundesliga,2021,1,1,0,3,3.0
-F. Parisi,Empoli,Serie A,2022,1,1,0,3,3.0
-F. Onyeka,Brentford,Premier League,2023,1,1,0,3,3.0
-F. Ogier,Clermont Foot,Ligue 1,2023,1,1,0,3,3.0
-F. Nmecha,VfL Wolfsburg,Bundesliga,2022,1,1,0,3,3.0
-F. Nmecha,Borussia Dortmund,Bundesliga,2024,1,1,0,3,3.0
-F. Niederlechner,FC Augsburg,Bundesliga,2021,1,1,0,3,3.0
-J. Leweling,Union Berlin,Bundesliga,2022,1,1,0,3,3.0
-J. Leweling,SpVgg Greuther Furth,Bundesliga,2021,1,1,0,3,3.0
-J. Lerma,Manchester City,Premier League,2022,1,1,0,3,3.0
-J. Lerma,Bournemouth,Premier League,2022,1,1,0,3,3.0
-J. Le Douaron,Stade Brestois 29,Ligue 1,2023,1,1,0,3,3.0
-J. Le Douaron,Stade Brestois 29,Ligue 1,2022,1,1,0,3,3.0
-J. Le Douaron,Stade Brestois 29,Ligue 1,2021,1,1,0,3,3.0
-J. Laursen,Arminia Bielefeld,Bundesliga,2021,1,1,0,3,3.0
-J. Laporte,Lorient,Ligue 1,2021,1,1,0,3,3.0
-J. Kucka,Watford,Premier League,2021,1,1,0,3,3.0
-J. Kucka,Norwich,Premier League,2021,1,1,0,3,3.0
-J. Krasso,Saint Etienne,Ligue 1,2021,1,1,0,3,3.0
-J. Koundé,Real Betis,La Liga,2022,1,1,0,3,3.0
-J. Kluivert,Nice,Ligue 1,2021,1,1,0,3,3.0
-J. Kiwior,Arsenal,Premier League,2022,1,1,0,3,3.0
-J. King,Toulouse,Ligue 1,2024,1,1,0,3,3.0
-J. Manzambi,SC Freiburg,Bundesliga,2024,1,1,0,3,3.0
-J. Malatini,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-F. Mollet,FC Schalke 04,Bundesliga,2022,1,1,0,3,3.0
-F. Mendy,Real Madrid,La Liga,2021,1,1,0,3,3.0
-F. Melegoni,Genoa,Serie A,2021,1,1,0,3,3.0
-F. Maouassa,Montpellier,Ligue 1,2022,1,1,0,3,3.0
-F. Lemaréchal,Strasbourg,Ligue 1,2024,1,1,0,3,3.0
-F. Lejeune,Real Sociedad,La Liga,2022,1,1,0,3,3.0
-F. Lejeune,Rayo Vallecano,La Liga,2022,1,1,0,3,3.0
-F. Klos,Arminia Bielefeld,Bundesliga,2021,1,1,0,3,3.0
-F. Kessié,Barcelona,La Liga,2022,1,1,0,3,3.0
-F. Kessié,AC Milan,Serie A,2021,1,1,0,3,3.0
-F. Jensen,FC Augsburg,Bundesliga,2022,1,1,0,3,3.0
-J. Maddison,Leicester,Premier League,2022,1,1,0,3,3.0
-J. Lotomba,Nice,Ligue 1,2023,1,1,0,3,3.0
-J. Locadia,VfL BOCHUM,Bundesliga,2021,1,1,0,3,3.0
-J. Njinmah,Werder Bremen,Bundesliga,2024,1,1,0,3,3.0
-J. Njinmah,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-J. Nilsson,Arminia Bielefeld,Bundesliga,2021,1,1,0,3,3.0
-J. Niemiec,Fortuna Dusseldorf,Bundesliga,2023,1,1,0,3,3.0
-J. Ngankam,Hertha Berlin,Bundesliga,2022,1,1,0,3,3.0
-J. Mæhle,VfL Wolfsburg,Bundesliga,2024,1,1,0,3,3.0
-J. Mæhle,Atalanta,Serie A,2021,1,1,0,3,3.0
-J. Mwanga,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-J. Musiala,Bayern Munich,Bundesliga,2023,1,1,0,3,3.0
-J. Murphy,Newcastle,Premier League,2023,1,1,0,3,3.0
-J. Murphy,Newcastle,Premier League,2022,1,1,0,3,3.0
-J. Mojica,Mallorca,La Liga,2024,1,1,0,3,3.0
-J. McGinn,Aston Villa,Premier League,2024,1,1,0,3,3.0
-J. McAtee,Manchester City,Premier League,2024,1,1,0,3,3.0
-J. Matip,Tottenham,Premier League,2023,1,1,0,3,3.0
-J. Mateta,Crystal Palace,Premier League,2022,1,1,0,3,3.0
-J. Sebas,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-J. Schlupp,Crystal Palace,Premier League,2023,1,1,0,3,3.0
-J. Schlupp,Crystal Palace,Premier League,2022,1,1,0,3,3.0
-J. Schlupp,Crystal Palace,Premier League,2021,1,1,0,3,3.0
-J. Scally,Borussia Monchengladbach,Bundesliga,2023,1,1,0,3,3.0
-J. Scally,Borussia Monchengladbach,Bundesliga,2021,1,1,0,3,3.0
-J. Sambia,Salernitana,Serie A,2023,1,1,0,3,3.0
-J. Rowe,Marseille,Ligue 1,2024,1,1,0,3,3.0
-J. Robinson,Luton,Premier League,2023,1,1,0,3,3.0
-J. Ramsey,Aston Villa,Premier League,2023,1,1,0,3,3.0
-J. Ramsey,Aston Villa,Premier League,2022,1,1,0,3,3.0
-J. Perea,VfB Stuttgart,Bundesliga,2022,1,1,0,3,3.0
-J. Palomino,Atalanta,Serie A,2022,1,1,0,3,3.0
-J. Ondrejka,Parma,Serie A,2024,1,1,0,3,3.0
-J. Onana,Bordeaux,Ligue 1,2021,1,1,0,3,3.0
-J. O'Brien,Lyon,Ligue 1,2023,1,1,0,3,3.0
-J. Tah,Bayer Leverkusen,Bundesliga,2021,1,1,0,3,3.0
-J. Stage,Werder Bremen,Bundesliga,2022,1,1,0,3,3.0
-J. Solís,Girona,La Liga,2024,1,1,0,3,3.0
-J. Siebatcheu,Union Berlin,Bundesliga,2022,1,1,0,3,3.0
-F. Honorat,Borussia Monchengladbach,Bundesliga,2023,1,1,0,3,3.0
-F. Hanin,Angers,Ligue 1,2024,1,1,0,3,3.0
-F. Guilbert,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-F. Gatti,Sassuolo,Serie A,2023,1,1,0,3,3.0
-F. Gatti,Juventus,Serie A,2023,1,1,0,3,3.0
-F. Di Francesco,Lecce,Serie A,2023,1,1,0,3,3.0
-F. Dahmen,Eintracht Frankfurt,Bundesliga,2023,1,1,0,3,3.0
-F. Coquelin,Villarreal,La Liga,2022,1,1,0,3,3.0
-F. Chiesa,Juventus,Serie A,2022,1,1,0,3,3.0
-F. Chaïbi,Toulouse,Ligue 1,2022,1,1,0,3,3.0
-F. Ceccherini,Verona,Serie A,2022,1,1,0,3,3.0
-F. Caputo,Empoli,Serie A,2023,1,1,0,3,3.0
-F. Ballo,AC Milan,Serie A,2022,1,1,0,3,3.0
-F. Arp,Holstein Kiel,Bundesliga,2024,1,1,0,3,3.0
-J. Ward,Crystal Palace,Premier League,2022,1,1,0,3,3.0
-J. Vásquez,Genoa,Serie A,2021,1,1,0,3,3.0
-J. Vásquez,Cremonese,Serie A,2022,1,1,0,3,3.0
-J. Veretout,AS Roma,Serie A,2021,1,1,0,3,3.0
-J. Vardy,Leicester,Premier League,2024,1,1,0,3,3.0
-J. Vagnoman,VfB Stuttgart,Bundesliga,2024,1,1,0,3,3.0
-J. Vagnoman,VfB Stuttgart,Bundesliga,2023,1,1,0,3,3.0
-J. Vagnoman,VfB Stuttgart,Bundesliga,2022,1,1,0,3,3.0
-J. Thielmann,1.FC Köln,Bundesliga,2023,1,1,0,3,3.0
-J. Tchatchoua,Verona,Serie A,2024,1,1,0,3,3.0
-J. Taylor,Ipswich,Premier League,2024,1,1,0,3,3.0
-J. Tarkowski,Everton,Premier League,2024,1,1,0,3,3.0
-J. Tah,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-J. Tah,Bayer Leverkusen,Bundesliga,2022,1,1,0,3,3.0
-J. Worrall,Nottingham Forest,Premier League,2022,1,1,0,3,3.0
-J. Wind,VfL Wolfsburg,Bundesliga,2023,1,1,0,3,3.0
-J. Wind,VfL Wolfsburg,Bundesliga,2022,1,1,0,3,3.0
-J. Wilson-Esbrand,Reims,Ligue 1,2023,1,1,0,3,3.0
-J. Willock,Newcastle,Premier League,2023,1,1,0,3,3.0
-J. Weigl,Borussia Monchengladbach,Bundesliga,2022,1,1,0,3,3.0
-F. Caputo,Empoli,Serie A,2022,1,1,0,3,3.0
-F. Caicedo,Genoa,Serie A,2021,1,1,0,3,3.0
-F. Buonanotte,Leicester,Premier League,2024,1,1,0,3,3.0
-F. Boulaya,Metz,Ligue 1,2021,1,1,0,3,3.0
-F. Bonazzoli,Salernitana,Serie A,2022,1,1,0,3,3.0
-F. Bianchi,Genoa,Serie A,2021,1,1,0,3,3.0
-F. Bernardeschi,Juventus,Serie A,2021,1,1,0,3,3.0
-F. Baschirotto,Lecce,Serie A,2024,1,1,0,3,3.0
-F. Bandinelli,Empoli,Serie A,2021,1,1,0,3,3.0
-F. Balogun,Monaco,Ligue 1,2024,1,1,0,3,3.0
-Jesús Areso,Osasuna,La Liga,2023,1,1,0,3,3.0
-Jeong Wooyeong,Union Berlin,Bundesliga,2024,1,1,0,3,3.0
-Jeong Woo-Yeong,VfB Stuttgart,Bundesliga,2023,1,1,0,3,3.0
-Jeffinho,Lyon,Ligue 1,2023,1,1,0,3,3.0
-Javier Muñoz,Las Palmas,La Liga,2023,1,1,0,3,3.0
-Javier Hernández,Cadiz,La Liga,2023,1,1,0,3,3.0
-Javi Muñoz,Las Palmas,La Liga,2024,1,1,0,3,3.0
-Javi Martínez,Osasuna,La Liga,2021,1,1,0,3,3.0
-Javi Llabrés,Mallorca,La Liga,2023,1,1,0,3,3.0
-Javi Guerra,Valencia,La Liga,2022,1,1,0,3,3.0
-Jaime Mata,Getafe,La Liga,2023,1,1,0,3,3.0
-Jaime Mata,Getafe,La Liga,2022,1,1,0,3,3.0
-Jacobo Ramón,Real Madrid,La Liga,2024,1,1,0,3,3.0
-J. Álvarez,Manchester City,Premier League,2022,1,1,0,3,3.0
-J. Zirkzee,Manchester United,Premier League,2024,1,1,0,3,3.0
-J. Zirkzee,Bologna,Serie A,2022,1,1,0,3,3.0
-Jorge de Frutos,Rayo Vallecano,La Liga,2024,1,1,0,3,3.0
-Jorge de Frutos,Levante,La Liga,2021,1,1,0,3,3.0
-Jorge Sáenz,Leganes,La Liga,2024,1,1,0,3,3.0
-Jorge Pascual,Villarreal,La Liga,2022,1,1,0,3,3.0
-Jordi Alba,Barcelona,La Liga,2022,1,1,0,3,3.0
-Jordi Alba,Barcelona,La Liga,2021,1,1,0,3,3.0
-Jonathan Viera,Las Palmas,La Liga,2023,1,1,0,3,3.0
-Jon Olasagasti,Real Sociedad,La Liga,2024,1,1,0,3,3.0
-Jon Guridi,Real Sociedad,La Liga,2021,1,1,0,3,3.0
-Jon Guridi,Alaves,La Liga,2024,1,1,0,3,3.0
-Jon Guridi,Alaves,La Liga,2023,1,1,0,3,3.0
-Joelinton,Newcastle,Premier League,2024,1,1,0,3,3.0
-Joelinton,Newcastle,Premier League,2023,1,1,0,3,3.0
-Joelinton,Newcastle,Premier League,2022,1,1,0,3,3.0
-Joaquín Fernández,Atletico Madrid,La Liga,2022,1,1,0,3,3.0
-Jesús Vázquez,Valencia,La Liga,2023,1,1,0,3,3.0
-Jota,Rennes,Ligue 1,2024,1,1,0,3,3.0
-José Sá,Arsenal,Premier League,2021,1,1,0,3,3.0
-José Gragera,Espanyol,La Liga,2022,1,1,0,3,3.0
-José Gayà,Valencia,La Liga,2021,1,1,0,3,3.0
-Josep Chavarría,Rayo Vallecano,La Liga,2023,1,1,0,3,3.0
-Joselu,Real Madrid,La Liga,2023,1,1,0,3,3.0
-F. Agu,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-Eric García,Barcelona,La Liga,2024,1,1,0,3,3.0
-Enric Franquesa,Leganes,La Liga,2024,1,1,0,3,3.0
-Endrick,Real Madrid,La Liga,2024,1,1,0,3,3.0
-E. Ünal,Getafe,La Liga,2021,1,1,0,3,3.0
-E. Ünal,Bournemouth,Premier League,2023,1,1,0,3,3.0
-E. Álvarez,West Ham,Premier League,2023,1,1,0,3,3.0
-E. Zhegrova,Lille,Ligue 1,2024,1,1,0,3,3.0
-E. Zhegrova,Lille,Ligue 1,2023,1,1,0,3,3.0
-Jorginho,Chelsea,Premier League,2022,1,1,0,3,3.0
-João Moutinho,Wolves,Premier League,2021,1,1,0,3,3.0
-João Gomes,Wolves,Premier League,2022,1,1,0,3,3.0
-João Félix,Chelsea,Premier League,2024,1,1,0,3,3.0
-E. Zhegrova,Lille,Ligue 1,2021,1,1,0,3,3.0
-E. Wahi,Montpellier,Ligue 1,2021,1,1,0,3,3.0
-E. Vignato,Empoli,Serie A,2022,1,1,0,3,3.0
-E. Valeri,Cremonese,Serie A,2022,1,1,0,3,3.0
-E. Touré,VfB Stuttgart,Bundesliga,2024,1,1,0,3,3.0
-E. Touré,Almeria,La Liga,2022,1,1,0,3,3.0
-E. Tchato,Montpellier,Ligue 1,2022,1,1,0,3,3.0
-E. Tapsoba,RB Leipzig,Bundesliga,2024,1,1,0,3,3.0
-E. Smith,FC St. Pauli,Bundesliga,2024,1,1,0,3,3.0
-E. Skhiri,FC Koln,Bundesliga,2022,1,1,0,3,3.0
-E. Skhiri,FC Koln,Bundesliga,2021,1,1,0,3,3.0
-E. Simms,Everton,Premier League,2022,1,1,0,3,3.0
-João Félix,Barcelona,La Liga,2023,1,1,0,3,3.0
-Junior Messias,Genoa,Serie A,2024,1,1,0,3,3.0
-Junior Messias,Genoa,Serie A,2023,1,1,0,3,3.0
-Junior Messias,AC Milan,Serie A,2021,1,1,0,3,3.0
-Junior Firpo,Leeds,Premier League,2022,1,1,0,3,3.0
-Jubal,Le Havre,Ligue 1,2024,1,1,0,3,3.0
-Jubal,Auxerre,Ligue 1,2022,1,1,0,3,3.0
-Jubal,Auxerre,Ligue 1,2021,1,1,0,3,3.0
-Juanmi Latasa,Valladolid,La Liga,2024,1,1,0,3,3.0
-Juan Soriano,Osasuna,La Liga,2024,1,1,0,3,3.0
-Juan Jesus,Napoli,Serie A,2023,1,1,0,3,3.0
-Juan Cruz,Real Betis,La Liga,2022,1,1,0,3,3.0
-Juan Bernat,Paris Saint Germain,Ligue 1,2022,1,1,0,3,3.0
-João Pedro,Cagliari,Serie A,2021,1,1,0,3,3.0
-João Palhinha,Leeds,Premier League,2022,1,1,0,3,3.0
-João Palhinha,Fulham,Premier League,2023,1,1,0,3,3.0
-João Palhinha,Fulham,Premier League,2022,1,1,0,3,3.0
-K. Bamba,Nantes,Ligue 1,2023,1,1,0,3,3.0
-K. Baldé,Monza,Serie A,2024,1,1,0,3,3.0
-K. Ayhan,Sassuolo,Serie A,2021,1,1,0,3,3.0
-K. Akpoguma,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-E. Shomurodov,Cagliari,Serie A,2023,1,1,0,3,3.0
-E. Shomurodov,AS Roma,Serie A,2024,1,1,0,3,3.0
-E. Shomurodov,AS Roma,Serie A,2021,1,1,0,3,3.0
-E. Sabbi,LE Havre,Ligue 1,2023,1,1,0,3,3.0
-E. Rexhbeçaj,FC Augsburg,Bundesliga,2023,1,1,0,3,3.0
-E. Rashani,Clermont Foot,Ligue 1,2022,1,1,0,3,3.0
-E. Ponce,Elche,La Liga,2021,1,1,0,3,3.0
-E. Pinnock,Newcastle,Premier League,2022,1,1,0,3,3.0
-E. Pinnock,Brentford,Premier League,2022,1,1,0,3,3.0
-E. Nuamah,Lyon,Ligue 1,2024,1,1,0,3,3.0
-K. Ajer,Brentford,Premier League,2021,1,1,0,3,3.0
-Jérémie Bela,Clermont Foot,Ligue 1,2022,1,1,0,3,3.0
-K. Gameiro,Strasbourg,Ligue 1,2021,1,1,0,3,3.0
-K. Fayad,Montpellier,Ligue 1,2023,1,1,0,3,3.0
-K. Fayad,Lyon,Ligue 1,2024,1,1,0,3,3.0
-K. Ehizibue,Udinese,Serie A,2022,1,1,0,3,3.0
-K. Doumbia,Stade Brestois 29,Ligue 1,2023,1,1,0,3,3.0
-K. Dolberg,1899 Hoffenheim,Bundesliga,2022,1,1,0,3,3.0
-K. Diatta,Monaco,Ligue 1,2022,1,1,0,3,3.0
-K. Demirbay,Bayer Leverkusen,Bundesliga,2021,1,1,0,3,3.0
-K. De Winter,Genoa,Serie A,2024,1,1,0,3,3.0
-K. De Bruyne,Manchester City,Premier League,2021,1,1,0,3,3.0
-K. Davis,Udinese,Serie A,2023,1,1,0,3,3.0
-K. Danso,Lens,Ligue 1,2023,1,1,0,3,3.0
-K. Coman,Bayern Munich,Bundesliga,2023,1,1,0,3,3.0
-K. Coman,Bayern Munich,Bundesliga,2022,1,1,0,3,3.0
-K. Behrens,VfL Wolfsburg,Bundesliga,2024,1,1,0,3,3.0
-K. Behrens,Union Berlin,Bundesliga,2022,1,1,0,3,3.0
-E. Holm,Atalanta,Serie A,2023,1,1,0,3,3.0
-K. Mavropanos,VfB Stuttgart,Bundesliga,2022,1,1,0,3,3.0
-K. Mainoo,Manchester United,Premier League,2023,1,1,0,3,3.0
-K. Lewis-Potter,Brentford,Premier League,2024,1,1,0,3,3.0
-K. Lala,Stade Brestois 29,Ligue 1,2024,1,1,0,3,3.0
-K. Lala,Stade Brestois 29,Ligue 1,2023,1,1,0,3,3.0
-K. Laimer,RB Leipzig,Bundesliga,2022,1,1,0,3,3.0
-K. Kvaratskhelia,Paris Saint Germain,Ligue 1,2024,1,1,0,3,3.0
-K. Kvaratskhelia,Napoli,Serie A,2023,1,1,0,3,3.0
-K. Koulibaly,Napoli,Serie A,2021,1,1,0,3,3.0
-K. Karaman,FC Schalke 04,Bundesliga,2022,1,1,0,3,3.0
-K. Jakić,FC Augsburg,Bundesliga,2023,1,1,0,3,3.0
-K. Jakić,Eintracht Frankfurt,Bundesliga,2022,1,1,0,3,3.0
-K. Hause,Aston Villa,Premier League,2021,1,1,0,3,3.0
-K. Günter,AC Milan,Serie A,2021,1,1,0,3,3.0
-K. Gameiro,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-K. Moore,Bournemouth,Premier League,2022,1,1,0,3,3.0
-K. Miyoshi,VfL Bochum,Bundesliga,2024,1,1,0,3,3.0
-K. Mitoma,Brighton,Premier League,2023,1,1,0,3,3.0
-K. Mitoma,Brighton,Premier League,2022,1,1,0,3,3.0
-K. McLean,Norwich,Premier League,2021,1,1,0,3,3.0
-E. Nketiah,Crystal Palace,Premier League,2024,1,1,0,3,3.0
-E. Nketiah,Arsenal,Premier League,2022,1,1,0,3,3.0
-E. Ndicka,VfL BOCHUM,Bundesliga,2022,1,1,0,3,3.0
-E. Millot,VfB Stuttgart,Bundesliga,2024,1,1,0,3,3.0
-E. Mašović,VfL BOCHUM,Bundesliga,2022,1,1,0,3,3.0
-E. Martínez,Luton,Premier League,2023,1,1,0,3,3.0
-E. Martínez,Arsenal,Premier League,2022,1,1,0,3,3.0
-E. Lepaul,Angers,Ligue 1,2024,1,1,0,3,3.0
-E. Le Fée,Lorient,Ligue 1,2022,1,1,0,3,3.0
-E. Kroupi,Lorient,Ligue 1,2023,1,1,0,3,3.0
-E. Konsa,Aston Villa,Premier League,2024,1,1,0,3,3.0
-K. Piątek,Salernitana,Serie A,2022,1,1,0,3,3.0
-E. Gyasi,Empoli,Serie A,2023,1,1,0,3,3.0
-E. Guessand,Nice,Ligue 1,2024,1,1,0,3,3.0
-E. Guessand,Nice,Ligue 1,2021,1,1,0,3,3.0
-E. Guessand,Nantes,Ligue 1,2022,1,1,0,3,3.0
-E. Goldaniga,Como,Serie A,2024,1,1,0,3,3.0
-E. Forsberg,RB Leipzig,Bundesliga,2022,1,1,0,3,3.0
-E. Fernández,Chelsea,Premier League,2023,1,1,0,3,3.0
-E. Ferguson,Brighton,Premier League,2024,1,1,0,3,3.0
-E. Ferguson,Brighton,Premier League,2023,1,1,0,3,3.0
-E. Eze,Crystal Palace,Premier League,2024,1,1,0,3,3.0
-K. Paredes,VfL Wolfsburg,Bundesliga,2022,1,1,0,3,3.0
-K. Onisiwo,FSV Mainz 05,Bundesliga,2023,1,1,0,3,3.0
-K. Onisiwo,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-K. Mutandwa,Cagliari,Serie A,2023,1,1,0,3,3.0
-K. Moore,Bournemouth,Premier League,2023,1,1,0,3,3.0
-K. Yıldız,Juventus,Serie A,2023,1,1,0,3,3.0
-K. Yeboah,FC Augsburg,Bundesliga,2022,1,1,0,3,3.0
-K. Walker-Peters,Southampton,Premier League,2022,1,1,0,3,3.0
-K. Volland,Union Berlin,Bundesliga,2023,1,1,0,3,3.0
-K. Volland,Reims,Ligue 1,2021,1,1,0,3,3.0
-K. Trippier,Newcastle,Premier League,2021,1,1,0,3,3.0
-K. Topp,Werder Bremen,Bundesliga,2024,1,1,0,3,3.0
-K. Toko-Ekambi,Lyon,Ligue 1,2022,1,1,0,3,3.0
-K. Stöger,VfL BOCHUM,Bundesliga,2022,1,1,0,3,3.0
-K. Stöger,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-K. Schlotterbeck,VfL BOCHUM,Bundesliga,2022,1,1,0,3,3.0
-K. Schlotterbeck,FC Heidenheim,Bundesliga,2023,1,1,0,3,3.0
-K. Schlotterbeck,FC Augsburg,Bundesliga,2024,1,1,0,3,3.0
-K. Schade,SC Freiburg,Bundesliga,2022,1,1,0,3,3.0
-K. Schade,Brentford,Premier League,2023,1,1,0,3,3.0
-K. Rekik,Sevilla,La Liga,2022,1,1,0,3,3.0
-L. Ajorque,Strasbourg,Ligue 1,2021,1,1,0,3,3.0
-L. Ajorque,FSV Mainz 05,Bundesliga,2023,1,1,0,3,3.0
-L. Ajorque,FSV Mainz 05,Bundesliga,2022,1,1,0,3,3.0
-L. Abram,Alaves,La Liga,2021,1,1,0,3,3.0
-Koke,Atletico Madrid,La Liga,2024,1,1,0,3,3.0
-Koka,Le Havre,Ligue 1,2024,1,1,0,3,3.0
-Kirian Rodríguez,Las Palmas,La Liga,2023,1,1,0,3,3.0
-Kim Min-Jae,Napoli,Serie A,2022,1,1,0,3,3.0
-Kike Salas,Sevilla,La Liga,2024,1,1,0,3,3.0
-Kike Salas,Sevilla,La Liga,2023,1,1,0,3,3.0
-Kike García,Osasuna,La Liga,2022,1,1,0,3,3.0
-Kaio Jorge,Frosinone,Serie A,2023,1,1,0,3,3.0
-Kaiky,Almeria,La Liga,2023,1,1,0,3,3.0
-K. Ịheanachọ,Leicester,Premier League,2021,1,1,0,3,3.0
-K. Świderski,Verona,Serie A,2023,1,1,0,3,3.0
-K. Zouma,West Ham,Premier League,2023,1,1,0,3,3.0
-L. Bittencourt,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-L. Beltrán,Fiorentina,Serie A,2023,1,1,0,3,3.0
-L. Barreiro,FSV Mainz 05,Bundesliga,2023,1,1,0,3,3.0
-L. Banda,Lecce,Serie A,2022,1,1,0,3,3.0
-L. Bailey                                  1,Aston Villa,Premier League,2023,1,1,0,3,3.0
-L. Bailey,Aston Villa,Premier League,2024,1,1,0,3,3.0
-E. Eze,Crystal Palace,Premier League,2023,1,1,0,3,3.0
-E. Eze,Crystal Palace,Premier League,2022,1,1,0,3,3.0
-E. Eyong,Villarreal,La Liga,2024,1,1,0,3,3.0
-E. Elmas,Napoli,Serie A,2021,1,1,0,3,3.0
-E. Ebimbe,Eintracht Frankfurt,Bundesliga,2022,1,1,0,3,3.0
-E. Dier,Newcastle,Premier League,2021,1,1,0,3,3.0
-E. Dier,Bayern München,Bundesliga,2024,1,1,0,3,3.0
-L. Ayling,Leeds,Premier League,2021,1,1,0,3,3.0
-L. Assignon,Rennes,Ligue 1,2024,1,1,0,3,3.0
-L. Alario,Eintracht Frankfurt,Bundesliga,2022,1,1,0,3,3.0
-L. De Silvestri,Bologna,Serie A,2021,1,1,0,3,3.0
-L. Da Cunha,Clermont Foot,Ligue 1,2021,1,1,0,3,3.0
-L. Coulibaly,Auxerre,Ligue 1,2024,1,1,0,3,3.0
-L. Cook,Bournemouth,Premier League,2024,1,1,0,3,3.0
-L. Colombo,Monza,Serie A,2023,1,1,0,3,3.0
-L. Caldirola,Monza,Serie A,2023,1,1,0,3,3.0
-L. Caldirola,Monza,Serie A,2022,1,1,0,3,3.0
-L. Cabrera,Espanyol,La Liga,2024,1,1,0,3,3.0
-L. Cabrera,Espanyol,La Liga,2021,1,1,0,3,3.0
-L. Bénes,Union Berlin,Bundesliga,2024,1,1,0,3,3.0
-L. Buchanan,Werder Bremen,Bundesliga,2022,1,1,0,3,3.0
-L. Brassier,Stade Brestois 29,Ligue 1,2023,1,1,0,3,3.0
-L. Boyé,Elche,La Liga,2021,1,1,0,3,3.0
-L. Bonucci,Juventus,Serie A,2022,1,1,0,3,3.0
-L. Blas,Rennes,Ligue 1,2023,1,1,0,3,3.0
-L. Blas,Nantes,Ligue 1,2021,1,1,0,3,3.0
-E. Biumla,Angers,Ligue 1,2024,1,1,0,3,3.0
-E. Ben Seghir,Monaco,Ligue 1,2022,1,1,0,3,3.0
-L. Hall,Newcastle,Premier League,2023,1,1,0,3,3.0
-L. Gourna-Douath,Saint Etienne,Ligue 1,2021,1,1,0,3,3.0
-L. Goretzka,Bayern München,Bundesliga,2024,1,1,0,3,3.0
-L. Giannetti,Napoli,Serie A,2024,1,1,0,3,3.0
-L. Gechter,Hertha Berlin,Bundesliga,2021,1,1,0,3,3.0
-L. Díaz,Liverpool,Premier League,2024,1,1,0,3,3.0
-L. Díaz,Liverpool,Premier League,2022,1,1,0,3,3.0
-L. Díaz,Liverpool,Premier League,2021,1,1,0,3,3.0
-L. Dobbin,Everton,Premier League,2023,1,1,0,3,3.0
-L. Digne,Everton,Premier League,2022,1,1,0,3,3.0
-L. Digne,Aston Villa,Premier League,2023,1,1,0,3,3.0
-L. Delap,Ipswich,Premier League,2024,1,1,0,3,3.0
-L. De Silvestri,Bologna,Serie A,2023,1,1,0,3,3.0
-L. De Silvestri,Bologna,Serie A,2022,1,1,0,3,3.0
-L. Kerber,1. FC Heidenheim,Bundesliga,2024,1,1,0,3,3.0
-L. Jović,AC Milan,Serie A,2024,1,1,0,3,3.0
-L. Höler,SC Freiburg,Bundesliga,2023,1,1,0,3,3.0
-L. Höler,SC Freiburg,Bundesliga,2021,1,1,0,3,3.0
-L. Henderson,Empoli,Serie A,2021,1,1,0,3,3.0
-E. Cömert,Valencia,La Liga,2022,1,1,0,3,3.0
-E. Choupo-Moting,Bayern Munich,Bundesliga,2023,1,1,0,3,3.0
-E. Choupo-Moting,Bayern Munich,Bundesliga,2022,1,1,0,3,3.0
-E. Capoue,Villarreal,La Liga,2021,1,1,0,3,3.0
-E. Can,Borussia Dortmund,Bundesliga,2024,1,1,0,3,3.0
-E. Can,Borussia Dortmund,Bundesliga,2023,1,1,0,3,3.0
-E. Can,Borussia Dortmund,Bundesliga,2021,1,1,0,3,3.0
-E. Buendía,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-E. Boyomo,Osasuna,La Liga,2024,1,1,0,3,3.0
-E. Bove,AS Roma,Serie A,2021,1,1,0,3,3.0
-E. Botheim,Salernitana,Serie A,2022,1,1,0,3,3.0
-L. Modrić,Real Madrid,La Liga,2021,1,1,0,3,3.0
-L. Mincarelli,Montpellier,Ligue 1,2024,1,1,0,3,3.0
-L. Messi,Paris Saint Germain,Ligue 1,2021,1,1,0,3,3.0
-L. Mazzitelli,Frosinone,Serie A,2023,1,1,0,3,3.0
-L. Martínez,Tottenham,Premier League,2023,1,1,0,3,3.0
-L. Martínez,Inter,Serie A,2022,1,1,0,3,3.0
-L. Martínez,Inter,Serie A,2021,1,1,0,3,3.0
-L. Majer,VfL Wolfsburg,Bundesliga,2023,1,1,0,3,3.0
-L. Majer,Rennes,Ligue 1,2022,1,1,0,3,3.0
-L. Maina,FC Koln,Bundesliga,2022,1,1,0,3,3.0
-L. Mafouta,Metz,Ligue 1,2021,1,1,0,3,3.0
-L. Lucca,Udinese,Serie A,2024,1,1,0,3,3.0
-L. Lochoshvili,Cremonese,Serie A,2022,1,1,0,3,3.0
-L. Kübler,SC Freiburg,Bundesliga,2024,1,1,0,3,3.0
-L. Krejčí,Girona,La Liga,2024,1,1,0,3,3.0
-L. Kilian,FC Koln,Bundesliga,2021,1,1,0,3,3.0
-L. Muriel,Atalanta,Serie A,2023,1,1,0,3,3.0
-L. Muriel,Atalanta,Serie A,2022,1,1,0,3,3.0
-Dário Essugo,Las Palmas,La Liga,2024,1,1,0,3,3.0
-Douglas Luiz,Aston Villa,Premier League,2022,1,1,0,3,3.0
-Douglas Augusto,Nantes,Ligue 1,2024,1,1,0,3,3.0
-Domingos Duarte,Getafe,La Liga,2024,1,1,0,3,3.0
-Diogo Jota,Liverpool,Premier League,2022,1,1,0,3,3.0
-Diogo Dalot,Manchester United,Premier League,2023,1,1,0,3,3.0
-Diogo Dalot,Manchester United,Premier League,2022,1,1,0,3,3.0
-Diego Llorente,AS Roma,Serie A,2023,1,1,0,3,3.0
-Diego García,Leganes,La Liga,2024,1,1,0,3,3.0
-L. Mothiba,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-L. Mothiba,Strasbourg,Ligue 1,2022,1,1,0,3,3.0
-L. Mothiba,Estac Troyes,Ligue 1,2021,1,1,0,3,3.0
-L. Modrić,Real Madrid,La Liga,2024,1,1,0,3,3.0
-L. Modrić,Real Madrid,La Liga,2022,1,1,0,3,3.0
-L. Schaub,FC Koln,Bundesliga,2021,1,1,0,3,3.0
-L. Sané,Bayern Munich,Bundesliga,2023,1,1,0,3,3.0
-L. Sané,Bayern Munich,Bundesliga,2022,1,1,0,3,3.0
-L. Samardžić,Atalanta,Serie A,2024,1,1,0,3,3.0
-L. Ritzka,FC St. Pauli,Bundesliga,2024,1,1,0,3,3.0
-L. Rao-Lisoa,Angers,Ligue 1,2022,1,1,0,3,3.0
-L. Ranieri,Fiorentina,Serie A,2023,1,1,0,3,3.0
-L. Pétrot,Lorient,Ligue 1,2021,1,1,0,3,3.0
-L. Pellegrini,AS Roma,Serie A,2022,1,1,0,3,3.0
-L. Pavoletti,Cagliari,Serie A,2024,1,1,0,3,3.0
-L. Pavoletti,Cagliari,Serie A,2021,1,1,0,3,3.0
-L. Ocampos,Sevilla,La Liga,2022,1,1,0,3,3.0
-L. Ocampos,Sevilla,La Liga,2021,1,1,0,3,3.0
-L. O'Brien,Nottingham Forest,Premier League,2022,1,1,0,3,3.0
-L. Nmecha,VfL Wolfsburg,Bundesliga,2023,1,1,0,3,3.0
-L. Nmecha,VfL Wolfsburg,Bundesliga,2021,1,1,0,3,3.0
-L. Sinisterra,Bournemouth,Premier League,2023,1,1,0,3,3.0
-L. Sinayoko,Auxerre,Ligue 1,2024,1,1,0,3,3.0
-Deulofeu,Udinese,Serie A,2021,1,1,0,3,3.0
-Denis Suárez,Villarreal,La Liga,2024,1,1,0,3,3.0
-De Marcos,Athletic Club,La Liga,2021,1,1,0,3,3.0
-David Pereira da Costa,Lens,Ligue 1,2023,1,1,0,3,3.0
-David Neres,Napoli,Serie A,2024,1,1,0,3,3.0
-David García,Osasuna,La Liga,2021,1,1,0,3,3.0
-David Costa,Lens,Ligue 1,2022,1,1,0,3,3.0
-Darío Poveda,Getafe,La Liga,2021,1,1,0,3,3.0
-Darwin Machís,Cadiz,La Liga,2023,1,1,0,3,3.0
-Dany Mota,Monza,Serie A,2024,1,1,0,3,3.0
-Dany Mota,Monza,Serie A,2023,1,1,0,3,3.0
-Dany Mota,Monza,Serie A,2022,1,1,0,3,3.0
-Danilo Pereira,Paris Saint Germain,Ligue 1,2022,1,1,0,3,3.0
-Danilo,Juventus,Serie A,2022,1,1,0,3,3.0
-Lee Jae-Sung,FSV Mainz 05,Bundesliga,2022,1,1,0,3,3.0
-Lee Jae-Sung,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-Lamine Yamal,Barcelona,La Liga,2023,1,1,0,3,3.0
-L. Štulac,Empoli,Serie A,2021,1,1,0,3,3.0
-L. Venuti,AC Milan,Serie A,2021,1,1,0,3,3.0
-L. Valenti,Parma,Serie A,2024,1,1,0,3,3.0
-L. Ugochukwu,Southampton,Premier League,2024,1,1,0,3,3.0
-L. Ugochukwu,Rennes,Ligue 1,2021,1,1,0,3,3.0
-L. Trossard,Brighton,Premier League,2022,1,1,0,3,3.0
-L. Torreira,Fiorentina,Serie A,2021,1,1,0,3,3.0
-L. Tchaouna,Lazio,Serie A,2024,1,1,0,3,3.0
-L. Sučić,Real Sociedad,La Liga,2024,1,1,0,3,3.0
-L. Suárez,Marseille,Ligue 1,2022,1,1,0,3,3.0
-L. Stindl,Borussia Monchengladbach,Bundesliga,2021,1,1,0,3,3.0
-L. Spinazzola,AS Roma,Serie A,2023,1,1,0,3,3.0
-L. Sinisterra,Bournemouth,Premier League,2024,1,1,0,3,3.0
-Logan Costa,Lyon,Ligue 1,2022,1,1,0,3,3.0
-Lisandro Martínez,Manchester United,Premier League,2024,1,1,0,3,3.0
-Lee Kang-In,Elche,La Liga,2021,1,1,0,3,3.0
-Danilo,Juventus,Serie A,2021,1,1,0,3,3.0
-Daniel Podence,Wolves,Premier League,2022,1,1,0,3,3.0
-Dani Vivian,Athletic Club,La Liga,2024,1,1,0,3,3.0
-Dani Vivian,Athletic Club,La Liga,2022,1,1,0,3,3.0
-Dani Raba,Leganes,La Liga,2024,1,1,0,3,3.0
-Dani Parejo                                  0,Villarreal,La Liga,2024,1,1,0,3,3.0
-Dani Parejo,Villarreal,La Liga,2024,1,1,0,3,3.0
-Dani Parejo,Villarreal,La Liga,2023,1,1,0,3,3.0
-Dani Parejo,Villarreal,La Liga,2021,1,1,0,3,3.0
-Dani Olmo,RB Leipzig,Bundesliga,2022,1,1,0,3,3.0
-Dani Olmo,RB Leipzig,Bundesliga,2021,1,1,0,3,3.0
-Dani Gómez,Valencia,La Liga,2024,1,1,0,3,3.0
-Dani Gómez,Levante,La Liga,2021,1,1,0,3,3.0
-Luis Henrique,Marseille,Ligue 1,2023,1,1,0,3,3.0
-Lucas Vázquez,Real Madrid,La Liga,2023,1,1,0,3,3.0
-Dango Ouattara,Lorient,Ligue 1,2021,1,1,0,3,3.0
-D. Črnigoj,Venezia,Serie A,2021,1,1,0,3,3.0
-D. Čolina,FC Augsburg,Bundesliga,2022,1,1,0,3,3.0
-D. Ćaleta-Car,Marseille,Ligue 1,2021,1,1,0,3,3.0
-D. Zappacosta,Atalanta,Serie A,2024,1,1,0,3,3.0
-D. Zappacosta,Atalanta,Serie A,2023,1,1,0,3,3.0
-D. Zapata,Atalanta,Serie A,2022,1,1,0,3,3.0
-D. Yongwa,Lorient,Ligue 1,2023,1,1,0,3,3.0
-Lucas Torró,Osasuna,La Liga,2023,1,1,0,3,3.0
-Lucas Torró,Osasuna,La Liga,2022,1,1,0,3,3.0
-Lucas Paquetá,West Ham,Premier League,2024,1,1,0,3,3.0
-Lucas Paquetá,West Ham,Premier League,2023,1,1,0,3,3.0
-Lucas Moura,Tottenham,Premier League,2022,1,1,0,3,3.0
-Loren Morón,Espanyol,La Liga,2021,1,1,0,3,3.0
-M. Arnautović,Inter,Serie A,2023,1,1,0,3,3.0
-M. Antonio,West Ham,Premier League,2023,1,1,0,3,3.0
-M. Andersen,Luton,Premier League,2023,1,1,0,3,3.0
-M. Albrighton,Leicester,Premier League,2021,1,1,0,3,3.0
-M. Akliouche,Monaco,Ligue 1,2023,1,1,0,3,3.0
-M. Acuña,Sevilla,La Liga,2022,1,1,0,3,3.0
-M. Abline,Rennes,Ligue 1,2022,1,1,0,3,3.0
-M. Abline,Nantes,Ligue 1,2024,1,1,0,3,3.0
-M'Bala Nzola,Spezia,Serie A,2022,1,1,0,3,3.0
-M'Bala Nzola,Spezia,Serie A,2021,1,1,0,3,3.0
-M'Bala Nzola,Lens,Ligue 1,2024,1,1,0,3,3.0
-Lázaro,Almeria,La Liga,2022,1,1,0,3,3.0
-Luís Maximiano,Athletic Club,La Liga,2021,1,1,0,3,3.0
-Luka Modrić,Real Madrid,La Liga,2023,1,1,0,3,3.0
-Luis Milla,Granada CF,La Liga,2021,1,1,0,3,3.0
-Luis Henrique,Marseille,Ligue 1,2024,1,1,0,3,3.0
-M. Bamba,Lorient,Ligue 1,2023,1,1,0,3,3.0
-M. Bakker,Bayer Leverkusen,Bundesliga,2022,1,1,0,3,3.0
-M. Badelj,Genoa,Serie A,2021,1,1,0,3,3.0
-M. Autret,Auxerre,Ligue 1,2022,1,1,0,3,3.0
-M. Arnold,VfL Wolfsburg,Bundesliga,2023,1,1,0,3,3.0
-M. Arnold,VfL Wolfsburg,Bundesliga,2021,1,1,0,3,3.0
-D. Vlahović,Juventus,Serie A,2022,1,1,0,3,3.0
-D. Vlahović,Juventus,Serie A,2021,1,1,0,3,3.0
-D. Vavro,VfL Wolfsburg,Bundesliga,2024,1,1,0,3,3.0
-D. Undav,Brighton,Premier League,2022,1,1,0,3,3.0
-D. Udogie,Udinese,Serie A,2022,1,1,0,3,3.0
-D. Udogie,Udinese,Serie A,2021,1,1,0,3,3.0
-D. Sánchez,Tottenham,Premier League,2021,1,1,0,3,3.0
-D. Szoboszlai,Liverpool,Premier League,2023,1,1,0,3,3.0
-D. Spence,Tottenham,Premier League,2024,1,1,0,3,3.0
-D. Sow,Eintracht Frankfurt,Bundesliga,2021,1,1,0,3,3.0
-M. Bülter,1899 Hoffenheim,Bundesliga,2023,1,1,0,3,3.0
-M. Brozović,Inter,Serie A,2022,1,1,0,3,3.0
-M. Broschinski,VfL BOCHUM,Bundesliga,2022,1,1,0,3,3.0
-M. Brescianini,Frosinone,Serie A,2023,1,1,0,3,3.0
-M. Bourabia,Spezia,Serie A,2021,1,1,0,3,3.0
-M. Boadu,Monaco,Ligue 1,2023,1,1,0,3,3.0
-M. Boadu,Monaco,Ligue 1,2022,1,1,0,3,3.0
-M. Biereth,Monaco,Ligue 1,2024,1,1,0,3,3.0
-M. Bero,Vfl Bochum,Bundesliga,2023,1,1,0,3,3.0
-M. Berisha,FC Augsburg,Bundesliga,2022,1,1,0,3,3.0
-M. Beier,Borussia Dortmund,Bundesliga,2024,1,1,0,3,3.0
-M. Bayo,Lille,Ligue 1,2024,1,1,0,3,3.0
-M. Bayo,Lille,Ligue 1,2022,1,1,0,3,3.0
-M. Bauer,Hertha Berlin,Bundesliga,2021,1,1,0,3,3.0
-M. Batshuayi,Eintracht Frankfurt,Bundesliga,2024,1,1,0,3,3.0
-M. Barreto,Ajaccio,Ligue 1,2022,1,1,0,3,3.0
-M. Caqueret,Lyon,Ligue 1,2022,1,1,0,3,3.0
-M. Cancellieri,Parma,Serie A,2024,1,1,0,3,3.0
-M. Cancellieri,Empoli,Serie A,2023,1,1,0,3,3.0
-D. Solanke,Bournemouth,Premier League,2022,1,1,0,3,3.0
-D. Sinani,FC St. Pauli,Bundesliga,2024,1,1,0,3,3.0
-D. Selke,Hertha Berlin,Bundesliga,2021,1,1,0,3,3.0
-D. Scherhant,Hertha Berlin,Bundesliga,2022,1,1,0,3,3.0
-D. Rugani,Juventus,Serie A,2023,1,1,0,3,3.0
-D. Rice,West Ham,Premier League,2022,1,1,0,3,3.0
-D. Rice,Arsenal,Premier League,2024,1,1,0,3,3.0
-D. Raum,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-D. Praet,Leicester,Premier League,2022,1,1,0,3,3.0
-D. Payet,Marseille,Ligue 1,2022,1,1,0,3,3.0
-D. Ouattara,Bournemouth,Premier League,2022,1,1,0,3,3.0
-M. Camara,Saint Etienne,Ligue 1,2021,1,1,0,3,3.0
-M. Bülter,1899 Hoffenheim,Bundesliga,2024,1,1,0,3,3.0
-M. De Sciglio,Juventus,Serie A,2021,1,1,0,3,3.0
-M. Darmian,Parma,Serie A,2024,1,1,0,3,3.0
-D. Origi,AC Milan,Serie A,2022,1,1,0,3,3.0
-D. Okereke,Venezia,Serie A,2021,1,1,0,3,3.0
-D. O'Shea,West Ham,Premier League,2023,1,1,0,3,3.0
-D. Núñez,Liverpool,Premier League,2022,1,1,0,3,3.0
-D. Ndoye,Bologna,Serie A,2024,1,1,0,3,3.0
-D. Muñoz,Crystal Palace,Premier League,2024,1,1,0,3,3.0
-D. Mertens,Napoli,Serie A,2021,1,1,0,3,3.0
-D. Malen,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-M. Coulibaly,Salernitana,Serie A,2021,1,1,0,3,3.0
-M. Cornet,Genoa,Serie A,2024,1,1,0,3,3.0
-M. Cissé,Atalanta,Serie A,2021,1,1,0,3,3.0
-M. Cho,Angers,Ligue 1,2021,1,1,0,3,3.0
-M. Cham,Clermont Foot,Ligue 1,2022,1,1,0,3,3.0
-M. Caqueret,Lyon,Ligue 1,2023,1,1,0,3,3.0
-M. Gabbiadini,Sampdoria,Serie A,2022,1,1,0,3,3.0
-M. Gabbia,AC Milan,Serie A,2024,1,1,0,3,3.0
-M. Friedl,FC Koln,Bundesliga,2022,1,1,0,3,3.0
-M. Frendrup,AC Milan,Serie A,2024,1,1,0,3,3.0
-M. Finkgräfe,1.FC Köln,Bundesliga,2023,1,1,0,3,3.0
-M. Fares,Genoa,Serie A,2021,1,1,0,3,3.0
-M. Faraoni,Verona,Serie A,2022,1,1,0,3,3.0
-M. Erlić,Spezia,Serie A,2021,1,1,0,3,3.0
-M. Erlić,Sampdoria,Serie A,2022,1,1,0,3,3.0
-M. Elyounoussi,Southampton,Premier League,2021,1,1,0,3,3.0
-M. Elia,Nantes,Ligue 1,2024,1,1,0,3,3.0
-M. El Haddadi,Getafe,La Liga,2022,1,1,0,3,3.0
-M. Eggestein,SC Freiburg,Bundesliga,2024,1,1,0,3,3.0
-M. Ducksch,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-M. Doherty,Wolves,Premier League,2023,1,1,0,3,3.0
-M. Diakhaby,Valencia,La Liga,2022,1,1,0,3,3.0
-M. Gregoritsch,SC Freiburg,Bundesliga,2023,1,1,0,3,3.0
-M. Greenwood,Manchester United,Premier League,2021,1,1,0,3,3.0
-M. Ginter,SC Freiburg,Bundesliga,2022,1,1,0,3,3.0
-M. Ginter,FC Heidenheim,Bundesliga,2023,1,1,0,3,3.0
-M. Gibbs-White,Nottingham Forest,Premier League,2022,1,1,0,3,3.0
-D. Malen,Aston Villa,Premier League,2024,1,1,0,3,3.0
-D. Machís,Granada CF,La Liga,2021,1,1,0,3,3.0
-D. Machado,Lens,Ligue 1,2024,1,1,0,3,3.0
-D. Lukébakio,VfL Wolfsburg,Bundesliga,2021,1,1,0,3,3.0
-D. Ljubičić,FC Koln,Bundesliga,2021,1,1,0,3,3.0
-D. Kulusevski                                  0,Tottenham,Premier League,2023,1,1,0,3,3.0
-D. Kulusevski,Tottenham,Premier League,2023,1,1,0,3,3.0
-D. Kohr,FSV Mainz 05,Bundesliga,2022,1,1,0,3,3.0
-D. Johnsen,Venezia,Serie A,2021,1,1,0,3,3.0
-D. Jebbison,Bournemouth,Premier League,2024,1,1,0,3,3.0
-M. Geschwill,FC St. Pauli,Bundesliga,2024,1,1,0,3,3.0
-D. Fofana,Union Berlin,Bundesliga,2023,1,1,0,3,3.0
-D. Fofana,Burnley,Premier League,2023,1,1,0,3,3.0
-M. Koné,AS Roma,Serie A,2024,1,1,0,3,3.0
-M. Kilman,Wolves,Premier League,2023,1,1,0,3,3.0
-M. Kerkez,Bournemouth,Premier League,2024,1,1,0,3,3.0
-M. Kempf,VfB Stuttgart,Bundesliga,2021,1,1,0,3,3.0
-M. Keane,Everton,Premier League,2022,1,1,0,3,3.0
-M. Kean,Juventus,Serie A,2021,1,1,0,3,3.0
-M. Kamiński,FC Schalke 04,Bundesliga,2022,1,1,0,3,3.0
-M. Jørgensen,Nottingham Forest,Premier League,2022,1,1,0,3,3.0
-M. Honsak,1. FC Heidenheim,Bundesliga,2024,1,1,0,3,3.0
-M. Hongla,Verona,Serie A,2021,1,1,0,3,3.0
-M. Guéhi,Crystal Palace,Premier League,2021,1,1,0,3,3.0
-M. Guéhi,Brighton,Premier League,2024,1,1,0,3,3.0
-M. Guéhi,Arsenal,Premier League,2022,1,1,0,3,3.0
-M. Gusto,Marseille,Ligue 1,2022,1,1,0,3,3.0
-M. Lambourde,Verona,Serie A,2024,1,1,0,3,3.0
-M. Lacroix,VfL Wolfsburg,Bundesliga,2023,1,1,0,3,3.0
-M. Lacroix,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-M. Kudus,West Ham,Premier League,2024,1,1,0,3,3.0
-M. Kruse,Union Berlin,Bundesliga,2021,1,1,0,3,3.0
-M. Kovačić,Chelsea,Premier League,2022,1,1,0,3,3.0
-D. James,Leeds,Premier League,2021,1,1,0,3,3.0
-D. Ings,West Ham,Premier League,2024,1,1,0,3,3.0
-D. Ings,West Ham,Premier League,2023,1,1,0,3,3.0
-D. Ings,Aston Villa,Premier League,2022,1,1,0,3,3.0
-D. Huijsen,Torino,Serie A,2023,1,1,0,3,3.0
-D. Henderson,West Ham,Premier League,2023,1,1,0,3,3.0
-D. Gómez,Brighton,Premier League,2024,1,1,0,3,3.0
-D. Gray,Everton,Premier League,2021,1,1,0,3,3.0
-D. Gosling,Watford,Premier League,2021,1,1,0,3,3.0
-D. Frattesi,Sassuolo,Serie A,2022,1,1,0,3,3.0
-M. Nade,Saint Etienne,Ligue 1,2021,1,1,0,3,3.0
-M. Munetsi,Reims,Ligue 1,2024,1,1,0,3,3.0
-M. Munetsi,Reims,Ligue 1,2022,1,1,0,3,3.0
-M. Munetsi,Reims,Ligue 1,2021,1,1,0,3,3.0
-M. Mudryk,Chelsea,Premier League,2023,1,1,0,3,3.0
-M. Mount,Manchester United,Premier League,2023,1,1,0,3,3.0
-M. Meïté,Rennes,Ligue 1,2024,1,1,0,3,3.0
-M. McKenzie,Toulouse,Ligue 1,2024,1,1,0,3,3.0
-M. Maolida,Hertha Berlin,Bundesliga,2021,1,1,0,3,3.0
-M. Malsa,Levante,La Liga,2021,1,1,0,3,3.0
-M. Locatelli,Juventus,Serie A,2021,1,1,0,3,3.0
-M. Lemina,Wolves,Premier League,2023,1,1,0,3,3.0
-M. Lemina,Nice,Ligue 1,2021,1,1,0,3,3.0
-M. Leitsch,FSV Mainz 05,Bundesliga,2024,1,1,0,3,3.0
-M. Lanzini,West Ham,Premier League,2022,1,1,0,3,3.0
-M. Lanzini,West Ham,Premier League,2021,1,1,0,3,3.0
-M. Olivera,Napoli,Serie A,2022,1,1,0,3,3.0
-M. Olise,Crystal Palace,Premier League,2023,1,1,0,3,3.0
-M. Olise,Crystal Palace,Premier League,2021,1,1,0,3,3.0
-M. Olise,Bayern München,Bundesliga,2024,1,1,0,3,3.0
-M. O'Riley,Fulham,Premier League,2024,1,1,0,3,3.0
-D. Faraoni,Verona,Serie A,2021,1,1,0,3,3.0
-D. Dumfries,Monza,Serie A,2022,1,1,0,3,3.0
-D. Dumfries,Inter,Serie A,2023,1,1,0,3,3.0
-D. Dumfries,Inter,Serie A,2022,1,1,0,3,3.0
-D. Doué,Rennes,Ligue 1,2023,1,1,0,3,3.0
-D. Coppola,Verona,Serie A,2023,1,1,0,3,3.0
-D. Cataldi,Lazio,Serie A,2021,1,1,0,3,3.0
-D. Calvert-Lewin,Everton,Premier League,2023,1,1,0,3,3.0
-M. Niang,Bordeaux,Ligue 1,2021,1,1,0,3,3.0
-M. Niang,Auxerre,Ligue 1,2022,1,1,0,3,3.0
-M. Niakhate,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-D. Burn,Newcastle,Premier League,2023,1,1,0,3,3.0
-D. Burgzorg,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-D. Brooks,Bournemouth,Premier League,2023,1,1,0,3,3.0
-D. Brašanac,Osasuna,La Liga,2022,1,1,0,3,3.0
-D. Brašanac,Leganes,La Liga,2024,1,1,0,3,3.0
-D. Bouanga,Saint Etienne,Ligue 1,2021,1,1,0,3,3.0
-D. Blum,VfL BOCHUM,Bundesliga,2021,1,1,0,3,3.0
-D. Benedetto,Elche,La Liga,2021,1,1,0,3,3.0
-D. Beljo,FC Augsburg,Bundesliga,2023,1,1,0,3,3.0
-D. Appiah,Paris Saint Germain,Ligue 1,2021,1,1,0,3,3.0
-M. Pessina,Atalanta,Serie A,2021,1,1,0,3,3.0
-M. Pellegrino,Parma,Serie A,2024,1,1,0,3,3.0
-M. Pašalić,Atalanta,Serie A,2023,1,1,0,3,3.0
-M. Pašalić,Atalanta,Serie A,2022,1,1,0,3,3.0
-M. Pantović,Union Berlin,Bundesliga,2023,1,1,0,3,3.0
-M. Pantović,Union Berlin,Bundesliga,2022,1,1,0,3,3.0
-M. Sissoko,Watford,Premier League,2021,1,1,0,3,3.0
-M. Sissoko,Nantes,Ligue 1,2022,1,1,0,3,3.0
-M. Simon,Nantes,Ligue 1,2024,1,1,0,3,3.0
-M. Simon,Nantes,Ligue 1,2023,1,1,0,3,3.0
-M. Saračević,Clermont Foot,Ligue 1,2022,1,1,0,3,3.0
-M. Sanson,Nice,Ligue 1,2023,1,1,0,3,3.0
-M. Sabitzer,Bayern Munich,Bundesliga,2022,1,1,0,3,3.0
-M. Sabitzer,Bayern Munich,Bundesliga,2021,1,1,0,3,3.0
-M. Ritchie,Newcastle,Premier League,2023,1,1,0,3,3.0
-M. Reus,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-M. Rasmussen,Brentford,Premier League,2021,1,1,0,3,3.0
-M. Rashford,Manchester United,Premier League,2023,1,1,0,3,3.0
-M. Politano,Napoli,Serie A,2022,1,1,0,3,3.0
-M. Pieringer,1. FC Heidenheim,Bundesliga,2024,1,1,0,3,3.0
-M. Philipp,SC Freiburg,Bundesliga,2023,1,1,0,3,3.0
-D. Calabria,AC Milan,Serie A,2023,1,1,0,3,3.0
-Cristian Herrera,Las Palmas,La Liga,2023,1,1,0,3,3.0
-Coke,Levante,La Liga,2021,1,1,0,3,3.0
-Chris Ramos,Cadiz,La Liga,2023,1,1,0,3,3.0
-Chimy Ávila,Osasuna,La Liga,2023,1,1,0,3,3.0
-Catena,Rayo Vallecano,La Liga,2022,1,1,0,3,3.0
-Casemiro,Manchester United,Premier League,2024,1,1,0,3,3.0
-Casemiro,Manchester United,Premier League,2022,1,1,0,3,3.0
-Carlos Vinícius,Fulham,Premier League,2023,1,1,0,3,3.0
-Carlos Vinícius,Fulham,Premier League,2022,1,1,0,3,3.0
-Carlos Vicente,Alaves,La Liga,2024,1,1,0,3,3.0
-Carlos Romero,Espanyol,La Liga,2024,1,1,0,3,3.0
-Carlos Fernández,Real Sociedad,La Liga,2023,1,1,0,3,3.0
-M. Svanberg,VfL Wolfsburg,Bundesliga,2022,1,1,0,3,3.0
-M. Svanberg,Bologna,Serie A,2021,1,1,0,3,3.0
-M. Soulé,Juventus,Serie A,2022,1,1,0,3,3.0
-M. Soulé,Frosinone,Serie A,2023,1,1,0,3,3.0
-M. Wittek,Vfl Bochum,Bundesliga,2023,1,1,0,3,3.0
-M. Vydra,Burnley,Premier League,2021,1,1,0,3,3.0
-M. Viña,Empoli,Serie A,2023,1,1,0,3,3.0
-M. Veljković,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-M. Veljković,Werder Bremen,Bundesliga,2022,1,1,0,3,3.0
-M. Valjent,Mallorca,La Liga,2024,1,1,0,3,3.0
-M. Uzuni,Granada CF,La Liga,2021,1,1,0,3,3.0
-M. Uth,FC Koln,Bundesliga,2021,1,1,0,3,3.0
-M. Ugarte,Manchester United,Premier League,2024,1,1,0,3,3.0
-M. Udol,Metz,Ligue 1,2024,1,1,0,3,3.0
-M. Trauco,Saint Etienne,Ligue 1,2021,1,1,0,3,3.0
-M. Thiaw,Genoa,Serie A,2023,1,1,0,3,3.0
-M. Terrier,Rennes,Ligue 1,2023,1,1,0,3,3.0
-M. Tel,Tottenham,Premier League,2024,1,1,0,3,3.0
-M. Tavernier,Bournemouth,Premier League,2024,1,1,0,3,3.0
-César Tárrega,Valencia,La Liga,2024,1,1,0,3,3.0
-Manu Fuster,Las Palmas,La Liga,2024,1,1,0,3,3.0
-Mama Baldé,Lyon,Ligue 1,2023,1,1,0,3,3.0
-Mama Baldé,Estac Troyes,Ligue 1,2022,1,1,0,3,3.0
-Mahmoud Dahoud,VfB Stuttgart,Bundesliga,2023,1,1,0,3,3.0
-M. Đurić,Salernitana,Serie A,2021,1,1,0,3,3.0
-M. Đurić,Monza,Serie A,2023,1,1,0,3,3.0
-M. Ødegaard,Arsenal,Premier League,2024,1,1,0,3,3.0
-M. Ødegaard,Arsenal,Premier League,2023,1,1,0,3,3.0
-M. van de Ven,Tottenham,Premier League,2023,1,1,0,3,3.0
-M. de Roon,Atalanta,Serie A,2024,1,1,0,3,3.0
-M. de Roon,Atalanta,Serie A,2021,1,1,0,3,3.0
-M. de Ligt,Bayern Munich,Bundesliga,2023,1,1,0,3,3.0
-M. Zaccagni,Verona,Serie A,2021,1,1,0,3,3.0
-M. Zaccagni,Lazio,Serie A,2024,1,1,0,3,3.0
-M. Zaccagni,Lazio,Serie A,2021,1,1,0,3,3.0
-M. Wolf,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-Marc Bartra,Real Betis,La Liga,2024,1,1,0,3,3.0
-Carlos Domínguez,Real Madrid,La Liga,2023,1,1,0,3,3.0
-Carlos Augusto,Monza,Serie A,2022,1,1,0,3,3.0
-Carlos Augusto,Inter,Serie A,2024,1,1,0,3,3.0
-Carles Pérez,Getafe,La Liga,2024,1,1,0,3,3.0
-Carles Pérez,Celta Vigo,La Liga,2022,1,1,0,3,3.0
-Carles Pérez,AS Roma,Serie A,2021,1,1,0,3,3.0
-Carles Aleñá,Getafe,La Liga,2021,1,1,0,3,3.0
-Caio Henrique,Nantes,Ligue 1,2022,1,1,0,3,3.0
-Caio Henrique,Monaco,Ligue 1,2021,1,1,0,3,3.0
-C. Ünder,Marseille,Ligue 1,2022,1,1,0,3,3.0
-C. Wooh,Strasbourg,Ligue 1,2024,1,1,0,3,3.0
-C. Woodrow,Luton,Premier League,2023,1,1,0,3,3.0
-C. Wood,Nottingham Forest,Premier League,2022,1,1,0,3,3.0
-Marc Bartra,Real Betis,La Liga,2021,1,1,0,3,3.0
-Manu Sánchez,Osasuna,La Liga,2021,1,1,0,3,3.0
-Matheus Nunes,Manchester City,Premier League,2024,1,1,0,3,3.0
-Matheus Henrique,Sassuolo,Serie A,2022,1,1,0,3,3.0
-Matheus França,Crystal Palace,Premier League,2024,1,1,0,3,3.0
-Mateus Fernandes,Southampton,Premier League,2024,1,1,0,3,3.0
-Mata,Getafe,La Liga,2021,1,1,0,3,3.0
-Mason Greenwood,Getafe,La Liga,2023,1,1,0,3,3.0
-Martín Zubimendi,Real Sociedad,La Liga,2024,1,1,0,3,3.0
-Marko Milovanović,Almeria,La Liga,2023,1,1,0,3,3.0
-Mario Gila,Juventus,Serie A,2024,1,1,0,3,3.0
-Marcos Antônio,Lazio,Serie A,2022,1,1,0,3,3.0
-Marcos André,Valencia,La Liga,2022,1,1,0,3,3.0
-Marcos André,Valencia,La Liga,2021,1,1,0,3,3.0
-Marcos Alonso,Celta Vigo,La Liga,2024,1,1,0,3,3.0
-Marc Roca,Leeds,Premier League,2022,1,1,0,3,3.0
-Marc Guiu,Barcelona,La Liga,2023,1,1,0,3,3.0
-Marc Cucurella,Chelsea,Premier League,2024,1,1,0,3,3.0
-Miguel Gutiérrez,Girona,La Liga,2022,1,1,0,3,3.0
-Mexer,Bordeaux,Ligue 1,2021,1,1,0,3,3.0
-C. Volpato,AS Roma,Serie A,2022,1,1,0,3,3.0
-C. Vidal,Ajaccio,Ligue 1,2022,1,1,0,3,3.0
-C. Uzun,Eintracht Frankfurt,Bundesliga,2024,1,1,0,3,3.0
-C. Tzolis,Fortuna Dusseldorf,Bundesliga,2023,1,1,0,3,3.0
-C. Traorè,AC Milan,Serie A,2023,1,1,0,3,3.0
-C. Tolisso,Lyon,Ligue 1,2024,1,1,0,3,3.0
-C. Starfelt,Celta Vigo,La Liga,2024,1,1,0,3,3.0
-C. Smalling,AS Roma,Serie A,2021,1,1,0,3,3.0
-C. Romero,Tottenham,Premier League,2023,1,1,0,3,3.0
-C. Richards,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-Melero,Almeria,La Liga,2022,1,1,0,3,3.0
-Matija Nastasić,Mallorca,La Liga,2023,1,1,0,3,3.0
-Mathias Pereira Lage,Stade Brestois 29,Ligue 1,2023,1,1,0,3,3.0
-Mathias Lage,Angers,Ligue 1,2021,1,1,0,3,3.0
-Monchu,Valladolid,La Liga,2022,1,1,0,3,3.0
-Moi Gómez,Villarreal,La Liga,2021,1,1,0,3,3.0
-C. Pulisic,Chelsea,Premier League,2021,1,1,0,3,3.0
-C. Piccini,Valencia,La Liga,2021,1,1,0,3,3.0
-C. Palmer                                  1,Chelsea,Premier League,2023,1,1,0,3,3.0
-C. Ogbene,Luton,Premier League,2023,1,1,0,3,3.0
-C. Nørgaard,Brentford,Premier League,2021,1,1,0,3,3.0
-C. Nkunku,Chelsea,Premier League,2024,1,1,0,3,3.0
-C. Nkunku,Chelsea,Premier League,2023,1,1,0,3,3.0
-C. Ngonge,Napoli,Serie A,2023,1,1,0,3,3.0
-C. Matsima,Bayern München,Bundesliga,2024,1,1,0,3,3.0
-Moi Gómez,Osasuna,La Liga,2022,1,1,0,3,3.0
-Moi Gómez,Celta Vigo,La Liga,2024,1,1,0,3,3.0
-Mikel Oyarzabal,Real Sociedad,La Liga,2024,1,1,0,3,3.0
-Miguel de la Fuente,Leganes,La Liga,2024,1,1,0,3,3.0
-Miguel Rodríguez,Celta Vigo,La Liga,2022,1,1,0,3,3.0
-N. Cambiaghi,Bologna,Serie A,2024,1,1,0,3,3.0
-N. Bentaleb,Lille,Ligue 1,2024,1,1,0,3,3.0
-N. Barella,Inter,Serie A,2023,1,1,0,3,3.0
-N. Bajrami,Sassuolo,Serie A,2022,1,1,0,3,3.0
-N. Bajrami,Empoli,Serie A,2022,1,1,0,3,3.0
-N. Bajrami,Empoli,Serie A,2021,1,1,0,3,3.0
-N. Amiri,FSV Mainz 05,Bundesliga,2024,1,1,0,3,3.0
-N. Amiri,Bayer Leverkusen,Bundesliga,2022,1,1,0,3,3.0
-N. Amiri,Bayer Leverkusen,Bundesliga,2021,1,1,0,3,3.0
-N. Aké,Manchester City,Premier League,2023,1,1,0,3,3.0
-N. Aké,Manchester City,Premier League,2021,1,1,0,3,3.0
-N. Aguerd,Rennes,Ligue 1,2021,1,1,0,3,3.0
-Mousa Al Ta'mari,Montpellier,Ligue 1,2024,1,1,0,3,3.0
-Mousa Al Ta'mari,Montpellier,Ligue 1,2023,1,1,0,3,3.0
-Mostafa Mohamed,Nantes,Ligue 1,2023,1,1,0,3,3.0
-Montoro,Granada CF,La Liga,2021,1,1,0,3,3.0
-C. Larin,Mallorca,La Liga,2024,1,1,0,3,3.0
-C. Kouamé,Fiorentina,Serie A,2022,1,1,0,3,3.0
-C. Klarer,SV Darmstadt 98,Bundesliga,2023,1,1,0,3,3.0
-C. Jullien,Montpellier,Ligue 1,2023,1,1,0,3,3.0
-C. Jean,Lens,Ligue 1,2021,1,1,0,3,3.0
-C. Hudson-Odoi,Nottingham Forest,Premier League,2024,1,1,0,3,3.0
-C. Hudson-Odoi,Nottingham Forest,Premier League,2023,1,1,0,3,3.0
-C. Hountondji,Strasbourg,Ligue 1,2021,1,1,0,3,3.0
-N. Elvedi,Borussia Monchengladbach,Bundesliga,2021,1,1,0,3,3.0
-N. El Aynaoui,Lens,Ligue 1,2024,1,1,0,3,3.0
-N. El Aynaoui,Lens,Ligue 1,2023,1,1,0,3,3.0
-N. Dovedan,FC Heidenheim,Bundesliga,2023,1,1,0,3,3.0
-N. Dorsch,FC Augsburg,Bundesliga,2021,1,1,0,3,3.0
-N. Dorsch,1. FC Heidenheim,Bundesliga,2024,1,1,0,3,3.0
-N. Domínguez,Bologna,Serie A,2022,1,1,0,3,3.0
-N. Collins,Eintracht Frankfurt,Bundesliga,2024,1,1,0,3,3.0
-N. Murru,Sampdoria,Serie A,2021,1,1,0,3,3.0
-N. Milenković,Nottingham Forest,Premier League,2024,1,1,0,3,3.0
-N. Milenković,AC Milan,Serie A,2022,1,1,0,3,3.0
-N. Mbemba,LE Havre,Ligue 1,2023,1,1,0,3,3.0
-N. Mazraoui,Bayern Munich,Bundesliga,2022,1,1,0,3,3.0
-N. Madueke,Chelsea,Premier League,2023,1,1,0,3,3.0
-N. Krstović,Lecce,Serie A,2024,1,1,0,3,3.0
-N. Keïta,Liverpool,Premier League,2021,1,1,0,3,3.0
-N. Jackson,Chelsea,Premier League,2024,1,1,0,3,3.0
-N. Gudelj,Sevilla,La Liga,2022,1,1,0,3,3.0
-N. Füllkrug,West Ham,Premier League,2024,1,1,0,3,3.0
-N. Fagioli,Juventus,Serie A,2022,1,1,0,3,3.0
-N. Elvedi,Borussia Monchengladbach,Bundesliga,2022,1,1,0,3,3.0
-C. Lykogiannis,Bologna,Serie A,2023,1,1,0,3,3.0
-C. Lenglet,Atletico Madrid,La Liga,2024,1,1,0,3,3.0
-C. Larin,Valladolid,La Liga,2022,1,1,0,3,3.0
-N. Schlotterbeck,SC Freiburg,Bundesliga,2021,1,1,0,3,3.0
-N. Sarenren Bazee,FC Augsburg,Bundesliga,2021,1,1,0,3,3.0
-N. Sansone,Lecce,Serie A,2023,1,1,0,3,3.0
-N. Sansone,Bologna,Serie A,2022,1,1,0,3,3.0
-N. Sansone,Bologna,Serie A,2021,1,1,0,3,3.0
-N. Radonjić,Torino,Serie A,2023,1,1,0,3,3.0
-N. Pérez,Udinese,Serie A,2022,1,1,0,3,3.0
-N. Pépé,Nice,Ligue 1,2022,1,1,0,3,3.0
-N. Pépé,Arsenal,Premier League,2021,1,1,0,3,3.0
-N. Pisilli,AS Roma,Serie A,2024,1,1,0,3,3.0
-N. Petersen,SC Freiburg,Bundesliga,2021,1,1,0,3,3.0
-N. Pallois,Marseille,Ligue 1,2022,1,1,0,3,3.0
-N. Okafor,AC Milan,Serie A,2024,1,1,0,3,3.0
-N. Nández,Cagliari,Serie A,2023,1,1,0,3,3.0
-N. Nkounkou,Eintracht Frankfurt,Bundesliga,2023,1,1,0,3,3.0
-N. Ngoumou,Borussia Monchengladbach,Bundesliga,2023,1,1,0,3,3.0
-N. Zaniolo,Atalanta,Serie A,2024,1,1,0,3,3.0
-N. Williams,Nottingham Forest,Premier League,2024,1,1,0,3,3.0
-N. Vlašić,West Ham,Premier League,2021,1,1,0,3,3.0
-N. Vlašić,Torino,Serie A,2022,1,1,0,3,3.0
-N. Tella,Bayer Leverkusen,Bundesliga,2023,1,1,0,3,3.0
-N. Süle,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-C. Hernández,Real Betis,La Liga,2024,1,1,0,3,3.0
-C. Grenier,Mallorca,La Liga,2021,1,1,0,3,3.0
-C. Gamboa,VfL Bochum,Bundesliga,2024,1,1,0,3,3.0
-C. Gallagher,Chelsea,Premier League,2022,1,1,0,3,3.0
-C. Führich,VfB Stuttgart,Bundesliga,2022,1,1,0,3,3.0
-C. Führich,VfB Stuttgart,Bundesliga,2021,1,1,0,3,3.0
-C. Eriksen,Manchester United,Premier League,2024,1,1,0,3,3.0
-C. Ejuke,Sevilla,La Liga,2024,1,1,0,3,3.0
-C. De Ketelaere,Atalanta,Serie A,2024,1,1,0,3,3.0
-N. Stark,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-O. Aina,Nottingham Forest,Premier League,2024,1,1,0,3,3.0
-O. Afolayan,FC St. Pauli,Bundesliga,2024,1,1,0,3,3.0
-Nuno da Costa,Auxerre,Ligue 1,2022,1,1,0,3,3.0
-Nuno Mendes,Paris Saint Germain,Ligue 1,2023,1,1,0,3,3.0
-Nico Williams,Athletic Club,La Liga,2024,1,1,0,3,3.0
-Nico González,Manchester City,Premier League,2024,1,1,0,3,3.0
-Nico González,Barcelona,La Liga,2021,1,1,0,3,3.0
-Nemanja Maksimović,Getafe,La Liga,2023,1,1,0,3,3.0
-Nacho Vidal,Osasuna,La Liga,2023,1,1,0,3,3.0
-Nacho Ferri,Eintracht Frankfurt,Bundesliga,2023,1,1,0,3,3.0
-Nacho,Real Madrid,La Liga,2021,1,1,0,3,3.0
-Nabil Fekir,Real Betis,La Liga,2023,1,1,0,3,3.0
-N. Zortea,Frosinone,Serie A,2023,1,1,0,3,3.0
-N. Zortea,Cagliari,Serie A,2024,1,1,0,3,3.0
-N. Zortea,Atalanta,Serie A,2023,1,1,0,3,3.0
-N. Zortea,Atalanta,Serie A,2022,1,1,0,3,3.0
-O. Giroud,AC Milan,Serie A,2021,1,1,0,3,3.0
-O. Duda,FC Koln,Bundesliga,2021,1,1,0,3,3.0
-O. Dembélé,Barcelona,La Liga,2022,1,1,0,3,3.0
-O. Deman,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-O. Colley,Sampdoria,Serie A,2022,1,1,0,3,3.0
-C. Dawson,West Ham,Premier League,2021,1,1,0,3,3.0
-C. Boukhalfa,FC St. Pauli,Bundesliga,2024,1,1,0,3,3.0
-C. Biraghi,Lazio,Serie A,2021,1,1,0,3,3.0
-C. Biraghi,Bologna,Serie A,2024,1,1,0,3,3.0
-C. Benavídez,Alaves,La Liga,2024,1,1,0,3,3.0
-C. Bayala,Ajaccio,Ligue 1,2022,1,1,0,3,3.0
-C. Baumgartner,RB Leipzig,Bundesliga,2024,1,1,0,3,3.0
-C. Baleba,Brighton,Premier League,2024,1,1,0,3,3.0
-C. Archer,Sheffield Utd,Premier League,2023,1,1,0,3,3.0
-O. Bukari,Nantes,Ligue 1,2021,1,1,0,3,3.0
-O. Bobb,Manchester City,Premier League,2023,1,1,0,3,3.0
-Oier Zarraga,Udinese,Serie A,2023,1,1,0,3,3.0
-Oier Zarraga,Athletic Club,La Liga,2021,1,1,0,3,3.0
-C. Alcaraz,Everton,Premier League,2024,1,1,0,3,3.0
-C. Adams,Torino,Serie A,2024,1,1,0,3,3.0
-C. Adams,Southampton,Premier League,2022,1,1,0,3,3.0
-C. Adams,Southampton,Premier League,2021,1,1,0,3,3.0
-Bryan Zaragoza,Granada CF,La Liga,2023,1,1,0,3,3.0
-Bruno Méndez,Granada CF,La Liga,2023,1,1,0,3,3.0
-Bruno Fernandes,Manchester United,Premier League,2022,1,1,0,3,3.0
-O. Sahraoui,Lille,Ligue 1,2024,1,1,0,3,3.0
-O. Norwood,Sheffield Utd,Premier League,2023,1,1,0,3,3.0
-O. N'Dicka,Eintracht Frankfurt,Bundesliga,2021,1,1,0,3,3.0
-O. McBurnie,Las Palmas,La Liga,2024,1,1,0,3,3.0
-O. Maamma,Montpellier,Ligue 1,2024,1,1,0,3,3.0
-O. Højlund,Eintracht Frankfurt,Bundesliga,2024,1,1,0,3,3.0
-O. Giroud,AC Milan,Serie A,2022,1,1,0,3,3.0
-P. Billing,Napoli,Serie A,2024,1,1,0,3,3.0
-P. Billing,Bournemouth,Premier League,2023,1,1,0,3,3.0
-P. Bamford,Leeds,Premier League,2022,1,1,0,3,3.0
-P. Almqvist,Parma,Serie A,2024,1,1,0,3,3.0
-P. Almqvist,Lecce,Serie A,2023,1,1,0,3,3.0
-Oriol Romeu,Southampton,Premier League,2021,1,1,0,3,3.0
-Brian Oliván,Espanyol,La Liga,2022,1,1,0,3,3.0
-Bremer,Juventus,Serie A,2023,1,1,0,3,3.0
-Bremer,Juventus,Serie A,2022,1,1,0,3,3.0
-Brais Méndez,Real Sociedad,La Liga,2024,1,1,0,3,3.0
-Brais Méndez,Real Sociedad,La Liga,2023,1,1,0,3,3.0
-Brahim Díaz,Real Madrid,La Liga,2024,1,1,0,3,3.0
-Brahim Díaz,AC Milan,Serie A,2021,1,1,0,3,3.0
-Borja Iglesias,Celta Vigo,La Liga,2024,1,1,0,3,3.0
-Oriol Romeu,Girona,La Liga,2022,1,1,0,3,3.0
-Omar Marmoush,VfL Wolfsburg,Bundesliga,2022,1,1,0,3,3.0
-Beto,Everton,Premier League,2024,1,1,0,3,3.0
-Beraldo,Paris Saint Germain,Ligue 1,2024,1,1,0,3,3.0
-Bellerín,Sevilla,La Liga,2021,1,1,0,3,3.0
-Barrenetxea,Real Sociedad,La Liga,2024,1,1,0,3,3.0
-B. Yılmaz,Lille,Ligue 1,2021,1,1,0,3,3.0
-B. White,Arsenal,Premier League,2023,1,1,0,3,3.0
-B. Traoré,Aston Villa,Premier League,2022,1,1,0,3,3.0
-B. Touré,Auxerre,Ligue 1,2021,1,1,0,3,3.0
-B. Schmitz,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-P. Diong,Strasbourg,Ligue 1,2024,1,1,0,3,3.0
-P. Diallo,Metz,Ligue 1,2023,1,1,0,3,3.0
-P. Dawidowicz,Napoli,Serie A,2023,1,1,0,3,3.0
-P. Daka,Leicester,Premier League,2024,1,1,0,3,3.0
-P. Daka,Leicester,Premier League,2021,1,1,0,3,3.0
-P. Ciss,Rayo Vallecano,La Liga,2024,1,1,0,3,3.0
-P. Ciss,Rayo Vallecano,La Liga,2021,1,1,0,3,3.0
-P. Højbjerg,Tottenham,Premier League,2022,1,1,0,3,3.0
-P. Højbjerg,Marseille,Ligue 1,2024,1,1,0,3,3.0
-P. Hofmann,VfL BOCHUM,Bundesliga,2022,1,1,0,3,3.0
-P. Hincapié,Bayer Leverkusen,Bundesliga,2023,1,1,0,3,3.0
-P. Herrmann,Borussia Monchengladbach,Bundesliga,2022,1,1,0,3,3.0
-P. Gómez,Sevilla,La Liga,2022,1,1,0,3,3.0
-P. Gueye,Sevilla,La Liga,2022,1,1,0,3,3.0
-P. Gueye,Marseille,Ligue 1,2023,1,1,0,3,3.0
-P. Groß,Brighton,Premier League,2023,1,1,0,3,3.0
-P. Groß,Brighton,Premier League,2021,1,1,0,3,3.0
-P. Förster,VfL BOCHUM,Bundesliga,2022,1,1,0,3,3.0
-P. Frankowski,Lens,Ligue 1,2024,1,1,0,3,3.0
-P. Frankowski,Lens,Ligue 1,2021,1,1,0,3,3.0
-P. Foden,Manchester City,Premier League,2022,1,1,0,3,3.0
-P. Estupiñán,Brighton,Premier League,2022,1,1,0,3,3.0
-P. Dorgu,Lecce,Serie A,2023,1,1,0,3,3.0
-P. Schick,Bayer Leverkusen,Bundesliga,2022,1,1,0,3,3.0
-P. Sarr,Tottenham,Premier League,2024,1,1,0,3,3.0
-P. Rosario,Nice,Ligue 1,2024,1,1,0,3,3.0
-P. Pellegri,Torino,Serie A,2023,1,1,0,3,3.0
-P. Pellegri,Torino,Serie A,2022,1,1,0,3,3.0
-P. Mainka,1. FC Heidenheim,Bundesliga,2024,1,1,0,3,3.0
-P. Lienhart,SC Freiburg,Bundesliga,2022,1,1,0,3,3.0
-P. Lienhart,SC Freiburg,Bundesliga,2021,1,1,0,3,3.0
-P. Lees-Melou,Stade Brestois 29,Ligue 1,2024,1,1,0,3,3.0
-P. Lees-Melou,Stade Brestois 29,Ligue 1,2023,1,1,0,3,3.0
-P. Lees-Melou,Stade Brestois 29,Ligue 1,2022,1,1,0,3,3.0
-P. Kadeřábek,1899 Hoffenheim,Bundesliga,2024,1,1,0,3,3.0
-P. Kadeřábek,1899 Hoffenheim,Bundesliga,2023,1,1,0,3,3.0
-P. Kadeřábek,1899 Hoffenheim,Bundesliga,2022,1,1,0,3,3.0
-P. Kadeřábek,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-P. Jaeckel,Union Berlin,Bundesliga,2022,1,1,0,3,3.0
-Pablo Sarabia,Wolves,Premier League,2024,1,1,0,3,3.0
-Pablo Sarabia,Wolves,Premier League,2023,1,1,0,3,3.0
-Pablo Sarabia,Paris Saint Germain,Ligue 1,2021,1,1,0,3,3.0
-Pablo Marí,Udinese,Serie A,2021,1,1,0,3,3.0
-Pablo Maffeo,Mallorca,La Liga,2023,1,1,0,3,3.0
-Pablo Maffeo,Mallorca,La Liga,2021,1,1,0,3,3.0
-Pablo Ibáñez,Osasuna,La Liga,2024,1,1,0,3,3.0
-Pablo Fornals,West Ham,Premier League,2022,1,1,0,3,3.0
-Pablo Barrios,Atletico Madrid,La Liga,2024,1,1,0,3,3.0
-P. Zieliński,Napoli,Serie A,2022,1,1,0,3,3.0
-P. Wimmer,VfL Wolfsburg,Bundesliga,2022,1,1,0,3,3.0
-P. Wimmer,Arminia Bielefeld,Bundesliga,2021,1,1,0,3,3.0
-P. Treu,SC Freiburg,Bundesliga,2024,1,1,0,3,3.0
-P. Tietz,FC Augsburg,Bundesliga,2023,1,1,0,3,3.0
-P. Struijk,Leeds,Premier League,2021,1,1,0,3,3.0
-P. Schick,Bayer Leverkusen,Bundesliga,2023,1,1,0,3,3.0
-Pedro,Lazio,Serie A,2021,1,1,0,3,3.0
-Pedri,Barcelona,La Liga,2023,1,1,0,3,3.0
-Pedraza,Villarreal,La Liga,2021,1,1,0,3,3.0
-Paulinho,Bayer Leverkusen,Bundesliga,2022,1,1,0,3,3.0
-Pau Víctor,Barcelona,La Liga,2024,1,1,0,3,3.0
-Pau Cabanes,Villarreal,La Liga,2024,1,1,0,3,3.0
-B. Saka,Arsenal,Premier League,2024,1,1,0,3,3.0
-B. Omeragić,Lens,Ligue 1,2024,1,1,0,3,3.0
-B. Nuytinck,Udinese,Serie A,2021,1,1,0,3,3.0
-B. Mbeumo,Brentford,Premier League,2021,1,1,0,3,3.0
-B. Lasme,Arminia Bielefeld,Bundesliga,2021,1,1,0,3,3.0
-B. Johnson,Tottenham,Premier League,2024,1,1,0,3,3.0
-B. Johnson,Tottenham,Premier League,2023,1,1,0,3,3.0
-B. Henrichs,RB Leipzig,Bundesliga,2021,1,1,0,3,3.0
-B. Guirassy,Nantes,Ligue 1,2024,1,1,0,3,3.0
-Patric,Lazio,Serie A,2023,1,1,0,3,3.0
-Portu,Girona,La Liga,2024,1,1,0,3,3.0
-Portillo,Almeria,La Liga,2022,1,1,0,3,3.0
-Pol Lirola,Paris Saint Germain,Ligue 1,2024,1,1,0,3,3.0
-Pol Lirola,Frosinone,Serie A,2023,1,1,0,3,3.0
-B. Gruda,Brighton,Premier League,2024,1,1,0,3,3.0
-B. Embolo,Monaco,Ligue 1,2024,1,1,0,3,3.0
-B. Dieng,Lorient,Ligue 1,2022,1,1,0,3,3.0
-B. Diakité,Lille,Ligue 1,2024,1,1,0,3,3.0
-B. Dia,Lazio,Serie A,2024,1,1,0,3,3.0
-B. De Cordova-Reid,Leicester,Premier League,2024,1,1,0,3,3.0
-B. De Cordova-Reid,Fulham,Premier League,2022,1,1,0,3,3.0
-Philippe Coutinho,Aston Villa,Premier League,2021,1,1,0,3,3.0
-Pepelu,Valencia,La Liga,2023,1,1,0,3,3.0
-Pedro Pereira,Monza,Serie A,2024,1,1,0,3,3.0
-Pedro Neto,Wolves,Premier League,2023,1,1,0,3,3.0
-Pedro Neto,Chelsea,Premier League,2024,1,1,0,3,3.0
-B. Davies,Tottenham,Premier League,2023,1,1,0,3,3.0
-B. Cristante,AS Roma,Serie A,2021,1,1,0,3,3.0
-B. Chilwell,Chelsea,Premier League,2022,1,1,0,3,3.0
-B. Chilwell,Chelsea,Premier League,2021,1,1,0,3,3.0
-B. Bourigeaud,Rennes,Ligue 1,2021,1,1,0,3,3.0
-B. Badiashile,Chelsea,Premier League,2022,1,1,0,3,3.0
-B. André,Lille,Ligue 1,2023,1,1,0,3,3.0
-B. Aaronson,Union Berlin,Bundesliga,2023,1,1,0,3,3.0
-R. Baku,VfL Wolfsburg,Bundesliga,2021,1,1,0,3,3.0
-R. Aït Nouri,Wolves,Premier League,2022,1,1,0,3,3.0
-R. Araújo,Barcelona,La Liga,2021,1,1,0,3,3.0
-R. Andrich,Bayer Leverkusen,Bundesliga,2021,1,1,0,3,3.0
-Q. Merlin,Nantes,Ligue 1,2021,1,1,0,3,3.0
-Q. Boisgard,Lorient,Ligue 1,2022,1,1,0,3,3.0
-Q. Boisgard,Lorient,Ligue 1,2021,1,1,0,3,3.0
-Portu,Real Sociedad,La Liga,2021,1,1,0,3,3.0
-R. Faivre,Lyon,Ligue 1,2021,1,1,0,3,3.0
-R. Faivre,Lorient,Ligue 1,2023,1,1,0,3,3.0
-R. Esse,Crystal Palace,Premier League,2024,1,1,0,3,3.0
-R. Dugimont,Auxerre,Ligue 1,2021,1,1,0,3,3.0
-R. Doan,SC Freiburg,Bundesliga,2023,1,1,0,3,3.0
-R. Del Castillo,Stade Brestois 29,Ligue 1,2024,1,1,0,3,3.0
-R. Del Castillo,Stade Brestois 29,Ligue 1,2022,1,1,0,3,3.0
-R. Czichos,SC Freiburg,Bundesliga,2021,1,1,0,3,3.0
-R. Cherki,Lyon,Ligue 1,2023,1,1,0,3,3.0
-R. Cherki,Lyon,Ligue 1,2022,1,1,0,3,3.0
-R. Cabella,Lille,Ligue 1,2023,1,1,0,3,3.0
-R. Borré,Eintracht Frankfurt,Bundesliga,2021,1,1,0,3,3.0
-R. Bensebaïni,Borussia Monchengladbach,Bundesliga,2022,1,1,0,3,3.0
-R. Bensebaïni,Borussia Monchengladbach,Bundesliga,2021,1,1,0,3,3.0
-R. Barkley,Chelsea,Premier League,2021,1,1,0,3,3.0
-R. Baku,VfL Wolfsburg,Bundesliga,2024,1,1,0,3,3.0
-R. James,Chelsea,Premier League,2021,1,1,0,3,3.0
-R. Højlund,Manchester United,Premier League,2024,1,1,0,3,3.0
-R. Holding,Arsenal,Premier League,2022,1,1,0,3,3.0
-Ayoze Pérez,Real Betis,La Liga,2023,1,1,0,3,3.0
-Aurélio Buta,Eintracht Frankfurt,Bundesliga,2023,1,1,0,3,3.0
-Aurélien Tchouaméni,Real Madrid,La Liga,2023,1,1,0,3,3.0
-Assane Diao,Real Betis,La Liga,2024,1,1,0,3,3.0
-Asier Villalibre,Athletic Club,La Liga,2023,1,1,0,3,3.0
-Asensio,Real Madrid,La Liga,2022,1,1,0,3,3.0
-Asensio,Real Madrid,La Liga,2021,1,1,0,3,3.0
-Arthur Cabral,Fiorentina,Serie A,2021,1,1,0,3,3.0
-Arthur,Fiorentina,Serie A,2023,1,1,0,3,3.0
-Artem Dovbyk,Girona,La Liga,2023,1,1,0,3,3.0
-R. Gosens,Fiorentina,Serie A,2024,1,1,0,3,3.0
-R. Gagliardini,Inter,Serie A,2021,1,1,0,3,3.0
-R. Faivre,Stade Brestois 29,Ligue 1,2024,1,1,0,3,3.0
-Antony,Real Betis,La Liga,2024,1,1,0,3,3.0
-Antony,Manchester United,Premier League,2023,1,1,0,3,3.0
-Antonio Sivera,Rayo Vallecano,La Liga,2024,1,1,0,3,3.0
-Antonio Rüdiger,Real Madrid,La Liga,2023,1,1,0,3,3.0
-Antonio Raíllo,Mallorca,La Liga,2023,1,1,0,3,3.0
-Angeliño,RB Leipzig,Bundesliga,2021,1,1,0,3,3.0
-Angeliño,AS Roma,Serie A,2024,1,1,0,3,3.0
-André Silva,Real Sociedad,La Liga,2023,1,1,0,3,3.0
-André Gomes,Lille,Ligue 1,2022,1,1,0,3,3.0
-André Gomes,Everton,Premier League,2023,1,1,0,3,3.0
-R. Kolo Muani,Juventus,Serie A,2024,1,1,0,3,3.0
-R. Koch,Eintracht Frankfurt,Bundesliga,2023,1,1,0,3,3.0
-R. Khedira,Union Berlin,Bundesliga,2022,1,1,0,3,3.0
-R. Jiménez,Fulham,Premier League,2024,1,1,0,3,3.0
-R. James,Chelsea,Premier League,2024,1,1,0,3,3.0
-R. James,Chelsea,Premier League,2022,1,1,0,3,3.0
-Aleix García,Girona,La Liga,2023,1,1,0,3,3.0
-R. Oudin,Lecce,Serie A,2022,1,1,0,3,3.0
-R. Nicolaisen,Toulouse,Ligue 1,2023,1,1,0,3,3.0
-R. Nelson,Fulham,Premier League,2024,1,1,0,3,3.0
-R. Nelson,Arsenal,Premier League,2022,1,1,0,3,3.0
-R. Massimo,VfB Stuttgart,Bundesliga,2021,1,1,0,3,3.0
-R. Marin,Empoli,Serie A,2022,1,1,0,3,3.0
-R. Marin,Cagliari,Serie A,2024,1,1,0,3,3.0
-R. Mandragora,Fiorentina,Serie A,2024,1,1,0,3,3.0
-R. Mandragora,Fiorentina,Serie A,2022,1,1,0,3,3.0
-R. Manaj,Spezia,Serie A,2021,1,1,0,3,3.0
-R. Mahrez,Manchester City,Premier League,2022,1,1,0,3,3.0
-R. Loftus-Cheek,AC Milan,Serie A,2023,1,1,0,3,3.0
-R. Le Normand,Celta Vigo,La Liga,2022,1,1,0,3,3.0
-R. Labeau Lascary,Lens,Ligue 1,2024,1,1,0,3,3.0
-R. Kristensen,AS Roma,Serie A,2023,1,1,0,3,3.0
-R. Piccoli,Atalanta,Serie A,2021,1,1,0,3,3.0
-R. Perraud,Southampton,Premier League,2022,1,1,0,3,3.0
-R. Perraud,Real Betis,La Liga,2024,1,1,0,3,3.0
-R. Oudin,Lecce,Serie A,2023,1,1,0,3,3.0
-André Almeida,Valencia,La Liga,2023,1,1,0,3,3.0
-André Almeida,Valencia,La Liga,2022,1,1,0,3,3.0
-Andrey Santos,Strasbourg,Ligue 1,2024,1,1,0,3,3.0
-Andrey Santos,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-Ander Guevara,Alaves,La Liga,2023,1,1,0,3,3.0
-Amir Rrahmani,Napoli,Serie A,2023,1,1,0,3,3.0
-Alfon González,Celta Vigo,La Liga,2024,1,1,0,3,3.0
-Alexsandro Ribeiro,Auxerre,Ligue 1,2024,1,1,0,3,3.0
-Alex Suárez,Las Palmas,La Liga,2023,1,1,0,3,3.0
-Aleksandar Sedlar,Alaves,La Liga,2023,1,1,0,3,3.0
-Alejo,Cadiz,La Liga,2021,1,1,0,3,3.0
-Alejandro Catena,Osasuna,La Liga,2023,1,1,0,3,3.0
-Rafael Leão,AC Milan,Serie A,2023,1,1,0,3,3.0
-Rafa Mir,Sevilla,La Liga,2023,1,1,0,3,3.0
-Rafa Mir,Sevilla,La Liga,2022,1,1,0,3,3.0
-Radamel Falcao,Rayo Vallecano,La Liga,2023,1,1,0,3,3.0
-R. Yates,Nottingham Forest,Premier League,2024,1,1,0,3,3.0
-R. Vargas,FC Augsburg,Bundesliga,2023,1,1,0,3,3.0
-R. Vargas,FC Augsburg,Bundesliga,2022,1,1,0,3,3.0
-R. Varane,Manchester United,Premier League,2023,1,1,0,3,3.0
-R. Sterling,Chelsea,Premier League,2023,1,1,0,3,3.0
-R. Sottil,Fiorentina,Serie A,2024,1,1,0,3,3.0
-R. Schmid,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-R. Saïss,Wolves,Premier League,2021,1,1,0,3,3.0
-R. Saponara,Fiorentina,Serie A,2022,1,1,0,3,3.0
-R. Ripart,Estac Troyes,Ligue 1,2022,1,1,0,3,3.0
-R. Ripart,Estac Troyes,Ligue 1,2021,1,1,0,3,3.0
-R. Reitz,Borussia Monchengladbach,Bundesliga,2023,1,1,0,3,3.0
-Raphaël Guerreiro,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-Alberto Moreno,Villarreal,La Liga,2021,1,1,0,3,3.0
-Alberto Marí,Valencia,La Liga,2022,1,1,0,3,3.0
-Aitor Paredes,Athletic Club,La Liga,2024,1,1,0,3,3.0
-Aitor Paredes,Athletic Club,La Liga,2023,1,1,0,3,3.0
-Aimar Oroz,Osasuna,La Liga,2024,1,1,0,3,3.0
-Adrián Embarba,Almeria,La Liga,2023,1,1,0,3,3.0
-Adrià Pedrosa,Sevilla,La Liga,2024,1,1,0,3,3.0
-Adria Miquel Bosch Sanchis,Real Sociedad,La Liga,2023,1,1,0,3,3.0
-Adri Embarba,Almeria,La Liga,2022,1,1,0,3,3.0
-Adama Traoré,Wolves,Premier League,2022,1,1,0,3,3.0
-Adama Traoré,Wolves,Premier League,2021,1,1,0,3,3.0
-Adama Traoré,Fulham,Premier League,2023,1,1,0,3,3.0
-Abel Bretones,Osasuna,La Liga,2024,1,1,0,3,3.0
-Abdón Prats,Mallorca,La Liga,2024,1,1,0,3,3.0
-Ramón Martínez,Sevilla,La Liga,2024,1,1,0,3,3.0
-Rodrigo Gomes,Wolves,Premier League,2024,1,1,0,3,3.0
-Rodrigo Becão,Udinese,Serie A,2021,1,1,0,3,3.0
-Rodrigo,Leeds,Premier League,2021,1,1,0,3,3.0
-Robin Le Normand,Real Sociedad,La Liga,2023,1,1,0,3,3.0
-Roberto Torres,Osasuna,La Liga,2021,1,1,0,3,3.0
-Roberto Firmino,Liverpool,Premier League,2021,1,1,0,3,3.0
-Rober,Levante,La Liga,2021,1,1,0,3,3.0
-Richarlison,Tottenham,Premier League,2022,1,1,0,3,3.0
-Reinildo Mandava,Atletico Madrid,La Liga,2023,1,1,0,3,3.0
-Raúl de Tomás,Rayo Vallecano,La Liga,2022,1,1,0,3,3.0
-Raúl Moro,Valladolid,La Liga,2024,1,1,0,3,3.0
-Raúl García,Athletic Club,La Liga,2022,1,1,0,3,3.0
-Raíllo,Mallorca,La Liga,2022,1,1,0,3,3.0
-Raíllo,Mallorca,La Liga,2021,1,1,0,3,3.0
-Raphinha,Leeds,Premier League,2021,1,1,0,3,3.0
-Raphinha,Barcelona,La Liga,2023,1,1,0,3,3.0
-Rodrigo de Paul,Atletico Madrid,La Liga,2023,1,1,0,3,3.0
-Rodrigo Riquelme,Atletico Madrid,La Liga,2023,1,1,0,3,3.0
-Rodrigo Muniz,Fulham,Premier League,2023,1,1,0,3,3.0
-Abdón Prats,Mallorca,La Liga,2022,1,1,0,3,3.0
-Abdu Conté,Estac Troyes,Ligue 1,2022,1,1,0,3,3.0
-Abdessamad Ezzalzouli,Real Betis,La Liga,2023,1,1,0,3,3.0
-Aarón Martín,FSV Mainz 05,Bundesliga,2022,1,1,0,3,3.0
-A. Álvarez,Sassuolo,Serie A,2022,1,1,0,3,3.0
-A. Zanoli,Sampdoria,Serie A,2022,1,1,0,3,3.0
-A. Zanoli,Genoa,Serie A,2024,1,1,0,3,3.0
-A. Young,Brighton,Premier League,2023,1,1,0,3,3.0
-A. Witsel,Borussia Dortmund,Bundesliga,2021,1,1,0,3,3.0
-A. Webster,Brighton,Premier League,2021,1,1,0,3,3.0
-A. Véliz,Tottenham,Premier League,2023,1,1,0,3,3.0
-A. Véliz,Espanyol,La Liga,2024,1,1,0,3,3.0
-A. Voglsammer,Union Berlin,Bundesliga,2021,1,1,0,3,3.0
-S. Amrabat,Fiorentina,Serie A,2021,1,1,0,3,3.0
-S. Amo-Ameyaw,Strasbourg,Ligue 1,2024,1,1,0,3,3.0
-S. Amallah,Valladolid,La Liga,2024,1,1,0,3,3.0
-S. Alvero,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-S. Alvero,Lyon,Ligue 1,2023,1,1,0,3,3.0
-S. Agüero,Barcelona,La Liga,2021,1,1,0,3,3.0
-S. Adingra,Brighton,Premier League,2024,1,1,0,3,3.0
-S. Adamyan,FC Koln,Bundesliga,2022,1,1,0,3,3.0
-S. Adamyan,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-Rúben Neves,Wolves,Premier League,2022,1,1,0,3,3.0
-Rubén García,Osasuna,La Liga,2023,1,1,0,3,3.0
-Rubén García,Osasuna,La Liga,2022,1,1,0,3,3.0
-Rubén Duarte,Alaves,La Liga,2023,1,1,0,3,3.0
-Rubén Alcaraz,Cadiz,La Liga,2022,1,1,0,3,3.0
-Ronald Araújo,Barcelona,La Liga,2023,1,1,0,3,3.0
-Rodrygo,Real Madrid,La Liga,2023,1,1,0,3,3.0
-S. Castro,Verona,Serie A,2024,1,1,0,3,3.0
-S. Boufal,Angers,Ligue 1,2022,1,1,0,3,3.0
-S. Botman,Newcastle,Premier League,2023,1,1,0,3,3.0
-S. Bornauw,FC Augsburg,Bundesliga,2023,1,1,0,3,3.0
-S. Benrahma,West Ham,Premier League,2022,1,1,0,3,3.0
-S. Benrahma,Lyon,Ligue 1,2024,1,1,0,3,3.0
-S. Bell,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-S. Becker,Union Berlin,Bundesliga,2022,1,1,0,3,3.0
-S. Becker,Union Berlin,Bundesliga,2021,1,1,0,3,3.0
-S. Bastoni,Empoli,Serie A,2023,1,1,0,3,3.0
-S. Baptiste,Brentford,Premier League,2023,1,1,0,3,3.0
-S. Banza,Lens,Ligue 1,2021,1,1,0,3,3.0
-S. Babicka,Toulouse,Ligue 1,2024,1,1,0,3,3.0
-S. Azmoun,AS Roma,Serie A,2023,1,1,0,3,3.0
-S. Arias,Granada CF,La Liga,2021,1,1,0,3,3.0
-S. Andersson,FC Koln,Bundesliga,2021,1,1,0,3,3.0
-S. Delaye,Montpellier,Ligue 1,2022,1,1,0,3,3.0
-S. Dallas,Leeds,Premier League,2021,1,1,0,3,3.0
-S. Conteh,1. FC Heidenheim,Bundesliga,2024,1,1,0,3,3.0
-S. Coleman,Bournemouth,Premier League,2023,1,1,0,3,3.0
-A. Vogliacco,Genoa,Serie A,2024,1,1,0,3,3.0
-A. Tuhami,Valladolid,La Liga,2024,1,1,0,3,3.0
-A. Tuhami,Valladolid,La Liga,2022,1,1,0,3,3.0
-A. Touré,Metz,Ligue 1,2024,1,1,0,3,3.0
-A. Tosin,Lorient,Ligue 1,2023,1,1,0,3,3.0
-A. Thomasson,Lens,Ligue 1,2024,1,1,0,3,3.0
-A. Thomasson,Lens,Ligue 1,2022,1,1,0,3,3.0
-A. Theate,Bologna,Serie A,2021,1,1,0,3,3.0
-A. Terzić,Fiorentina,Serie A,2022,1,1,0,3,3.0
-A. Sørloth,Real Sociedad,La Liga,2022,1,1,0,3,3.0
-S. Chukwueze,Villarreal,La Liga,2022,1,1,0,3,3.0
-S. Chukwueze,AC Milan,Serie A,2023,1,1,0,3,3.0
-S. Idumbo,Sevilla,La Liga,2024,1,1,0,3,3.0
-S. Haller,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-S. Guirassy,VfB Stuttgart,Bundesliga,2022,1,1,0,3,3.0
-S. Grandsir,LE Havre,Ligue 1,2023,1,1,0,3,3.0
-S. Gnabry,Bayern Munich,Bundesliga,2021,1,1,0,3,3.0
-S. Ghoddos,Brentford,Premier League,2023,1,1,0,3,3.0
-S. Ghoddos,Brentford,Premier League,2021,1,1,0,3,3.0
-S. Fukuda,Borussia Mönchengladbach,Bundesliga,2024,1,1,0,3,3.0
-S. Fofana,Lens,Ligue 1,2022,1,1,0,3,3.0
-S. Esposito,Spezia,Serie A,2022,1,1,0,3,3.0
-S. Esposito,Empoli,Serie A,2024,1,1,0,3,3.0
-S. El Shaarawy,AS Roma,Serie A,2024,1,1,0,3,3.0
-S. Doucouré,Lorient,Ligue 1,2023,1,1,0,3,3.0
-S. Diop,Nice,Ligue 1,2024,1,1,0,3,3.0
-S. Diop,Monaco,Ligue 1,2021,1,1,0,3,3.0
-S. Diarra,Lorient,Ligue 1,2022,1,1,0,3,3.0
-S. Kalu,Bordeaux,Ligue 1,2021,1,1,0,3,3.0
-S. Jovetić,Hertha Berlin,Bundesliga,2022,1,1,0,3,3.0
-A. Sánchez,Inter,Serie A,2023,1,1,0,3,3.0
-A. Sylla,Strasbourg,Ligue 1,2023,1,1,0,3,3.0
-A. Stiller,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-A. Stiller,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-A. Stach,1899 Hoffenheim,Bundesliga,2023,1,1,0,3,3.0
-A. Souquet,Montpellier,Ligue 1,2021,1,1,0,3,3.0
-A. Sima,Lorient,Ligue 1,2022,1,1,0,3,3.0
-A. Sima,Angers,Ligue 1,2022,1,1,0,3,3.0
-A. Seydel,SV Darmstadt 98,Bundesliga,2023,1,1,0,3,3.0
-A. Semenyo,Bournemouth,Premier League,2022,1,1,0,3,3.0
-A. Scott,Bournemouth,Premier League,2023,1,1,0,3,3.0
-A. Schäfer,Union Berlin,Bundesliga,2021,1,1,0,3,3.0
-S. Jovetić,Hertha Berlin,Bundesliga,2021,1,1,0,3,3.0
-S. Iling-Junior,Bologna,Serie A,2024,1,1,0,3,3.0
-A. Robertson,Liverpool,Premier League,2023,1,1,0,3,3.0
-S. Mounié,Stade Brestois 29,Ligue 1,2023,1,1,0,3,3.0
-S. Mounié,Stade Brestois 29,Ligue 1,2022,1,1,0,3,3.0
-S. Mounié,FC Augsburg,Bundesliga,2024,1,1,0,3,3.0
-S. Michel,FC Augsburg,Bundesliga,2023,1,1,0,3,3.0
-S. McKenna,Rayo Vallecano,La Liga,2024,1,1,0,3,3.0
-S. Mbangula,Juventus,Serie A,2024,1,1,0,3,3.0
-S. Mara,Bordeaux,Ligue 1,2021,1,1,0,3,3.0
-S. Mandanda,Nice,Ligue 1,2023,1,1,0,3,3.0
-S. Lukić,Torino,Serie A,2022,1,1,0,3,3.0
-S. Lukić,Torino,Serie A,2021,1,1,0,3,3.0
-S. Lovrić,Udinese,Serie A,2022,1,1,0,3,3.0
-S. Long,Southampton,Premier League,2021,1,1,0,3,3.0
-S. Lobotka,Napoli,Serie A,2021,1,1,0,3,3.0
-S. Lammers,Empoli,Serie A,2022,1,1,0,3,3.0
-S. Kolašinac,Marseille,Ligue 1,2022,1,1,0,3,3.0
-S. Posch,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-S. Polter,VfL BOCHUM,Bundesliga,2021,1,1,0,3,3.0
-S. Nwankwo,Salernitana,Serie A,2023,1,1,0,3,3.0
-S. Nsoki,1899 Hoffenheim,Bundesliga,2022,1,1,0,3,3.0
-A. Schiavone,Salernitana,Serie A,2021,1,1,0,3,3.0
-A. Sarr,Lyon,Ligue 1,2022,1,1,0,3,3.0
-A. Sangante,Le Havre,Ligue 1,2024,1,1,0,3,3.0
-A. Sanabria,Torino,Serie A,2022,1,1,0,3,3.0
-A. Saint-Maximin,Newcastle,Premier League,2022,1,1,0,3,3.0
-A. Saint-Maximin,Newcastle,Premier League,2021,1,1,0,3,3.0
-A. Saelemaekers,AC Milan,Serie A,2022,1,1,0,3,3.0
-A. Rüdiger,Real Madrid,La Liga,2022,1,1,0,3,3.0
-A. Rüdiger,Chelsea,Premier League,2021,1,1,0,3,3.0
-A. Rrahmani,Napoli,Serie A,2022,1,1,0,3,3.0
-A. Rrahmani,Napoli,Serie A,2021,1,1,0,3,3.0
-A. Robertson,West Ham,Premier League,2024,1,1,0,3,3.0
-S. Zoller,VfL BOCHUM,Bundesliga,2021,1,1,0,3,3.0
-S. Widmer,FSV Mainz 05,Bundesliga,2021,1,1,0,3,3.0
-S. Weissman,Valladolid,La Liga,2022,1,1,0,3,3.0
-S. Verdi,Torino,Serie A,2021,1,1,0,3,3.0
-S. Verdi,Salernitana,Serie A,2021,1,1,0,3,3.0
-S. Tonali,AC Milan,Serie A,2022,1,1,0,3,3.0
-S. Tonali,AC Milan,Serie A,2021,1,1,0,3,3.0
-S. Tigges,FC Koln,Bundesliga,2022,1,1,0,3,3.0
-S. Thioub,Angers,Ligue 1,2022,1,1,0,3,3.0
-S. Surridge,Nottingham Forest,Premier League,2022,1,1,0,3,3.0
-S. Serdar,Hertha Berlin,Bundesliga,2022,1,1,0,3,3.0
-S. Sensi,Monza,Serie A,2024,1,1,0,3,3.0
-S. Sensi,Monza,Serie A,2022,1,1,0,3,3.0
-S. Ricci,Torino,Serie A,2022,1,1,0,3,3.0
-S. Ricci,Empoli,Serie A,2021,1,1,0,3,3.0
-S. Posch,Bologna,Serie A,2022,1,1,0,3,3.0
-Sergi Canós,Brentford,Premier League,2021,1,1,0,3,3.0
-Saúl Ñíguez,Atletico Madrid,La Liga,2023,1,1,0,3,3.0
-Saúl Coco,Cagliari,Serie A,2024,1,1,0,3,3.0
-Santi Comesaña,Villarreal,La Liga,2024,1,1,0,3,3.0
-Sandro Ramírez,Las Palmas,La Liga,2024,1,1,0,3,3.0
-Samuel Sáiz,Girona,La Liga,2022,1,1,0,3,3.0
-Samuel Omorodion,Alaves,La Liga,2023,1,1,0,3,3.0
-Samuel Lino,Valencia,La Liga,2022,1,1,0,3,3.0
-Samuel Lino,Atletico Madrid,La Liga,2024,1,1,0,3,3.0
-Samuel Lino,Atletico Madrid,La Liga,2023,1,1,0,3,3.0
-Samuel Costa,Mallorca,La Liga,2023,1,1,0,3,3.0
-Sam Morsy,Ipswich,Premier League,2024,1,1,0,3,3.0
-Salva Sevilla,Mallorca,La Liga,2021,1,1,0,3,3.0
-S. Żurkowski,Empoli,Serie A,2021,1,1,0,3,3.0
-S. van den Berg,FC Schalke 04,Bundesliga,2022,1,1,0,3,3.0
-S. de Vrij,Inter,Serie A,2024,1,1,0,3,3.0
-Sergio Camello,Rayo Vallecano,La Liga,2023,1,1,0,3,3.0
-Sergi Roberto,Barcelona,La Liga,2022,1,1,0,3,3.0
-Sergi Roberto,Barcelona,La Liga,2021,1,1,0,3,3.0
-A. Robertson,Liverpool,Premier League,2021,1,1,0,3,3.0
-A. Rebić,Lecce,Serie A,2024,1,1,0,3,3.0
-A. Rebić,AC Milan,Serie A,2022,1,1,0,3,3.0
-A. Ramsey,Nice,Ligue 1,2022,1,1,0,3,3.0
-A. Rami,Estac Troyes,Ligue 1,2021,1,1,0,3,3.0
-A. Rabiot,Juventus,Serie A,2023,1,1,0,3,3.0
-A. Pléa,Borussia Mönchengladbach,Bundesliga,2024,1,1,0,3,3.0
-A. Pléa,Borussia Monchengladbach,Bundesliga,2023,1,1,0,3,3.0
-A. Pinamonti,Sassuolo,Serie A,2023,1,1,0,3,3.0
-A. Pinamonti,Sassuolo,Serie A,2022,1,1,0,3,3.0
-A. Pieper,Werder Bremen,Bundesliga,2022,1,1,0,3,3.0
-Sergi Guardiola,Cadiz,La Liga,2023,1,1,0,3,3.0
-Sergi Darder,Mallorca,La Liga,2023,1,1,0,3,3.0
-A. Petagna,Monza,Serie A,2022,1,1,0,3,3.0
-A. Palaversa,Estac Troyes,Ligue 1,2022,1,1,0,3,3.0
-A. Ounas,Lille,Ligue 1,2023,1,1,0,3,3.0
-A. Ounahi,Marseille,Ligue 1,2022,1,1,0,3,3.0
-A. Oukidja,Lille,Ligue 1,2021,1,1,0,3,3.0
-A. Ouattara,Strasbourg,Ligue 1,2024,1,1,0,3,3.0
-A. Onana,Everton,Premier League,2023,1,1,0,3,3.0
-A. Onana,Atalanta,Serie A,2022,1,1,0,3,3.0
-A. Onaiwu,Auxerre,Ligue 1,2024,1,1,0,3,3.0
-A. Obert,Cagliari,Serie A,2024,1,1,0,3,3.0
-A. Nordin,Montpellier,Ligue 1,2023,1,1,0,3,3.0
-Sobrino,Cadiz,La Liga,2022,1,1,0,3,3.0
-Sergio Ramos,Paris Saint Germain,Ligue 1,2022,1,1,0,3,3.0
-Sergio Ramos,Barcelona,La Liga,2023,1,1,0,3,3.0
-Sergio González,Leganes,La Liga,2024,1,1,0,3,3.0
-Sergio Camello,Rayo Vallecano,La Liga,2024,1,1,0,3,3.0
-T. Buchanan,Villarreal,La Liga,2024,1,1,0,3,3.0
-T. Buchanan,Inter,Serie A,2023,1,1,0,3,3.0
-T. Bongonda,Cadiz,La Liga,2022,1,1,0,3,3.0
-T. Bašić,Lazio,Serie A,2022,1,1,0,3,3.0
-T. Awoniyi,Union Berlin,Bundesliga,2021,1,1,0,3,3.0
-T. Awoniyi,Nottingham Forest,Premier League,2024,1,1,0,3,3.0
-T. Asano,Vfl Bochum,Bundesliga,2023,1,1,0,3,3.0
-T. Arslan,Udinese,Serie A,2022,1,1,0,3,3.0
-T. Arslan,Udinese,Serie A,2021,1,1,0,3,3.0
-T. Almada,Lyon,Ligue 1,2024,1,1,0,3,3.0
-T. Alexander-Arnold,Liverpool,Premier League,2024,1,1,0,3,3.0
-T. Alexander-Arnold,Liverpool,Premier League,2021,1,1,0,3,3.0
-T. Abraham,AS Roma,Serie A,2023,1,1,0,3,3.0
-Stefan Bajčetić,Liverpool,Premier League,2022,1,1,0,3,3.0
-Sory Kaba,Las Palmas,La Liga,2023,1,1,0,3,3.0
-A. Petagna,Napoli,Serie A,2021,1,1,0,3,3.0
-T. Dallinga,Toulouse,Ligue 1,2023,1,1,0,3,3.0
-T. Dallinga,Toulouse,Ligue 1,2022,1,1,0,3,3.0
-A. Nordin,Montpellier,Ligue 1,2022,1,1,0,3,3.0
-A. Nagida,Rennes,Ligue 1,2024,1,1,0,3,3.0
-A. Murić,Brighton,Premier League,2023,1,1,0,3,3.0
-A. Murillo,Marseille,Ligue 1,2023,1,1,0,3,3.0
-A. Modeste,Borussia Dortmund,Bundesliga,2022,1,1,0,3,3.0
-A. Miranchuk,Atalanta,Serie A,2023,1,1,0,3,3.0
-A. Miranchuk,Atalanta,Serie A,2021,1,1,0,3,3.0
-A. Milik,Juventus,Serie A,2023,1,1,0,3,3.0
-A. Matusiwa,Reims,Ligue 1,2023,1,1,0,3,3.0
-A. Matturro,Udinese,Serie A,2023,1,1,0,3,3.0
-A. Masuaku,West Ham,Premier League,2021,1,1,0,3,3.0
-T. Coulibaly,Montpellier,Ligue 1,2024,1,1,0,3,3.0
-T. Chong,Luton,Premier League,2023,1,1,0,3,3.0
-T. Cairney,Fulham,Premier League,2023,1,1,0,3,3.0
-T. Livramento,Newcastle,Premier League,2023,1,1,0,3,3.0
-T. Le Bris,Lorient,Ligue 1,2022,1,1,0,3,3.0
-T. Lamptey,Brighton,Premier League,2024,1,1,0,3,3.0
-T. Kubo,Real Sociedad,La Liga,2024,1,1,0,3,3.0
-T. Kubo,Mallorca,La Liga,2021,1,1,0,3,3.0
-T. Kroos,Real Madrid,La Liga,2022,1,1,0,3,3.0
-T. Krauß,FSV Mainz 05,Bundesliga,2023,1,1,0,3,3.0
-T. Koopmeiners,Juventus,Serie A,2024,1,1,0,3,3.0
-T. Koopmeiners,Atalanta,Serie A,2023,1,1,0,3,3.0
-T. Kolodziejczak,Saint Etienne,Ligue 1,2021,1,1,0,3,3.0
-T. Kehrer,Paris Saint Germain,Ligue 1,2021,1,1,0,3,3.0
-T. Hernández,AC Milan,Serie A,2023,1,1,0,3,3.0
-T. Hernández,AC Milan,Serie A,2022,1,1,0,3,3.0
-T. Hernández,AC Milan,Serie A,2021,1,1,0,3,3.0
-T. Henry,Verona,Serie A,2023,1,1,0,3,3.0
-T. George,Chelsea,Premier League,2024,1,1,0,3,3.0
-T. Moffi,Nice,Ligue 1,2024,1,1,0,3,3.0
-T. Moffi,Lorient,Ligue 1,2022,1,1,0,3,3.0
-T. Mitchell,Crystal Palace,Premier League,2023,1,1,0,3,3.0
-T. Mings,Fulham,Premier League,2022,1,1,0,3,3.0
-T. Mings,Aston Villa,Premier League,2021,1,1,0,3,3.0
-A. Marušić,Lazio,Serie A,2023,1,1,0,3,3.0
-A. Mandi,Atletico Madrid,La Liga,2021,1,1,0,3,3.0
-A. Makoumbou,Cagliari,Serie A,2023,1,1,0,3,3.0
-A. Maitland-Niles,Lyon,Ligue 1,2023,1,1,0,3,3.0
-A. Mac Allister,Liverpool,Premier League,2023,1,1,0,3,3.0
-A. Losilla,VfL BOCHUM,Bundesliga,2021,1,1,0,3,3.0
-T. Minamino,Monaco,Ligue 1,2023,1,1,0,3,3.0
-T. Minamino,Monaco,Ligue 1,2022,1,1,0,3,3.0
-T. Mangani,Angers,Ligue 1,2021,1,1,0,3,3.0
-T. Louchet,Nice,Ligue 1,2024,1,1,0,3,3.0
-T. Louchet,Nice,Ligue 1,2023,1,1,0,3,3.0
-T. Tessmann,Lyon,Ligue 1,2024,1,1,0,3,3.0
-T. Souček,West Ham,Premier League,2024,1,1,0,3,3.0
-T. Skarke,SV Darmstadt 98,Bundesliga,2023,1,1,0,3,3.0
-T. Sainte-Luce,Montpellier,Ligue 1,2024,1,1,0,3,3.0
-T. Rothe,Union Berlin,Bundesliga,2024,1,1,0,3,3.0
-T. Pobega,Torino,Serie A,2021,1,1,0,3,3.0
-T. Pobega,Bologna,Serie A,2024,1,1,0,3,3.0
-T. Pobega,AC Milan,Serie A,2022,1,1,0,3,3.0
-T. Pembélé,Le Havre,Ligue 1,2024,1,1,0,3,3.0
-T. Partey,Arsenal,Premier League,2024,1,1,0,3,3.0
-T. Oberdorf,Fortuna Dusseldorf,Bundesliga,2023,1,1,0,3,3.0
-T. Noslin,Lazio,Serie A,2024,1,1,0,3,3.0
-T. Müller,Bayern München,Bundesliga,2024,1,1,0,3,3.0
-T. Müller,Bayern Munich,Bundesliga,2023,1,1,0,3,3.0
-T. Müller,Bayern Munich,Bundesliga,2022,1,1,0,3,3.0
-T. Müller,Bayern Munich,Bundesliga,2021,1,1,0,3,3.0
-Tello,Real Betis,La Liga,2021,1,1,0,3,3.0
-Tadeo Allende,Celta Vigo,La Liga,2023,1,1,0,3,3.0
-T. Čvančara,Borussia Mönchengladbach,Bundesliga,2024,1,1,0,3,3.0
-T. Werner,RB Leipzig,Bundesliga,2022,1,1,0,3,3.0
-T. Werner,Chelsea,Premier League,2021,1,1,0,3,3.0
-T. Walcott,Southampton,Premier League,2022,1,1,0,3,3.0
-A. La Mantia,Empoli,Serie A,2021,1,1,0,3,3.0
-A. Kramarić,1899 Hoffenheim,Bundesliga,2024,1,1,0,3,3.0
-A. Kramarić,1899 Hoffenheim,Bundesliga,2021,1,1,0,3,3.0
-A. Kelati,Holstein Kiel,Bundesliga,2024,1,1,0,3,3.0
-A. Kalimuendo-Muinga,Lens,Ligue 1,2021,1,1,0,3,3.0
-A. Jung,Werder Bremen,Bundesliga,2023,1,1,0,3,3.0
-A. Januzaj,Real Sociedad,La Liga,2021,1,1,0,3,3.0
-T. Walcott,Newcastle,Premier League,2022,1,1,0,3,3.0
-T. Tomiyasu,Arsenal,Premier League,2023,1,1,0,3,3.0
-T. Teuma,Reims,Ligue 1,2024,1,1,0,3,3.0
-A. Hakimi,Paris Saint Germain,Ligue 1,2023,1,1,0,3,3.0
-V. Carboni,Monza,Serie A,2023,1,1,0,3,3.0
-V. Boniface,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
-Unai Simón,Mallorca,La Liga,2021,1,1,0,3,3.0
-Unai Simón,Atletico Madrid,La Liga,2023,1,1,0,3,3.0
-Unai Núñez,Atletico Madrid,La Liga,2022,1,1,0,3,3.0
-Unai López,Rayo Vallecano,La Liga,2024,1,1,0,3,3.0
-Unai López,Rayo Vallecano,La Liga,2022,1,1,0,3,3.0
-U. Garcia,Marseille,Ligue 1,2024,1,1,0,3,3.0
-Tuta,Eintracht Frankfurt,Bundesliga,2023,1,1,0,3,3.0
-Tuta,Eintracht Frankfurt,Bundesliga,2021,1,1,0,3,3.0
-Trincão,Wolves,Premier League,2021,1,1,0,3,3.0
-Thiago Silva,Chelsea,Premier League,2023,1,1,0,3,3.0
-Theo Corbeanu,Granada CF,La Liga,2023,1,1,0,3,3.0
-Tete Morente,Elche,La Liga,2022,1,1,0,3,3.0
-Tete Morente,Elche,La Liga,2021,1,1,0,3,3.0
-V. Kovalenko,Empoli,Serie A,2023,1,1,0,3,3.0
-V. Grifo,SC Freiburg,Bundesliga,2023,1,1,0,3,3.0
-V. Grifo,SC Freiburg,Bundesliga,2021,1,1,0,3,3.0
-V. Germain,Montpellier,Ligue 1,2022,1,1,0,3,3.0
-V. Germain,Montpellier,Ligue 1,2021,1,1,0,3,3.0
-V. Castellanos,Girona,La Liga,2022,1,1,0,3,3.0
-A. Iwobi,Everton,Premier League,2021,1,1,0,3,3.0
-A. Isak,Real Sociedad,La Liga,2021,1,1,0,3,3.0
-A. Ilić,Union Berlin,Bundesliga,2024,1,1,0,3,3.0
-A. Hrustić,Eintracht Frankfurt,Bundesliga,2021,1,1,0,3,3.0
-A. Hložek,Bayer Leverkusen,Bundesliga,2023,1,1,0,3,3.0
-A. Hložek,Bayer Leverkusen,Bundesliga,2022,1,1,0,3,3.0
-A. Hickey,Bologna,Serie A,2021,1,1,0,3,3.0
-A. Harroui,Verona,Serie A,2024,1,1,0,3,3.0
-A. Harroui,Sassuolo,Serie A,2022,1,1,0,3,3.0
-A. Hakimi,Paris Saint Germain,Ligue 1,2024,1,1,0,3,3.0
-V. Černý,VfL Wolfsburg,Bundesliga,2023,1,1,0,3,3.0
-V. van Dijk,Liverpool,Premier League,2021,1,1,0,3,3.0
-V. Sierro,Toulouse,Ligue 1,2024,1,1,0,3,3.0
-V. Sierro,Toulouse,Ligue 1,2023,1,1,0,3,3.0
-A. Hakimi,Paris Saint Germain,Ligue 1,2021,1,1,0,3,3.0
-A. Hainaut,Parma,Serie A,2024,1,1,0,3,3.0
-A. Haidara,RB Leipzig,Bundesliga,2022,1,1,0,3,3.0
-A. Gómez,Sevilla,La Liga,2021,1,1,0,3,3.0
-A. Guðmundsson,Genoa,Serie A,2021,1,1,0,3,3.0
-A. Guðmundsson,Fiorentina,Serie A,2024,1,1,0,3,3.0
-A. Gouiri,Rennes,Ligue 1,2022,1,1,0,3,3.0
-A. Gouiri,Marseille,Ligue 1,2024,1,1,0,3,3.0
-A. Gordon,Newcastle,Premier League,2024,1,1,0,3,3.0
-A. Gordon,Newcastle,Premier League,2023,1,1,0,3,3.0
-V. Rongier,Marseille,Ligue 1,2024,1,1,0,3,3.0
-V. Kovalenko,Spezia,Serie A,2021,1,1,0,3,3.0
-W. Endo,Liverpool,Premier League,2023,1,1,0,3,3.0
-W. Cheddira,Espanyol,La Liga,2024,1,1,0,3,3.0
-W. Bondo,Monza,Serie A,2023,1,1,0,3,3.0
-W. Anton,VfB Stuttgart,Bundesliga,2022,1,1,0,3,3.0
-W. Anton,Borussia Dortmund,Bundesliga,2024,1,1,0,3,3.0
-Vítinha,Marseille,Ligue 1,2023,1,1,0,3,3.0
-Víctor Díaz,Granada CF,La Liga,2021,1,1,0,3,3.0
-Vitor Roque,Real Betis,La Liga,2024,1,1,0,3,3.0
-Vitinha,Paris Saint Germain,Ligue 1,2024,1,1,0,3,3.0
-Vitinha,Paris Saint Germain,Ligue 1,2023,1,1,0,3,3.0
-Vinícius Júnior,Real Madrid,La Liga,2023,1,1,0,3,3.0
-Vinicius Souza,Espanyol,La Liga,2022,1,1,0,3,3.0
-Viktor Tsygankov,Girona,La Liga,2023,1,1,0,3,3.0
-Vicente Guaita,Real Madrid,La Liga,2023,1,1,0,3,3.0
-Vanderson,Monaco,Ligue 1,2021,1,1,0,3,3.0
-Valery Fernández,Girona,La Liga,2023,1,1,0,3,3.0
-W. Ndidi,Arsenal,Premier League,2024,1,1,0,3,3.0
-W. Khazri,Montpellier,Ligue 1,2022,1,1,0,3,3.0
-W. Kanga,Hertha Berlin,Bundesliga,2022,1,1,0,3,3.0
-W. Foderingham,Fulham,Premier League,2023,1,1,0,3,3.0
-A. Golovin,Monaco,Ligue 1,2023,1,1,0,3,3.0
-A. Gilchrist,Chelsea,Premier League,2023,1,1,0,3,3.0
-A. Garnacho,Manchester United,Premier League,2023,1,1,0,3,3.0
-A. Gaich,Verona,Serie A,2022,1,1,0,3,3.0
-A. Gabrielloni,Como,Serie A,2024,1,1,0,3,3.0
-A. Fulgini,Lens,Ligue 1,2024,1,1,0,3,3.0
-A. Florenzi,AC Milan,Serie A,2021,1,1,0,3,3.0
-A. Flips,Reims,Ligue 1,2022,1,1,0,3,3.0
-A. Ezzalzouli,Real Betis,La Liga,2024,1,1,0,3,3.0
-A. Espino,Cadiz,La Liga,2021,1,1,0,3,3.0
-W. Faghir,VfB Stuttgart,Bundesliga,2021,1,1,0,3,3.0
-W. Endo,VfB Stuttgart,Bundesliga,2021,1,1,0,3,3.0
-A. Dembélé,Torino,Serie A,2024,1,1,0,3,3.0
-A. Delort,Montpellier,Ligue 1,2021,1,1,0,3,3.0
-Wu Lei,Espanyol,La Liga,2021,1,1,0,3,3.0
-Willian José,Real Betis,La Liga,2022,1,1,0,3,3.0
-Willian,Fulham,Premier League,2022,1,1,0,3,3.0
-William Carvalho,Real Betis,La Liga,2021,1,1,0,3,3.0
-Walace,Udinese,Serie A,2021,1,1,0,3,3.0
-W. Zaïre-Emery,Paris Saint Germain,Ligue 1,2022,1,1,0,3,3.0
-W. Weghorst,VfL Wolfsburg,Bundesliga,2021,1,1,0,3,3.0
-W. Troost-Ekong,Salernitana,Serie A,2022,1,1,0,3,3.0
-W. Singo,Torino,Serie A,2022,1,1,0,3,3.0
-W. Saïd,Lens,Ligue 1,2024,1,1,0,3,3.0
-W. Saïd,Lens,Ligue 1,2022,1,1,0,3,3.0
-W. Saïd,Lens,Ligue 1,2021,1,1,0,3,3.0
-W. Osula,Newcastle,Premier League,2024,1,1,0,3,3.0
-W. Orbán,RB Leipzig,Bundesliga,2024,1,1,0,3,3.0
-Y. Abdelhamid,Reims,Ligue 1,2023,1,1,0,3,3.0
-Y. Abdelhamid,Reims,Ligue 1,2021,1,1,0,3,3.0
-Xeka,Lille,Ligue 1,2021,1,1,0,3,3.0
-X. Simons,RB Leipzig,Bundesliga,2023,1,1,0,3,3.0
-X. Shaqiri,Lyon,Ligue 1,2021,1,1,0,3,3.0
-X. Chavalerin,Estac Troyes,Ligue 1,2021,1,1,0,3,3.0
-A. Elis,Bordeaux,Ligue 1,2021,1,1,0,3,3.0
-A. Elanga,Nottingham Forest,Premier League,2024,1,1,0,3,3.0
-A. Elanga,Manchester United,Premier League,2021,1,1,0,3,3.0
-A. Ekdal,Sampdoria,Serie A,2021,1,1,0,3,3.0
-A. Dønnum,Toulouse,Ligue 1,2024,1,1,0,3,3.0
-A. Doucouré,Everton,Premier League,2024,1,1,0,3,3.0
-A. Doucouré,Everton,Premier League,2023,1,1,0,3,3.0
-A. Dossena,Juventus,Serie A,2023,1,1,0,3,3.0
-A. Disasi,Chelsea,Premier League,2023,1,1,0,3,3.0
-A. Dioussé,Saint Etienne,Ligue 1,2021,1,1,0,3,3.0
-Y. Mina,Everton,Premier League,2022,1,1,0,3,3.0
-Y. Maleh,Fiorentina,Serie A,2021,1,1,0,3,3.0
-Y. Keitel,SC Freiburg,Bundesliga,2023,1,1,0,3,3.0
-Y. Karamoh,Torino,Serie A,2022,1,1,0,3,3.0
-Y. Karamoh,Montpellier,Ligue 1,2023,1,1,0,3,3.0
-Y. Kabadayı,FC Augsburg,Bundesliga,2024,1,1,0,3,3.0
-Y. Herrera,Espanyol,La Liga,2021,1,1,0,3,3.0
-Y. Gerhardt,VfL Wolfsburg,Bundesliga,2022,1,1,0,3,3.0
-Y. Gboho,Toulouse,Ligue 1,2024,1,1,0,3,3.0
-Y. Gboho,Toulouse,Ligue 1,2023,1,1,0,3,3.0
-Y. Fofana,Monaco,Ligue 1,2023,1,1,0,3,3.0
-Y. Engelhardt,Fortuna Dusseldorf,Bundesliga,2023,1,1,0,3,3.0
-Y. En-Nesyri,Sevilla,La Liga,2021,1,1,0,3,3.0
-Y. Carrasco,Atletico Madrid,La Liga,2022,1,1,0,3,3.0
-Y. Bissouma,Brighton,Premier League,2021,1,1,0,3,3.0
-Y. Atal,Nice,Ligue 1,2021,1,1,0,3,3.0
-A. Caci,FSV Mainz 05,Bundesliga,2024,1,1,0,3,3.0
-A. Caci,FSV Mainz 05,Bundesliga,2022,1,1,0,3,3.0
-A. Buongiorno,Napoli,Serie A,2024,1,1,0,3,3.0
-A. Budimir,Osasuna,La Liga,2024,1,1,0,3,3.0
-Yan Couto,Girona,La Liga,2023,1,1,0,3,3.0
-Y. Vertessen,Union Berlin,Bundesliga,2023,1,1,0,3,3.0
-Y. Touzghar,Estac Troyes,Ligue 1,2021,1,1,0,3,3.0
-Y. Tielemans,Leicester,Premier League,2021,1,1,0,3,3.0
-Y. Suzuki,Strasbourg,Ligue 1,2022,1,1,0,3,3.0
-Y. Sugawara,Southampton,Premier League,2024,1,1,0,3,3.0
-Y. Salmier,Estac Troyes,Ligue 1,2022,1,1,0,3,3.0
-Y. Ramadani,Lecce,Serie A,2023,1,1,0,3,3.0
-Y. Poulsen,RB Leipzig,Bundesliga,2021,1,1,0,3,3.0
-Y. Ndayishimiye,Nice,Ligue 1,2024,1,1,0,3,3.0
-Y. Moukoko,Borussia Dortmund,Bundesliga,2021,1,1,0,3,3.0
-Y. Minteh,Brighton,Premier League,2024,1,1,0,3,3.0
-Z. Amdouni,Burnley,Premier League,2023,1,1,0,3,3.0
-Z. Aboukhlal,Toulouse,Ligue 1,2023,1,1,0,3,3.0
-Yerson Mosquera,Villarreal,La Liga,2023,1,1,0,3,3.0
-Yeremi Pino,Villarreal,La Liga,2021,1,1,0,3,3.0
-Yeray,Athletic Club,La Liga,2024,1,1,0,3,3.0
-Yangel Herrera,Girona,La Liga,2023,1,1,0,3,3.0
-A. Deiola,Cagliari,Serie A,2024,1,1,0,3,3.0
-A. Davies,Bayern München,Bundesliga,2024,1,1,0,3,3.0
-A. Danjuma,Tottenham,Premier League,2022,1,1,0,3,3.0
-A. Danjuma,Girona,La Liga,2024,1,1,0,3,3.0
-A. Colpani,Monza,Serie A,2022,1,1,0,3,3.0
-A. Claude-Maurice,Lens,Ligue 1,2022,1,1,0,3,3.0
-A. Carboni,Monza,Serie A,2023,1,1,0,3,3.0
-A. Cambiaso,Juventus,Serie A,2024,1,1,0,3,3.0
-A. Cambiaso,Juventus,Serie A,2023,1,1,0,3,3.0
-A. Caci,Strasbourg,Ligue 1,2021,1,1,0,3,3.0
-6                         E. Ünal,Getafe,La Liga,2022,1,1,0,3,3.0
-0                         D. Malen,Aston Villa,Premier League,2024,1,1,0,3,3.0
-Óscar Rodríguez,Getafe,La Liga,2023,1,1,0,3,3.0
-Óscar Mingueza,Celta Vigo,La Liga,2023,1,1,0,3,3.0
-Ó. Duarte,Levante,La Liga,2021,1,1,0,3,3.0
-Íñigo Eguaras,Almeria,La Liga,2022,1,1,0,3,3.0
-Í. Bergmann Jóhannesson,Fortuna Dusseldorf,Bundesliga,2023,1,1,0,3,3.0
-Álex Moreno,Aston Villa,Premier League,2023,1,1,0,3,3.0
-Álex Collado,Granada CF,La Liga,2021,1,1,0,3,3.0
-Álex Centelles,Almeria,La Liga,2022,1,1,0,3,3.0
-Álex Berenguer,Athletic Club,La Liga,2022,1,1,0,3,3.0
-Álex Baena,Villarreal,La Liga,2024,1,1,0,3,3.0
-Álex,Cadiz,La Liga,2022,1,1,0,3,3.0
-Álex,Cadiz,La Liga,2021,1,1,0,3,3.0
-Á. Rodríguez,Real Madrid,La Liga,2022,1,1,0,3,3.0
-Á. Padilla,Sevilla,La Liga,2024,1,1,0,3,3.0
-Éder Militão,Real Madrid,La Liga,2021,1,1,0,3,3.0
-É. Capoue,Villarreal,La Liga,2022,1,1,0,3,3.0
-Ç. Söyüncü,Leicester,Premier League,2021,1,1,0,3,3.0
-Ángel Correa,Atletico Madrid,La Liga,2023,1,1,0,3,3.0
-Ángel,Mallorca,La Liga,2022,1,1,0,3,3.0
-Álvaro Tejero,Espanyol,La Liga,2024,1,1,0,3,3.0
-Álvaro Negredo,Cadiz,La Liga,2022,1,1,0,3,3.0
-Álvaro Morata,Juventus,Serie A,2021,1,1,0,3,3.0
-Álvaro Morata,AC Milan,Serie A,2024,1,1,0,3,3.0
-Álvaro García,Rayo Vallecano,La Liga,2023,1,1,0,3,3.0
-Álvaro Djaló,Athletic Club,La Liga,2024,1,1,0,3,3.0
-Álex Muñoz,Las Palmas,La Liga,2024,1,1,0,3,3.0
-A. Armstrong,Southampton,Premier League,2024,1,1,0,3,3.0
-A. Albers,FC St. Pauli,Bundesliga,2024,1,1,0,3,3.0
-A. Al Dakhil,Burnley,Premier League,2023,1,1,0,3,3.0
-A. Adli,Bayer Leverkusen,Bundesliga,2024,1,1,0,3,3.0
+player_id,player_name,team_id,team_name,league_id,league,year,Clutch_Matches,Clutch_Goal,Clutch_Assist,Clutch_Score,Score_per_Match
+759.0,K. Benzema,541,Real Madrid,140,La Liga,2021,11,11,3,39,3.5454545454545454
+762.0,Vinícius Júnior,541,Real Madrid,140,La Liga,2021,11,6,6,30,2.727272727272727
+180496.0,Georges Mikautadze,80,Lyon,61,Ligue 1,2024,10,6,6,30,3.0
+8492.0,A. Sørloth,530,Atletico Madrid,140,La Liga,2024,9,9,1,29,3.2222222222222223
+306.0,Mohamed Salah,40,Liverpool,39,Premier League,2024,10,8,2,28,2.8
+21591.0,A. Delort,84,Nice,61,Ligue 1,2021,9,8,2,28,3.111111111111111
+25391.0,N. Füllkrug,162,Werder Bremen,78,Bundesliga,2022,9,8,2,28,3.111111111111111
+521.0,R. Lewandowski,529,Barcelona,140,La Liga,2023,8,7,3,27,3.375
+306.0,Mohamed Salah,40,Liverpool,39,Premier League,2023,9,5,6,27,3.0
+278.0,K. Mbappé,85,Paris Saint Germain,61,Ligue 1,2022,8,8,1,26,3.25
+278.0,K. Mbappé,85,Paris Saint Germain,61,Ligue 1,2023,9,8,1,26,2.888888888888889
+269.0,C. Nkunku,173,RB Leipzig,78,Bundesliga,2022,8,6,4,26,3.25
+2617.0,C. Stuani,547,Girona,140,La Liga,2023,7,7,2,25,3.5714285714285716
+1100.0,E. Haaland,50,Manchester City,39,Premier League,2023,9,6,3,24,2.6666666666666665
+186.0,Son Heung-Min,47,Tottenham,39,Premier League,2023,8,6,3,24,3.0
+217.0,Lautaro Martínez,505,Inter,135,Serie A,2023,5,7,1,23,4.6
+1467.0,A. Lacazette,80,Lyon,61,Ligue 1,2022,6,7,1,23,3.8333333333333335
+217.0,Lautaro Martínez,505,Inter,135,Serie A,2022,7,7,1,23,3.2857142857142856
+26256.0,Tim Kleindienst,180,1. FC Heidenheim,78,Bundesliga,2023,7,7,1,23,3.2857142857142856
+18830.0,M. Arnautović,500,Bologna,135,Serie A,2021,8,7,1,23,2.875
+8489.0,J. David,79,Lille,61,Ligue 1,2022,8,6,2,22,2.75
+2617.0,C. Stuani,547,Girona,140,La Liga,2024,8,6,2,22,2.75
+26256.0,Tim Kleindienst,163,Borussia Mönchengladbach,78,Bundesliga,2024,8,6,2,22,2.75
+184.0,Harry Kane,157,Bayern München,78,Bundesliga,2024,6,6,2,22,3.6666666666666665
+931.0,Ferran Torres,529,Barcelona,140,La Liga,2024,6,6,2,22,3.6666666666666665
+47445.0,Iago Aspas,538,Celta Vigo,140,La Liga,2024,8,6,2,22,2.75
+157997.0,A. Diallo,33,Manchester United,39,Premier League,2024,5,7,0,21,4.2
+21393.0,S. Guirassy,172,VfB Stuttgart,78,Bundesliga,2023,5,7,0,21,4.2
+51617.0,D. Núñez,40,Liverpool,39,Premier League,2023,7,5,3,21,3.0
+521.0,R. Lewandowski,529,Barcelona,140,La Liga,2022,7,5,3,21,3.0
+278.0,K. Mbappé,85,Paris Saint Germain,61,Ligue 1,2021,8,3,6,21,2.625
+306.0,Mohamed Salah,40,Liverpool,39,Premier League,2022,7,5,3,21,3.0
+2299.0,Pedro,487,Lazio,135,Serie A,2024,6,7,0,21,3.5
+2763.0,M. Pašalić,499,Atalanta,135,Serie A,2021,8,4,4,20,2.5
+22236.0,Rafael Leão,489,AC Milan,135,Serie A,2022,6,4,4,20,3.3333333333333335
+184.0,Harry Kane,157,Bayern München,78,Bundesliga,2023,6,6,1,20,3.3333333333333335
+25242.0,M. Bülter,174,FC Schalke 04,78,Bundesliga,2022,7,6,1,20,2.857142857142857
+138835.0,F. Balogun,93,Reims,61,Ligue 1,2022,7,6,1,20,2.857142857142857
+195106.0,Rodrigo Muniz,36,Fulham,39,Premier League,2024,7,6,1,20,2.857142857142857
+152982.0,Cole Palmer,49,Chelsea,39,Premier League,2023,6,4,4,20,3.3333333333333335
+24811.0,Anthony Modeste,192,1.FC Köln,78,Bundesliga,2021,7,6,1,20,2.857142857142857
+8492.0,A. Sørloth,533,Villarreal,140,La Liga,2023,6,6,1,20,3.3333333333333335
+1100.0,E. Haaland,165,Borussia Dortmund,78,Bundesliga,2021,7,6,1,20,2.857142857142857
+85041.0,A. Gouiri,84,Nice,61,Ligue 1,2021,5,5,2,19,3.8
+22015.0,B. Dia,514,Salernitana,135,Serie A,2022,7,5,2,19,2.7142857142857144
+184.0,Harry Kane,47,Tottenham,39,Premier League,2022,7,5,2,19,2.7142857142857144
+978.0,K. Havertz,42,Arsenal,39,Premier League,2023,7,5,2,19,2.7142857142857144
+278.0,K. Mbappé,541,Real Madrid,140,La Liga,2024,6,5,2,19,3.1666666666666665
+25639.0,L. Stindl,163,Borussia Mönchengladbach,78,Bundesliga,2022,5,6,0,18,3.6
+907.0,R. Lukaku,505,Inter,135,Serie A,2022,5,4,3,18,3.6
+156477.0,R. Cherki,80,Lyon,61,Ligue 1,2024,6,4,3,18,3.0
+47320.0,Juanmi,543,Real Betis,140,La Liga,2021,6,4,3,18,3.0
+154.0,L. Messi,85,Paris Saint Germain,61,Ligue 1,2022,5,4,3,18,3.6
+270510.0,M. Tel,157,Bayern München,78,Bundesliga,2023,7,4,3,18,2.5714285714285716
+18907.0,Joselu,540,Espanyol,140,La Liga,2022,6,6,0,18,3.0
+8489.0,J. David,79,Lille,61,Ligue 1,2024,6,6,0,18,3.0
+2493.0,L. Muriel,499,Atalanta,135,Serie A,2021,5,4,3,18,3.6
+31094.0,A. Pinamonti,511,Empoli,135,Serie A,2021,5,6,0,18,3.6
+726.0,A. Kramarić,167,1899 Hoffenheim,78,Bundesliga,2023,5,6,0,18,3.6
+86.0,L. Openda,116,Lens,61,Ligue 1,2022,5,5,1,17,3.4
+21393.0,S. Guirassy,165,Borussia Dortmund,78,Bundesliga,2024,5,5,1,17,3.4
+161921.0,G. Reyna,165,Borussia Dortmund,78,Bundesliga,2022,6,5,1,17,2.8333333333333335
+22015.0,B. Dia,533,Villarreal,140,La Liga,2021,5,3,4,17,3.4
+41585.0,Gonçalo Ramos,85,Paris Saint Germain,61,Ligue 1,2023,5,5,1,17,3.4
+48389.0,N. Okafor,489,AC Milan,135,Serie A,2023,6,5,1,17,2.8333333333333335
+46930.0,E. Demirović,172,VfB Stuttgart,78,Bundesliga,2024,6,5,1,17,2.8333333333333335
+666.0,M. Dembélé,80,Lyon,61,Ligue 1,2021,6,5,1,17,2.8333333333333335
+1496.0,Raphinha,529,Barcelona,140,La Liga,2024,6,3,4,17,2.8333333333333335
+22097.0,Arnaud Nordin,1063,Saint Etienne,61,Ligue 1,2021,4,3,4,17,4.25
+2059.0,W. Ben Yedder,91,Monaco,61,Ligue 1,2021,6,5,1,17,2.8333333333333335
+521.0,R. Lewandowski,157,Bayern München,78,Bundesliga,2021,6,5,1,17,2.8333333333333335
+186.0,Son Heung-Min,47,Tottenham,39,Premier League,2021,6,5,1,17,2.8333333333333335
+386828.0,Lamine Yamal,529,Barcelona,140,La Liga,2024,7,3,4,17,2.4285714285714284
+645.0,R. Sterling,50,Manchester City,39,Premier League,2021,6,5,1,17,2.8333333333333335
+19281.0,A. Semenyo,35,Bournemouth,39,Premier League,2024,6,4,2,16,2.6666666666666665
+19366.0,O. Watkins,66,Aston Villa,39,Premier League,2023,6,4,2,16,2.6666666666666665
+2939.0,C. Wilson,34,Newcastle,39,Premier League,2022,5,4,2,16,3.2
+1165.0,Matheus Cunha,39,Wolves,39,Premier League,2024,6,4,2,16,2.6666666666666665
+56.0,A. Griezmann,530,Atletico Madrid,140,La Liga,2024,6,4,2,16,2.6666666666666665
+2617.0,C. Stuani,547,Girona,140,La Liga,2022,5,5,0,15,3.0
+1856.0,S. Milinković-Savić,487,Lazio,135,Serie A,2022,6,3,3,15,2.5
+47467.0,José Luis Morales,539,Levante,140,La Liga,2021,6,3,3,15,2.5
+25927.0,J. Mateta,52,Crystal Palace,39,Premier League,2024,5,5,0,15,3.0
+153.0,O. Dembélé,85,Paris Saint Germain,61,Ligue 1,2024,4,5,0,15,3.75
+30771.0,Domenico Criscito,495,Genoa,135,Serie A,2021,5,5,0,15,3.0
+30509.0,A. Belotti,503,Torino,135,Serie A,2021,3,5,0,15,5.0
+30410.0,F. Chiesa,496,Juventus,135,Serie A,2023,5,5,0,15,3.0
+10009.0,Rodrygo,541,Real Madrid,140,La Liga,2022,6,3,3,15,2.5
+20589.0,B. Mbeumo,55,Brentford,39,Premier League,2022,6,3,3,15,2.5
+30488.0,R. Orsolini,500,Bologna,135,Serie A,2022,5,5,0,15,3.0
+2059.0,W. Ben Yedder,91,Monaco,61,Ligue 1,2022,4,5,0,15,3.75
+18907.0,Joselu,542,Alaves,140,La Liga,2021,4,5,0,15,3.75
+1100.0,E. Haaland,50,Manchester City,39,Premier League,2022,5,5,0,15,3.0
+47258.0,M. Arambarri,546,Getafe,140,La Liga,2024,4,5,0,15,3.75
+25458.0,D. Lukébakio,536,Sevilla,140,La Liga,2024,5,5,0,15,3.0
+80.0,E. Dennis,38,Watford,39,Premier League,2021,3,3,3,15,5.0
+25461.0,K. Stöger,176,VfL Bochum,78,Bundesliga,2023,6,3,3,15,2.5
+6009.0,J. Alvarez,530,Atletico Madrid,140,La Liga,2024,6,3,3,15,2.5
+909.0,M. Rashford,33,Manchester United,39,Premier League,2022,5,5,0,15,3.0
+1165.0,Matheus Cunha,39,Wolves,39,Premier League,2023,6,3,3,15,2.5
+21104.0,R. Kolo Muani,85,Paris Saint Germain,61,Ligue 1,2023,6,3,3,15,2.5
+17.0,C. Pulišić,489,AC Milan,135,Serie A,2023,6,3,3,15,2.5
+18784.0,J. Maddison,46,Leicester,39,Premier League,2021,5,3,3,15,3.0
+152982.0,Cole Palmer,49,Chelsea,39,Premier League,2024,5,4,1,14,2.8
+21497.0,L. Blas,83,Nantes,61,Ligue 1,2022,5,4,1,14,2.8
+608.0,Lucas Boyé,715,Granada CF,140,La Liga,2023,5,4,1,14,2.8
+2216.0,M. Niang,511,Empoli,135,Serie A,2023,4,4,1,14,3.5
+129718.0,J. Bellingham,541,Real Madrid,140,La Liga,2023,5,4,1,14,2.8
+635.0,R. Mahrez,50,Manchester City,39,Premier League,2021,5,4,1,14,2.8
+20649.0,Yoane Wissa,55,Brentford,39,Premier League,2021,5,4,1,14,2.8
+30414.0,G. Simeone,492,Napoli,135,Serie A,2022,5,4,1,14,2.8
+53.0,Á. Correa,530,Atletico Madrid,140,La Liga,2024,5,4,1,14,2.8
+1863.0,C. Immobile,487,Lazio,135,Serie A,2022,5,2,4,14,2.8
+1828.0,Luka Jović,502,Fiorentina,135,Serie A,2022,5,4,1,14,2.8
+19194.0,T. Abraham,497,AS Roma,135,Serie A,2022,5,4,1,14,2.8
+286894.0,J. Gittens,165,Borussia Dortmund,78,Bundesliga,2024,5,4,1,14,2.8
+269163.0,W. Swedberg,538,Celta Vigo,140,La Liga,2024,6,2,4,14,2.3333333333333335
+217.0,Lautaro Martínez,505,Inter,135,Serie A,2021,5,4,1,14,2.8
+186.0,Son Heung-Min,47,Tottenham,39,Premier League,2022,3,4,1,14,4.666666666666667
+1467.0,A. Lacazette,80,Lyon,61,Ligue 1,2023,5,4,1,14,2.8
+983.0,Leon Bailey,66,Aston Villa,39,Premier League,2023,5,4,1,14,2.8
+129718.0,J. Bellingham,541,Real Madrid,140,La Liga,2024,4,4,1,14,3.5
+19083.0,Carlton Morris,1359,Luton,39,Premier League,2023,5,4,1,14,2.8
+563.0,Álex Grimaldo,168,Bayer Leverkusen,78,Bundesliga,2023,6,2,4,14,2.3333333333333335
+746.0,Marco Asensio,541,Real Madrid,140,La Liga,2022,5,4,1,14,2.8
+1097.0,M. Dabbur,167,1899 Hoffenheim,78,Bundesliga,2022,4,4,1,14,3.5
+877.0,M. Kean,502,Fiorentina,135,Serie A,2024,5,4,1,14,2.8
+907.0,R. Lukaku,497,AS Roma,135,Serie A,2023,5,4,1,14,2.8
+306.0,Mohamed Salah,40,Liverpool,39,Premier League,2021,5,4,1,14,2.8
+875.0,P. Dybala,497,AS Roma,135,Serie A,2023,5,2,4,14,2.8
+22261.0,A. Thomasson,95,Strasbourg,61,Ligue 1,2021,4,4,1,14,3.5
+30629.0,N. Viola,490,Cagliari,135,Serie A,2023,5,4,1,14,2.8
+3247.0,W. Zaha,52,Crystal Palace,39,Premier League,2021,3,4,1,14,4.666666666666667
+20589.0,B. Mbeumo,55,Brentford,39,Premier League,2023,4,4,1,14,3.5
+186.0,Son Heung-Min,47,Tottenham,39,Premier League,2024,5,3,2,13,2.6
+361348.0,M. Fofana,80,Lyon,61,Ligue 1,2024,5,3,2,13,2.6
+644.0,L. Sané,157,Bayern München,78,Bundesliga,2024,5,3,2,13,2.6
+19428.0,J. Bowen,48,West Ham,39,Premier League,2021,5,3,2,13,2.6
+19366.0,O. Watkins,66,Aston Villa,39,Premier League,2022,5,3,2,13,2.6
+2206.0,B. Bourigeaud,94,Rennes,61,Ligue 1,2023,5,3,2,13,2.6
+984.0,J. Brandt,165,Borussia Dortmund,78,Bundesliga,2022,5,3,2,13,2.6
+284797.0,Dango Ouattara,35,Bournemouth,39,Premier League,2024,4,3,2,13,3.25
+46930.0,E. Demirović,170,FC Augsburg,78,Bundesliga,2023,5,3,2,13,2.6
+10329.0,João Pedro,51,Brighton,39,Premier League,2024,4,3,2,13,3.25
+25927.0,J. Mateta,52,Crystal Palace,39,Premier League,2023,4,3,2,13,3.25
+663.0,M. Terrier,94,Rennes,61,Ligue 1,2022,4,3,2,13,3.25
+21592.0,G. Laborde,94,Rennes,61,Ligue 1,2021,5,3,2,13,2.6
+203224.0,F. Wirtz,168,Bayer Leverkusen,78,Bundesliga,2023,4,3,2,13,3.25
+47398.0,Pere Milla,797,Elche,140,La Liga,2021,5,3,2,13,2.6
+269.0,C. Nkunku,173,RB Leipzig,78,Bundesliga,2021,4,3,2,13,3.25
+44.0,Rodri,50,Manchester City,39,Premier League,2023,5,3,2,13,2.6
+2938.0,J. Ward-Prowse,41,Southampton,39,Premier League,2021,4,3,2,13,3.25
+925.0,Gonçalo Guedes,532,Valencia,140,La Liga,2021,5,3,2,13,2.6
+200139.0,M. Amoura,161,VfL Wolfsburg,78,Bundesliga,2024,4,3,2,13,3.25
+129682.0,A. Adli,168,Bayer Leverkusen,78,Bundesliga,2023,5,3,2,13,2.6
+129711.0,B. Johnson,47,Tottenham,39,Premier League,2023,5,1,5,13,2.6
+18788.0,J. Vardy,46,Leicester,39,Premier League,2021,4,3,2,13,3.25
+1856.0,S. Milinković-Savić,487,Lazio,135,Serie A,2021,5,3,2,13,2.6
+30436.0,M. Pessina,1579,Monza,135,Serie A,2023,5,3,2,13,2.6
+1485.0,Bruno Fernandes,33,Manchester United,39,Premier League,2023,4,3,2,13,3.25
+24288.0,M. Bayo,99,Clermont Foot,61,Ligue 1,2021,5,3,2,13,2.6
+211.0,M. Vecino,487,Lazio,135,Serie A,2023,4,4,0,12,3.0
+3395.0,S. Mounié,106,Stade Brestois 29,61,Ligue 1,2021,4,4,0,12,3.0
+1646.0,Lucas Paquetá,80,Lyon,61,Ligue 1,2021,4,4,0,12,3.0
+48392.0,E. Zhegrova,79,Lille,61,Ligue 1,2022,3,2,3,12,4.0
+759.0,K. Benzema,541,Real Madrid,140,La Liga,2022,2,4,0,12,6.0
+782.0,L. Pellegrini,497,AS Roma,135,Serie A,2021,4,4,0,12,3.0
+20535.0,H. Diallo,95,Strasbourg,61,Ligue 1,2022,4,4,0,12,3.0
+22236.0,Rafael Leão,489,AC Milan,135,Serie A,2024,5,2,3,12,2.4
+270510.0,M. Tel,157,Bayern München,78,Bundesliga,2022,4,4,0,12,3.0
+283058.0,N. Jackson,49,Chelsea,39,Premier League,2023,3,4,0,12,4.0
+1912.0,D. Payet,81,Marseille,61,Ligue 1,2021,5,2,3,12,2.4
+301771.0,S. Adingra,51,Brighton,39,Premier League,2023,3,4,0,12,4.0
+1859.0,Luis Alberto,487,Lazio,135,Serie A,2021,5,2,3,12,2.4
+157.0,L. Suárez,530,Atletico Madrid,140,La Liga,2021,3,4,0,12,4.0
+30812.0,I. Pussetto,494,Udinese,135,Serie A,2021,4,2,3,12,3.0
+30537.0,D. Berardi,488,Sassuolo,135,Serie A,2021,6,0,6,12,2.0
+18929.0,D. McNeil,45,Everton,39,Premier League,2022,3,4,0,12,4.0
+25928.0,K. Onisiwo,164,FSV Mainz 05,78,Bundesliga,2022,4,4,0,12,3.0
+24861.0,S. Polter,174,FC Schalke 04,78,Bundesliga,2022,5,2,3,12,2.4
+81573.0,Omar Marmoush,169,Eintracht Frankfurt,78,Bundesliga,2023,4,4,0,12,3.0
+6716.0,A. Mac Allister,51,Brighton,39,Premier League,2022,4,4,0,12,3.0
+2489.0,L. Díaz,40,Liverpool,39,Premier League,2023,5,2,3,12,2.4
+375000.0,I. Salah,94,Rennes,61,Ligue 1,2023,3,4,0,12,4.0
+128398.0,Oihan Sancet,531,Athletic Club,140,La Liga,2024,4,4,0,12,3.0
+106851.0,S. Machino,191,Holstein Kiel,78,Bundesliga,2024,4,4,0,12,3.0
+631.0,P. Foden,50,Manchester City,39,Premier League,2021,5,2,3,12,2.4
+1828.0,Luka Jović,489,AC Milan,135,Serie A,2023,4,4,0,12,3.0
+1859.0,Luis Alberto,487,Lazio,135,Serie A,2022,4,4,0,12,3.0
+2923.0,Yannick Carrasco,530,Atletico Madrid,140,La Liga,2021,4,2,3,12,3.0
+20649.0,Yoane Wissa,55,Brentford,39,Premier League,2022,4,4,0,12,3.0
+47499.0,E. Ünal,546,Getafe,140,La Liga,2022,4,4,0,12,3.0
+909.0,M. Rashford,33,Manchester United,39,Premier League,2021,4,4,0,12,3.0
+2937.0,D. Rice,42,Arsenal,39,Premier League,2023,4,4,0,12,3.0
+21509.0,M. Thuram,505,Inter,135,Serie A,2023,4,4,0,12,3.0
+47348.0,Borja Iglesias,543,Real Betis,140,La Liga,2022,4,4,0,12,3.0
+21509.0,M. Thuram,505,Inter,135,Serie A,2024,4,4,0,12,3.0
+21443.0,T. Savanier,82,Montpellier,61,Ligue 1,2022,4,4,0,12,3.0
+21393.0,S. Guirassy,94,Rennes,61,Ligue 1,2021,3,4,0,12,4.0
+47472.0,Borja Mayoral,546,Getafe,140,La Liga,2023,4,4,0,12,3.0
+47467.0,José Luis Morales,533,Villarreal,140,La Liga,2022,3,4,0,12,4.0
+21104.0,R. Kolo Muani,83,Nantes,61,Ligue 1,2021,4,2,3,12,3.0
+973.0,M. Weiser,162,Werder Bremen,78,Bundesliga,2022,6,0,6,12,2.0
+910.0,A. Sánchez,81,Marseille,61,Ligue 1,2022,4,4,0,12,3.0
+203762.0,E. Emegha,95,Strasbourg,61,Ligue 1,2023,4,4,0,12,3.0
+1165.0,Matheus Cunha,530,Atletico Madrid,140,La Liga,2021,4,2,3,12,3.0
+202514.0,P. Harres,191,Holstein Kiel,78,Bundesliga,2024,3,4,0,12,4.0
+203224.0,F. Wirtz,168,Bayer Leverkusen,78,Bundesliga,2021,4,2,3,12,3.0
+1302.0,J. Wind,161,VfL Wolfsburg,78,Bundesliga,2024,3,4,0,12,4.0
+41585.0,Gonçalo Ramos,85,Paris Saint Germain,61,Ligue 1,2024,3,4,0,12,4.0
+19221.0,H. Wilson,36,Fulham,39,Premier League,2024,3,4,0,12,4.0
+15911.0,M. Kudus,48,West Ham,39,Premier League,2023,5,2,3,12,2.4
+18778.0,H. Barnes,46,Leicester,39,Premier League,2022,4,4,0,12,3.0
+119.0,Radamel Falcao,728,Rayo Vallecano,140,La Liga,2021,4,4,0,12,3.0
+15811.0,A. Dovbyk,497,AS Roma,135,Serie A,2024,4,4,0,12,3.0
+47265.0,Jorge Molina,715,Granada CF,140,La Liga,2021,4,4,0,12,3.0
+276.0,Neymar,85,Paris Saint Germain,61,Ligue 1,2021,5,2,3,12,2.4
+275.0,E. Choupo-Moting,157,Bayern München,78,Bundesliga,2021,4,4,0,12,3.0
+47294.0,I. Williams,531,Athletic Club,140,La Liga,2024,5,2,3,12,2.4
+47396.0,Kike García,542,Alaves,140,La Liga,2024,3,4,0,12,4.0
+2598.0,R. Doan,160,SC Freiburg,78,Bundesliga,2024,4,2,3,12,3.0
+2495.0,D. Zapata,503,Torino,135,Serie A,2023,4,4,0,12,3.0
+26242.0,Keven Schlotterbeck,176,VfL Bochum,78,Bundesliga,2023,4,4,0,12,3.0
+663.0,M. Terrier,94,Rennes,61,Ligue 1,2021,4,4,0,12,3.0
+25391.0,N. Füllkrug,165,Borussia Dortmund,78,Bundesliga,2023,4,4,0,12,3.0
+288006.0,R. Højlund,33,Manchester United,39,Premier League,2023,4,4,0,12,3.0
+25458.0,D. Lukébakio,536,Sevilla,140,La Liga,2023,4,3,1,11,2.75
+2289.0,Jorginho,49,Chelsea,39,Premier League,2021,4,3,1,11,2.75
+2413.0,Richarlison,47,Tottenham,39,Premier League,2024,4,3,1,11,2.75
+30415.0,Dušan Vlahović,496,Juventus,135,Serie A,2024,4,3,1,11,2.75
+134926.0,Daniel Maldini,1579,Monza,135,Serie A,2023,4,3,1,11,2.75
+18778.0,H. Barnes,34,Newcastle,39,Premier League,2023,2,3,1,11,5.5
+129711.0,B. Johnson,65,Nottingham Forest,39,Premier League,2022,4,3,1,11,2.75
+10329.0,João Pedro,51,Brighton,39,Premier League,2023,4,3,1,11,2.75
+18819.0,M. Antonio,48,West Ham,39,Premier League,2021,3,3,1,11,3.6666666666666665
+18767.0,A. Lookman,499,Atalanta,135,Serie A,2024,4,3,1,11,2.75
+395040.0,G. Ilenikhena,91,Monaco,61,Ligue 1,2024,3,3,1,11,3.6666666666666665
+333.0,A. Milik,81,Marseille,61,Ligue 1,2021,4,3,1,11,2.75
+182219.0,Álex Baena,533,Villarreal,140,La Liga,2022,3,3,1,11,3.6666666666666665
+36899.0,T. Koopmeiners,499,Atalanta,135,Serie A,2022,4,3,1,11,2.75
+21443.0,T. Savanier,82,Montpellier,61,Ligue 1,2021,4,3,1,11,2.75
+21509.0,M. Thuram,163,Borussia Mönchengladbach,78,Bundesliga,2022,4,3,1,11,2.75
+19071.0,E. Buendía,66,Aston Villa,39,Premier League,2022,4,3,1,11,2.75
+19085.0,T. Pukki,71,Norwich,39,Premier League,2021,4,3,1,11,2.75
+47336.0,Darder,540,Espanyol,140,La Liga,2022,4,3,1,11,2.75
+18970.0,P. Groß,51,Brighton,39,Premier League,2023,5,1,4,11,2.2
+161919.0,Y. Moukoko,165,Borussia Dortmund,78,Bundesliga,2022,3,3,1,11,3.6666666666666665
+20784.0,F. Honorat,106,Stade Brestois 29,61,Ligue 1,2021,4,3,1,11,2.75
+1469.0,D. Welbeck,51,Brighton,39,Premier League,2021,3,3,1,11,3.6666666666666665
+266657.0,Savinho,547,Girona,140,La Liga,2023,3,3,1,11,3.6666666666666665
+863.0,Rodrigo Bentancur,47,Tottenham,39,Premier League,2022,3,3,1,11,3.6666666666666665
+879.0,S. Mavididi,82,Montpellier,61,Ligue 1,2022,4,3,1,11,2.75
+47522.0,Douglas Luiz,66,Aston Villa,39,Premier League,2023,4,3,1,11,2.75
+2910.0,Hwang Ui-Jo,78,Bordeaux,61,Ligue 1,2021,4,3,1,11,2.75
+21715.0,W. Saïd,116,Lens,61,Ligue 1,2023,4,3,1,11,2.75
+46746.0,A. Budimir,727,Osasuna,140,La Liga,2023,4,3,1,11,2.75
+903.0,S. McTominay,33,Manchester United,39,Premier League,2023,3,3,1,11,3.6666666666666665
+2864.0,A. Isak,34,Newcastle,39,Premier League,2023,3,3,1,11,3.6666666666666665
+22005.0,X. Chavalerin,110,Estac Troyes,61,Ligue 1,2022,4,3,1,11,2.75
+302.0,Roberto Firmino,40,Liverpool,39,Premier League,2022,3,3,1,11,3.6666666666666665
+272.0,A. Rabiot,496,Juventus,135,Serie A,2022,3,3,1,11,3.6666666666666665
+266.0,Á. Di María,85,Paris Saint Germain,61,Ligue 1,2021,4,3,1,11,2.75
+2938.0,J. Ward-Prowse,41,Southampton,39,Premier League,2022,4,3,1,11,2.75
+20617.0,S. Katompa Mvumpa,172,VfB Stuttgart,78,Bundesliga,2023,3,3,1,11,3.6666666666666665
+162707.0,E. Wahi,82,Montpellier,61,Ligue 1,2022,4,3,1,11,2.75
+26845.0,T. Douvikas,538,Celta Vigo,140,La Liga,2023,4,3,1,11,2.75
+30415.0,Dušan Vlahović,496,Juventus,135,Serie A,2023,4,3,1,11,2.75
+313236.0,E. Nwaneri,42,Arsenal,39,Premier League,2024,4,3,1,11,2.75
+283058.0,N. Jackson,533,Villarreal,140,La Liga,2022,4,3,1,11,2.75
+25081.0,M. Pantović,176,VfL Bochum,78,Bundesliga,2021,3,3,1,11,3.6666666666666665
+636.0,Bernardo Silva,50,Manchester City,39,Premier League,2023,3,3,1,11,3.6666666666666665
+631.0,P. Foden,50,Manchester City,39,Premier League,2024,4,3,1,11,2.75
+510.0,S. Gnabry,157,Bayern München,78,Bundesliga,2024,4,3,1,11,2.75
+81573.0,Omar Marmoush,169,Eintracht Frankfurt,78,Bundesliga,2024,4,3,1,11,2.75
+19192.0,J. Ramsey,66,Aston Villa,39,Premier League,2021,3,3,1,11,3.6666666666666665
+90590.0,G. Rutter,167,1899 Hoffenheim,78,Bundesliga,2021,3,3,1,11,3.6666666666666665
+24826.0,S. Michel,182,Union Berlin,78,Bundesliga,2022,3,3,1,11,3.6666666666666665
+19364.0,N. Maupay,51,Brighton,39,Premier League,2021,4,3,1,11,2.75
+753.0,Marcos Llorente,530,Atletico Madrid,140,La Liga,2023,4,3,1,11,2.75
+20535.0,H. Diallo,95,Strasbourg,61,Ligue 1,2021,3,3,1,11,3.6666666666666665
+67972.0,C. Gallagher,52,Crystal Palace,39,Premier League,2021,4,3,1,11,2.75
+94562.0,S. Giménez,489,AC Milan,135,Serie A,2024,4,3,1,11,2.75
+154.0,L. Messi,85,Paris Saint Germain,61,Ligue 1,2021,4,1,4,11,2.75
+726.0,A. Kramarić,167,1899 Hoffenheim,78,Bundesliga,2021,4,1,4,11,2.75
+147859.0,C. De Ketelaere,499,Atalanta,135,Serie A,2023,3,3,1,11,3.6666666666666665
+37724.0,C. Summerville,63,Leeds,39,Premier League,2022,4,3,1,11,2.75
+135513.0,O. Vilhelmsson,181,SV Darmstadt 98,78,Bundesliga,2023,4,3,1,11,2.75
+424.0,S. Skrzybski,191,Holstein Kiel,78,Bundesliga,2024,3,3,1,11,3.6666666666666665
+39245.0,Ibrahima Kone,97,Lorient,61,Ligue 1,2022,4,3,1,11,2.75
+39095.0,E. Rashani,99,Clermont Foot,61,Ligue 1,2021,3,3,1,11,3.6666666666666665
+1570.0,Sergio Canales,543,Real Betis,140,La Liga,2021,4,3,1,11,2.75
+22264.0,Ludovic Ajorque,106,Stade Brestois 29,61,Ligue 1,2024,4,3,1,11,2.75
+31094.0,A. Pinamonti,495,Genoa,135,Serie A,2024,4,3,1,11,2.75
+284324.0,A. Garnacho,33,Manchester United,39,Premier League,2024,4,3,1,11,2.75
+26475.0,D. Undav,172,VfB Stuttgart,78,Bundesliga,2024,4,3,1,11,2.75
+284324.0,A. Garnacho,33,Manchester United,39,Premier League,2022,4,3,1,11,2.75
+2413.0,Richarlison,47,Tottenham,39,Premier League,2023,3,2,2,10,3.3333333333333335
+265363.0,Tiago Tomás,172,VfB Stuttgart,78,Bundesliga,2022,4,2,2,10,2.5
+277.0,M. Diaby,66,Aston Villa,39,Premier League,2023,5,0,5,10,2.0
+927.0,Lee Kang-In,85,Paris Saint Germain,61,Ligue 1,2024,4,2,2,10,2.5
+162210.0,Arne Engels,170,FC Augsburg,78,Bundesliga,2023,4,2,2,10,2.5
+1358.0,E. Elmas,492,Napoli,135,Serie A,2022,4,2,2,10,2.5
+1375.0,Roberto Soldado,539,Levante,140,La Liga,2021,4,2,2,10,2.5
+181812.0,J. Musiala,157,Bayern München,78,Bundesliga,2022,4,2,2,10,2.5
+1417.0,Alexis Saelemaekers,500,Bologna,135,Serie A,2023,4,2,2,10,2.5
+161904.0,B. Barcola,80,Lyon,61,Ligue 1,2022,4,2,2,10,2.5
+2938.0,J. Ward-Prowse,48,West Ham,39,Premier League,2023,4,2,2,10,2.5
+20761.0,F. Sotoca,116,Lens,61,Ligue 1,2022,4,2,2,10,2.5
+140831.0,Zito Luvumbo,490,Cagliari,135,Serie A,2023,4,2,2,10,2.5
+19035.0,H. Elliott,40,Liverpool,39,Premier League,2023,4,2,2,10,2.5
+18784.0,J. Maddison,47,Tottenham,39,Premier League,2024,4,2,2,10,2.5
+46973.0,Josan Ferrández,797,Elche,140,La Liga,2021,4,2,2,10,2.5
+350037.0,N. Paz,895,Como,135,Serie A,2024,4,2,2,10,2.5
+633.0,İ. Gündoğan,529,Barcelona,140,La Liga,2023,4,2,2,10,2.5
+2413.0,Richarlison,45,Everton,39,Premier League,2021,4,2,2,10,2.5
+129695.0,D. Bakwa,95,Strasbourg,61,Ligue 1,2024,3,2,2,10,3.3333333333333335
+928.0,Dani Parejo,533,Villarreal,140,La Liga,2022,4,2,2,10,2.5
+2955.0,S. Khaoui,99,Clermont Foot,61,Ligue 1,2022,4,2,2,10,2.5
+1100.0,E. Haaland,50,Manchester City,39,Premier League,2024,4,2,2,10,2.5
+47311.0,Mikel Merino,548,Real Sociedad,140,La Liga,2023,4,2,2,10,2.5
+178749.0,L. Samardžić,494,Udinese,135,Serie A,2021,4,2,2,10,2.5
+47520.0,Portu,547,Girona,140,La Liga,2023,4,2,2,10,2.5
+18970.0,P. Groß,51,Brighton,39,Premier League,2022,4,2,2,10,2.5
+931.0,Ferran Torres,529,Barcelona,140,La Liga,2023,3,2,2,10,3.3333333333333335
+36902.0,T. Reijnders,489,AC Milan,135,Serie A,2024,4,2,2,10,2.5
+18906.0,Ayoze Pérez,46,Leicester,39,Premier League,2021,2,2,2,10,5.0
+15592.0,J. Stage,162,Werder Bremen,78,Bundesliga,2024,4,2,2,10,2.5
+18929.0,D. McNeil,45,Everton,39,Premier League,2023,3,2,2,10,3.3333333333333335
+691.0,Tetê,80,Lyon,61,Ligue 1,2021,3,2,2,10,3.3333333333333335
+67972.0,C. Gallagher,49,Chelsea,39,Premier League,2023,4,2,2,10,2.5
+875.0,P. Dybala,496,Juventus,135,Serie A,2021,4,2,2,10,2.5
+791.0,S. El Shaarawy,497,AS Roma,135,Serie A,2023,4,2,2,10,2.5
+726.0,A. Kramarić,167,1899 Hoffenheim,78,Bundesliga,2022,3,2,2,10,3.3333333333333335
+50502.0,Álvaro Negredo,724,Cadiz,140,La Liga,2021,4,2,2,10,2.5
+19569.0,J. Gelhardt,63,Leeds,39,Premier League,2021,4,2,2,10,2.5
+1465.0,P. Aubameyang,81,Marseille,61,Ligue 1,2023,4,2,2,10,2.5
+37186.0,C. Dessers,520,Cremonese,135,Serie A,2022,4,2,2,10,2.5
+51617.0,D. Núñez,40,Liverpool,39,Premier League,2024,3,2,2,10,3.3333333333333335
+792.0,J. Kluivert,35,Bournemouth,39,Premier League,2024,3,2,2,10,3.3333333333333335
+20589.0,B. Mbeumo,55,Brentford,39,Premier League,2024,4,2,2,10,2.5
+51070.0,Z. Ibrahimović,489,AC Milan,135,Serie A,2021,4,2,2,10,2.5
+22222.0,Z. Çelik,79,Lille,61,Ligue 1,2021,3,2,2,10,3.3333333333333335
+283323.0,Léo Scienza,180,1. FC Heidenheim,78,Bundesliga,2024,4,2,2,10,2.5
+1485.0,Bruno Fernandes,33,Manchester United,39,Premier League,2024,4,2,2,10,2.5
+274300.0,M. Akliouche,91,Monaco,61,Ligue 1,2024,4,2,2,10,2.5
+1709.0,K. Toko-Ekambi,80,Lyon,61,Ligue 1,2021,4,2,2,10,2.5
+30531.0,J. Boga,84,Nice,61,Ligue 1,2023,4,2,2,10,2.5
+1485.0,Bruno Fernandes,33,Manchester United,39,Premier League,2021,4,2,2,10,2.5
+30488.0,R. Orsolini,500,Bologna,135,Serie A,2021,4,2,2,10,2.5
+8500.0,W. Endō,172,VfB Stuttgart,78,Bundesliga,2022,4,2,2,10,2.5
+6011.0,R. Borré,169,Eintracht Frankfurt,78,Bundesliga,2022,3,2,2,10,3.3333333333333335
+1821.0,F. Kostić,169,Eintracht Frankfurt,78,Bundesliga,2021,4,2,2,10,2.5
+6002.0,E. Palacios,168,Bayer Leverkusen,78,Bundesliga,2023,4,2,2,10,2.5
+19428.0,J. Bowen,48,West Ham,39,Premier League,2024,4,2,2,10,2.5
+6009.0,J. Alvarez,50,Manchester City,39,Premier League,2023,4,2,2,10,2.5
+633.0,İ. Gündoğan,50,Manchester City,39,Premier League,2021,3,2,2,10,3.3333333333333335
+22.0,J. Bruun Larsen,167,1899 Hoffenheim,78,Bundesliga,2024,3,2,2,10,3.3333333333333335
+18784.0,J. Maddison,46,Leicester,39,Premier League,2022,4,1,3,9,2.25
+59.0,Álvaro Morata,530,Atletico Madrid,140,La Liga,2022,2,3,0,9,4.5
+361348.0,M. Fofana,80,Lyon,61,Ligue 1,2023,3,3,0,9,3.0
+8.0,Raphaël Guerreiro,165,Borussia Dortmund,78,Bundesliga,2022,4,1,3,9,2.25
+18833.0,Lucas Pérez,724,Cadiz,140,La Liga,2022,3,3,0,9,3.0
+18788.0,J. Vardy,46,Leicester,39,Premier League,2024,3,1,3,9,3.0
+18883.0,D. Solanke,35,Bournemouth,39,Premier League,2023,3,3,0,9,3.0
+17641.0,E. Adebayo,1359,Luton,39,Premier League,2023,3,3,0,9,3.0
+328225.0,B. Gruda,51,Brighton,39,Premier League,2024,3,1,3,9,3.0
+1124.0,O. Burke,162,Werder Bremen,78,Bundesliga,2024,3,3,0,9,3.0
+1135.0,O. Édouard,52,Crystal Palace,39,Premier League,2021,2,3,0,9,4.5
+47319.0,Willian José,543,Real Betis,140,La Liga,2021,3,3,0,9,3.0
+933.0,K. Gameiro,95,Strasbourg,61,Ligue 1,2022,3,3,0,9,3.0
+930.0,Carlos Soler,532,Valencia,140,La Liga,2021,3,3,0,9,3.0
+984.0,J. Brandt,165,Borussia Dortmund,78,Bundesliga,2021,3,1,3,9,3.0
+47085.0,Luis Milla,715,Granada CF,140,La Liga,2021,4,1,3,9,2.25
+47336.0,Darder,798,Mallorca,140,La Liga,2023,4,1,3,9,2.25
+47323.0,Mikel Oyarzabal,548,Real Sociedad,140,La Liga,2021,3,3,0,9,3.0
+935.0,Rodrigo,63,Leeds,39,Premier League,2022,3,3,0,9,3.0
+937.0,Rubén Sobrino,724,Cadiz,140,La Liga,2021,3,3,0,9,3.0
+47525.0,Anthony Lozano,724,Cadiz,140,La Liga,2021,3,3,0,9,3.0
+46751.0,Abdón Prats,798,Mallorca,140,La Liga,2023,2,3,0,9,4.5
+47291.0,Gorka Guruzeta,531,Athletic Club,140,La Liga,2024,3,3,0,9,3.0
+3033.0,C. Bakambu,81,Marseille,61,Ligue 1,2021,3,3,0,9,3.0
+47445.0,Iago Aspas,538,Celta Vigo,140,La Liga,2023,4,1,3,9,2.25
+47472.0,Borja Mayoral,546,Getafe,140,La Liga,2022,3,3,0,9,3.0
+47472.0,Borja Mayoral,546,Getafe,140,La Liga,2024,3,3,0,9,3.0
+47467.0,José Luis Morales,533,Villarreal,140,La Liga,2023,3,3,0,9,3.0
+897.0,M. Greenwood,81,Marseille,61,Ligue 1,2024,3,3,0,9,3.0
+30410.0,F. Chiesa,496,Juventus,135,Serie A,2022,4,1,3,9,2.25
+2676.0,Rúben Neves,39,Wolves,39,Premier League,2021,3,3,0,9,3.0
+2678.0,Diogo Jota,40,Liverpool,39,Premier League,2023,3,3,0,9,3.0
+6420.0,M. Retegui,499,Atalanta,135,Serie A,2024,3,3,0,9,3.0
+1941.0,M. Ingvartsen,164,FSV Mainz 05,78,Bundesliga,2021,3,3,0,9,3.0
+1941.0,M. Ingvartsen,164,FSV Mainz 05,78,Bundesliga,2022,3,3,0,9,3.0
+30414.0,G. Simeone,504,Verona,135,Serie A,2021,3,3,0,9,3.0
+30407.0,Christian Nørgaard,55,Brentford,39,Premier League,2021,4,1,3,9,2.25
+25158.0,D. Raum,167,1899 Hoffenheim,78,Bundesliga,2021,4,1,3,9,2.25
+25008.0,J. Clauss,116,Lens,61,Ligue 1,2021,4,1,3,9,2.25
+583.0,João Félix,530,Atletico Madrid,140,La Liga,2022,2,3,0,9,4.5
+1863.0,C. Immobile,487,Lazio,135,Serie A,2021,3,3,0,9,3.0
+1930.0,J. Mæhle,161,VfL Wolfsburg,78,Bundesliga,2024,4,1,3,9,2.25
+26315.0,N. González,502,Fiorentina,135,Serie A,2022,3,3,0,9,3.0
+125743.0,Beto,494,Udinese,135,Serie A,2021,3,3,0,9,3.0
+127769.0,Gabriel Martinelli,42,Arsenal,39,Premier League,2022,3,3,0,9,3.0
+113581.0,T. Coulibaly,172,VfB Stuttgart,78,Bundesliga,2022,3,3,0,9,3.0
+115589.0,B. Šeško,173,RB Leipzig,78,Bundesliga,2023,2,3,0,9,4.5
+127769.0,Gabriel Martinelli,42,Arsenal,39,Premier League,2023,2,3,0,9,4.5
+30440.0,R. Piccoli,867,Lecce,135,Serie A,2023,3,3,0,9,3.0
+30573.0,L. Pavoletti,490,Cagliari,135,Serie A,2023,2,3,0,9,4.5
+30544.0,G. Scamacca,488,Sassuolo,135,Serie A,2021,3,3,0,9,3.0
+13489.0,J. Durán,66,Aston Villa,39,Premier League,2024,3,3,0,9,3.0
+13736.0,Daniel Muñoz,52,Crystal Palace,39,Premier League,2024,4,1,3,9,2.25
+13489.0,J. Durán,66,Aston Villa,39,Premier League,2023,2,3,0,9,4.5
+30488.0,R. Orsolini,500,Bologna,135,Serie A,2024,3,3,0,9,3.0
+30486.0,M. Destro,495,Genoa,135,Serie A,2021,2,3,0,9,4.5
+1696.0,S. Chukwueze,533,Villarreal,140,La Liga,2022,3,1,3,9,3.0
+19337.0,O. McBurnie,62,Sheffield Utd,39,Premier League,2023,3,3,0,9,3.0
+19337.0,O. McBurnie,534,Las Palmas,140,La Liga,2024,4,1,3,9,2.25
+19366.0,O. Watkins,66,Aston Villa,39,Premier League,2021,3,3,0,9,3.0
+18906.0,Ayoze Pérez,533,Villarreal,140,La Liga,2024,3,3,0,9,3.0
+8489.0,J. David,79,Lille,61,Ligue 1,2023,2,3,0,9,4.5
+3428.0,J. Ayew,46,Leicester,39,Premier League,2024,3,3,0,9,3.0
+272.0,A. Rabiot,81,Marseille,61,Ligue 1,2024,3,3,0,9,3.0
+182181.0,Jesús Areso,727,Osasuna,140,La Liga,2023,4,1,3,9,2.25
+910.0,A. Sánchez,505,Inter,135,Serie A,2021,3,3,0,9,3.0
+20617.0,S. Katompa Mvumpa,172,VfB Stuttgart,78,Bundesliga,2022,3,3,0,9,3.0
+20634.0,A. Claude-Maurice,116,Lens,61,Ligue 1,2022,3,1,3,9,3.0
+333.0,A. Milik,496,Juventus,135,Serie A,2022,3,3,0,9,3.0
+178749.0,L. Samardžić,494,Udinese,135,Serie A,2023,3,3,0,9,3.0
+158054.0,N. Woltemade,172,VfB Stuttgart,78,Bundesliga,2024,3,3,0,9,3.0
+2810.0,D. Zakaria,91,Monaco,61,Ligue 1,2024,3,3,0,9,3.0
+1370.0,A. Ayew,111,Le Havre,61,Ligue 1,2023,2,3,0,9,4.5
+1323.0,Dani Olmo,529,Barcelona,140,La Liga,2024,3,3,0,9,3.0
+1161.0,E. Smith Rowe,42,Arsenal,39,Premier League,2021,3,3,0,9,3.0
+2906.0,Lee Jae-Sung,164,FSV Mainz 05,78,Bundesliga,2023,2,3,0,9,4.5
+2781.0,M. Simon,83,Nantes,61,Ligue 1,2024,4,1,3,9,2.25
+2672.0,Iker Muniain,531,Athletic Club,140,La Liga,2021,3,3,0,9,3.0
+2668.0,Mostafa Mohamed,83,Nantes,61,Ligue 1,2022,3,3,0,9,3.0
+2668.0,Mostafa Mohamed,83,Nantes,61,Ligue 1,2024,3,3,0,9,3.0
+2780.0,V. Osimhen,492,Napoli,135,Serie A,2021,3,3,0,9,3.0
+61774.0,O. Óskarsson,548,Real Sociedad,140,La Liga,2024,2,3,0,9,4.5
+1707.0,Gerard Moreno,533,Villarreal,140,La Liga,2022,3,3,0,9,3.0
+30807.0,S. Fofana,116,Lens,61,Ligue 1,2021,3,3,0,9,3.0
+24288.0,M. Bayo,111,Le Havre,61,Ligue 1,2023,2,3,0,9,4.5
+715.0,C. Baumgartner,173,RB Leipzig,78,Bundesliga,2023,3,3,0,9,3.0
+667.0,Memphis Depay,529,Barcelona,140,La Liga,2021,3,3,0,9,3.0
+70514.0,A. Gigović,191,Holstein Kiel,78,Bundesliga,2024,3,3,0,9,3.0
+794.0,P. Schick,168,Bayer Leverkusen,78,Bundesliga,2021,3,3,0,9,3.0
+757.0,Lucas Vázquez,541,Real Madrid,140,La Liga,2022,3,3,0,9,3.0
+304.0,S. Mané,40,Liverpool,39,Premier League,2021,2,3,0,9,4.5
+305.0,D. Origi,40,Liverpool,39,Premier League,2021,3,3,0,9,3.0
+181812.0,J. Musiala,157,Bayern München,78,Bundesliga,2024,3,3,0,9,3.0
+202736.0,P. Nebel,164,FSV Mainz 05,78,Bundesliga,2024,3,3,0,9,3.0
+2825.0,A. Mitrović,36,Fulham,39,Premier League,2022,3,3,0,9,3.0
+2864.0,A. Isak,34,Newcastle,39,Premier League,2022,3,3,0,9,3.0
+147831.0,A. Kalimuendo,94,Rennes,61,Ligue 1,2024,3,3,0,9,3.0
+197448.0,Yan Couto,547,Girona,140,La Liga,2023,4,1,3,9,2.25
+302.0,Roberto Firmino,40,Liverpool,39,Premier League,2021,4,1,3,9,2.25
+135775.0,Ansu Fati,529,Barcelona,140,La Liga,2022,3,3,0,9,3.0
+552.0,David Neres,492,Napoli,135,Serie A,2024,4,1,3,9,2.25
+137303.0,E. Guessand,84,Nice,61,Ligue 1,2023,3,3,0,9,3.0
+415.0,W. McKennie,496,Juventus,135,Serie A,2021,3,3,0,9,3.0
+149557.0,K. Paredes,161,VfL Wolfsburg,78,Bundesliga,2022,4,1,3,9,2.25
+426.0,M. Uth,192,1.FC Köln,78,Bundesliga,2021,4,1,3,9,2.25
+484.0,A. Miranchuk,499,Atalanta,135,Serie A,2021,3,1,3,9,3.0
+33321.0,K. Nakamura,93,Reims,61,Ligue 1,2024,3,3,0,9,3.0
+41621.0,Matheus Nunes,50,Manchester City,39,Premier League,2024,4,1,3,9,2.25
+20649.0,Yoane Wissa,55,Brentford,39,Premier League,2024,3,3,0,9,3.0
+1456.0,A. Maitland-Niles,80,Lyon,61,Ligue 1,2023,4,1,3,9,2.25
+31692.0,M. Đurić,504,Verona,135,Serie A,2023,3,3,0,9,3.0
+244.0,S. Bergwijn,47,Tottenham,39,Premier League,2021,2,3,0,9,4.5
+246.0,L. de Jong,529,Barcelona,140,La Liga,2021,3,3,0,9,3.0
+247.0,C. Gakpo,40,Liverpool,39,Premier League,2023,3,3,0,9,3.0
+31173.0,D. Frattesi,505,Inter,135,Serie A,2023,3,3,0,9,3.0
+31092.0,D. Ciofani,520,Cremonese,135,Serie A,2022,3,3,0,9,3.0
+59421.0,D. Mosquera,504,Verona,135,Serie A,2024,3,3,0,9,3.0
+1485.0,Bruno Fernandes,33,Manchester United,39,Premier League,2022,4,1,3,9,2.25
+31436.0,F. Bonazzoli,514,Salernitana,135,Serie A,2021,3,3,0,9,3.0
+249.0,D. Malen,165,Borussia Dortmund,78,Bundesliga,2023,3,3,0,9,3.0
+66817.0,N. Krstović,867,Lecce,135,Serie A,2023,3,3,0,9,3.0
+791.0,S. El Shaarawy,497,AS Roma,135,Serie A,2021,3,3,0,9,3.0
+35544.0,J. Vásquez,495,Genoa,135,Serie A,2024,3,3,0,9,3.0
+37127.0,Martin Ødegaard,42,Arsenal,39,Premier League,2023,4,1,3,9,2.25
+1243.0,Tomáš Souček,48,West Ham,39,Premier League,2023,3,3,0,9,3.0
+50048.0,V. Muriqi,798,Mallorca,140,La Liga,2023,3,3,0,9,3.0
+50048.0,V. Muriqi,798,Mallorca,140,La Liga,2024,3,3,0,9,3.0
+875.0,P. Dybala,497,AS Roma,135,Serie A,2022,3,3,0,9,3.0
+53535.0,E. Shomurodov,497,AS Roma,135,Serie A,2021,4,1,3,9,2.25
+41300.0,Jubal,108,Auxerre,61,Ligue 1,2024,2,3,0,9,4.5
+41323.0,Mama Baldé,80,Lyon,61,Ligue 1,2023,3,1,3,9,3.0
+48577.0,N. Bajrami,511,Empoli,135,Serie A,2021,4,1,3,9,2.25
+19974.0,I. Toney,55,Brentford,39,Premier League,2021,2,3,0,9,4.5
+22236.0,Rafael Leão,489,AC Milan,135,Serie A,2021,3,3,0,9,3.0
+47576.0,Gonzalo Melero,539,Levante,140,La Liga,2021,3,3,0,9,3.0
+86.0,L. Openda,173,RB Leipzig,78,Bundesliga,2023,3,3,0,9,3.0
+184.0,Harry Kane,47,Tottenham,39,Premier League,2021,4,1,3,9,2.25
+25464.0,M. Ducksch,162,Werder Bremen,78,Bundesliga,2022,3,3,0,9,3.0
+25464.0,M. Ducksch,162,Werder Bremen,78,Bundesliga,2023,3,1,3,9,3.0
+15797.0,J. Cajuste,93,Reims,61,Ligue 1,2022,3,3,0,9,3.0
+18830.0,M. Arnautović,505,Inter,135,Serie A,2023,4,1,3,9,2.25
+25458.0,D. Lukébakio,159,Hertha Berlin,78,Bundesliga,2022,3,3,0,9,3.0
+47398.0,Pere Milla,540,Espanyol,140,La Liga,2024,3,3,0,9,3.0
+47348.0,Borja Iglesias,543,Real Betis,140,La Liga,2021,3,3,0,9,3.0
+156477.0,R. Cherki,80,Lyon,61,Ligue 1,2022,4,1,3,9,2.25
+156477.0,R. Cherki,80,Lyon,61,Ligue 1,2023,3,1,3,9,3.0
+1096.0,Dominik Szoboszlai,173,RB Leipzig,78,Bundesliga,2022,3,3,0,9,3.0
+288006.0,R. Højlund,499,Atalanta,135,Serie A,2022,3,3,0,9,3.0
+30409.0,J. Veretout,497,AS Roma,135,Serie A,2021,4,1,3,9,2.25
+26475.0,D. Undav,172,VfB Stuttgart,78,Bundesliga,2023,3,3,0,9,3.0
+2060.0,M. El Haddadi,537,Leganes,140,La Liga,2024,3,3,0,9,3.0
+217.0,Lautaro Martínez,505,Inter,135,Serie A,2024,3,3,0,9,3.0
+226.0,D. Dumfries,505,Inter,135,Serie A,2024,3,3,0,9,3.0
+26260.0,L. Waldschmidt,161,VfL Wolfsburg,78,Bundesliga,2022,3,3,0,9,3.0
+1946.0,L. Trossard,42,Arsenal,39,Premier League,2023,3,3,0,9,3.0
+2380.0,C. Akpom,79,Lille,61,Ligue 1,2024,3,3,0,9,3.0
+18883.0,D. Solanke,47,Tottenham,39,Premier League,2024,3,3,0,9,3.0
+658.0,H. Aouar,80,Lyon,61,Ligue 1,2021,4,1,3,9,2.25
+129791.0,Fábio Silva,534,Las Palmas,140,La Liga,2024,3,3,0,9,3.0
+53.0,Á. Correa,530,Atletico Madrid,140,La Liga,2021,3,3,0,9,3.0
+25389.0,I. Bebou,167,1899 Hoffenheim,78,Bundesliga,2023,3,2,1,8,2.6666666666666665
+2495.0,D. Zapata,499,Atalanta,135,Serie A,2021,2,2,1,8,4.0
+2507.0,M. Almirón,34,Newcastle,39,Premier League,2022,3,2,1,8,2.6666666666666665
+339883.0,K. Yıldız,496,Juventus,135,Serie A,2024,3,2,1,8,2.6666666666666665
+116.0,K. Thuram,84,Nice,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+2295.0,O. Giroud,489,AC Milan,135,Serie A,2023,4,0,4,8,2.0
+26248.0,V. Grifo,160,SC Freiburg,78,Bundesliga,2022,3,2,1,8,2.6666666666666665
+2206.0,B. Bourigeaud,94,Rennes,61,Ligue 1,2022,3,2,1,8,2.6666666666666665
+30408.0,Gerson,81,Marseille,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+2032.0,J. Strand Larsen,39,Wolves,39,Premier League,2024,3,2,1,8,2.6666666666666665
+211.0,M. Vecino,487,Lazio,135,Serie A,2024,3,2,1,8,2.6666666666666665
+277191.0,A. Sima,106,Stade Brestois 29,61,Ligue 1,2024,2,2,1,8,4.0
+274328.0,S. Sow,1063,Saint Etienne,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+305730.0,Jack Hinshelwood,51,Brighton,39,Premier League,2024,3,2,1,8,2.6666666666666665
+26845.0,T. Douvikas,538,Celta Vigo,140,La Liga,2024,3,2,1,8,2.6666666666666665
+28382.0,H. Tabaković,167,1899 Hoffenheim,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+311067.0,S. Castro,500,Bologna,135,Serie A,2024,2,2,1,8,4.0
+309920.0,M. Sahi,95,Strasbourg,61,Ligue 1,2023,3,2,1,8,2.6666666666666665
+26315.0,N. González,502,Fiorentina,135,Serie A,2021,3,2,1,8,2.6666666666666665
+47393.0,Marc Cardona,534,Las Palmas,140,La Liga,2023,2,2,1,8,4.0
+1097.0,M. Dabbur,167,1899 Hoffenheim,78,Bundesliga,2021,3,2,1,8,2.6666666666666665
+47389.0,Joan Jordán,542,Alaves,140,La Liga,2024,3,2,1,8,2.6666666666666665
+19004.0,B. De Cordova-Reid,36,Fulham,39,Premier League,2023,3,2,1,8,2.6666666666666665
+10135.0,Bruno Guimarães,34,Newcastle,39,Premier League,2022,3,2,1,8,2.6666666666666665
+10135.0,Bruno Guimarães,34,Newcastle,39,Premier League,2024,3,2,1,8,2.6666666666666665
+19030.0,M. O'Riley,51,Brighton,39,Premier League,2024,3,2,1,8,2.6666666666666665
+19032.0,R. Sessegnon,36,Fulham,39,Premier League,2024,3,2,1,8,2.6666666666666665
+2939.0,C. Wilson,34,Newcastle,39,Premier League,2023,3,2,1,8,2.6666666666666665
+21154.0,F. Tait,94,Rennes,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+21138.0,R. Aït-Nouri,39,Wolves,39,Premier League,2024,3,2,1,8,2.6666666666666665
+21443.0,T. Savanier,82,Montpellier,61,Ligue 1,2023,3,2,1,8,2.6666666666666665
+348888.0,M. Kömür,170,FC Augsburg,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+2287.0,R. Barkley,66,Aston Villa,39,Premier League,2024,3,2,1,8,2.6666666666666665
+17.0,C. Pulišić,489,AC Milan,135,Serie A,2024,3,2,1,8,2.6666666666666665
+25614.0,E. Löwen,176,VfL Bochum,78,Bundesliga,2021,3,2,1,8,2.6666666666666665
+2287.0,R. Barkley,84,Nice,61,Ligue 1,2022,2,2,1,8,4.0
+2286.0,D. Zappacosta,499,Atalanta,135,Serie A,2023,3,2,1,8,2.6666666666666665
+25635.0,J. Hofmann,163,Borussia Mönchengladbach,78,Bundesliga,2021,3,2,1,8,2.6666666666666665
+18778.0,H. Barnes,34,Newcastle,39,Premier League,2024,3,2,1,8,2.6666666666666665
+1496.0,Raphinha,529,Barcelona,140,La Liga,2022,3,2,1,8,2.6666666666666665
+22097.0,Arnaud Nordin,82,Montpellier,61,Ligue 1,2024,3,2,1,8,2.6666666666666665
+22174.0,A. Tamèze,504,Verona,135,Serie A,2021,3,2,1,8,2.6666666666666665
+22177.0,I. Ganago,116,Lens,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+2737.0,M. Braithwaite,540,Espanyol,140,La Liga,2022,3,2,1,8,2.6666666666666665
+902.0,N. Matić,497,AS Roma,135,Serie A,2022,3,2,1,8,2.6666666666666665
+855.0,João Cancelo,529,Barcelona,140,La Liga,2023,2,2,1,8,4.0
+778.0,B. Cristante,497,AS Roma,135,Serie A,2024,3,2,1,8,2.6666666666666665
+785.0,C. Ünder,81,Marseille,61,Ligue 1,2021,2,2,1,8,4.0
+50856.0,V. Castellanos,487,Lazio,135,Serie A,2024,3,2,1,8,2.6666666666666665
+762.0,Vinícius Júnior,541,Real Madrid,140,La Liga,2024,3,2,1,8,2.6666666666666665
+778.0,B. Cristante,497,AS Roma,135,Serie A,2023,2,2,1,8,4.0
+22093.0,R. Cabella,79,Lille,61,Ligue 1,2022,3,2,1,8,2.6666666666666665
+22095.0,Romain Hamouma,1063,Saint Etienne,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+37127.0,Martin Ødegaard,42,Arsenal,39,Premier League,2021,3,2,1,8,2.6666666666666665
+37127.0,Martin Ødegaard,42,Arsenal,39,Premier League,2022,3,2,1,8,2.6666666666666665
+1321.0,L. Majer,94,Rennes,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+1300.0,M. Daramy,93,Reims,61,Ligue 1,2023,3,2,1,8,2.6666666666666665
+1273.0,J. Briand,78,Bordeaux,61,Ligue 1,2021,2,2,1,8,4.0
+745.0,Isco,543,Real Betis,140,La Liga,2023,3,2,1,8,2.6666666666666665
+19549.0,A. Robinson,36,Fulham,39,Premier League,2024,4,0,4,8,2.0
+56396.0,Junior Messias,489,AC Milan,135,Serie A,2022,3,2,1,8,2.6666666666666665
+746.0,Marco Asensio,66,Aston Villa,39,Premier League,2024,2,2,1,8,4.0
+66019.0,Adam Hložek,167,1899 Hoffenheim,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+790.0,E. Džeko,505,Inter,135,Serie A,2021,3,2,1,8,2.6666666666666665
+2780.0,V. Osimhen,492,Napoli,135,Serie A,2022,3,2,1,8,2.6666666666666665
+2780.0,V. Osimhen,492,Napoli,135,Serie A,2023,3,2,1,8,2.6666666666666665
+265363.0,Tiago Tomás,161,VfL Wolfsburg,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+202.0,A. Candreva,498,Sampdoria,135,Serie A,2021,3,2,1,8,2.6666666666666665
+1583.0,Sergio León,720,Valladolid,140,La Liga,2022,3,2,1,8,2.6666666666666665
+1649.0,P. Cutrone,895,Como,135,Serie A,2024,3,2,1,8,2.6666666666666665
+1469.0,D. Welbeck,51,Brighton,39,Premier League,2023,3,2,1,8,2.6666666666666665
+1461.0,Denis Suárez,538,Celta Vigo,140,La Liga,2021,3,2,1,8,2.6666666666666665
+32940.0,Ado Onaiwu,96,Toulouse,61,Ligue 1,2022,3,2,1,8,2.6666666666666665
+1460.0,B. Saka,42,Arsenal,39,Premier League,2021,3,2,1,8,2.6666666666666665
+1460.0,B. Saka,42,Arsenal,39,Premier League,2022,3,2,1,8,2.6666666666666665
+1455.0,A. Iwobi,36,Fulham,39,Premier League,2024,3,2,1,8,2.6666666666666665
+1578.0,G. Lo Celso,543,Real Betis,140,La Liga,2024,3,2,1,8,2.6666666666666665
+36907.0,M. Boadu,91,Monaco,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+181908.0,J. Thielmann,192,1.FC Köln,78,Bundesliga,2022,3,2,1,8,2.6666666666666665
+1257.0,Jules Koundé,536,Sevilla,140,La Liga,2021,3,2,1,8,2.6666666666666665
+20649.0,Yoane Wissa,55,Brentford,39,Premier League,2023,2,2,1,8,4.0
+135519.0,G. Isaksen,487,Lazio,135,Serie A,2024,3,2,1,8,2.6666666666666665
+146008.0,M. Cham,99,Clermont Foot,61,Ligue 1,2022,3,2,1,8,2.6666666666666665
+147831.0,A. Kalimuendo,94,Rennes,61,Ligue 1,2023,3,2,1,8,2.6666666666666665
+416.0,S. Rudy,167,1899 Hoffenheim,78,Bundesliga,2021,3,2,1,8,2.6666666666666665
+421.0,Breel Embolo,91,Monaco,61,Ligue 1,2022,3,2,1,8,2.6666666666666665
+421.0,Breel Embolo,163,Borussia Mönchengladbach,78,Bundesliga,2021,3,2,1,8,2.6666666666666665
+203224.0,F. Wirtz,168,Bayer Leverkusen,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+181812.0,J. Musiala,157,Bayern München,78,Bundesliga,2021,3,2,1,8,2.6666666666666665
+195512.0,M. Satriano,106,Stade Brestois 29,61,Ligue 1,2023,3,2,1,8,2.6666666666666665
+30543.0,G. Raspadori,492,Napoli,135,Serie A,2023,3,2,1,8,2.6666666666666665
+30803.0,A. Barák,504,Verona,135,Serie A,2021,3,2,1,8,2.6666666666666665
+67971.0,Marc Guéhi,52,Crystal Palace,39,Premier League,2024,3,2,1,8,2.6666666666666665
+756.0,F. Valverde,541,Real Madrid,140,La Liga,2022,3,2,1,8,2.6666666666666665
+70100.0,J. Zirkzee,500,Bologna,135,Serie A,2023,3,2,1,8,2.6666666666666665
+667.0,Memphis Depay,530,Atletico Madrid,140,La Liga,2023,3,2,1,8,2.6666666666666665
+668.0,N. Fekir,543,Real Betis,140,La Liga,2021,4,0,4,8,2.0
+102447.0,F. Moumbagna,81,Marseille,61,Ligue 1,2023,2,2,1,8,4.0
+19281.0,A. Semenyo,35,Bournemouth,39,Premier League,2023,3,2,1,8,2.6666666666666665
+81573.0,Omar Marmoush,172,VfB Stuttgart,78,Bundesliga,2021,2,2,1,8,4.0
+30790.0,G. Lapadula,490,Cagliari,135,Serie A,2023,3,2,1,8,2.6666666666666665
+2669.0,Hermoso,530,Atletico Madrid,140,La Liga,2021,3,2,1,8,2.6666666666666665
+1707.0,Gerard Moreno,533,Villarreal,140,La Liga,2021,3,2,1,8,2.6666666666666665
+1707.0,Gerard Moreno,533,Villarreal,140,La Liga,2023,2,2,1,8,4.0
+1707.0,Gerard Moreno,533,Villarreal,140,La Liga,2024,3,2,1,8,2.6666666666666665
+24288.0,M. Bayo,79,Lille,61,Ligue 1,2022,3,2,1,8,2.6666666666666665
+23643.0,M. Guilavogui,186,FC St. Pauli,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+6085.0,C. Benavídez,542,Alaves,140,La Liga,2023,3,2,1,8,2.6666666666666665
+19974.0,I. Toney,55,Brentford,39,Premier League,2022,3,2,1,8,2.6666666666666665
+1167.0,Y. Poulsen,173,RB Leipzig,78,Bundesliga,2022,3,2,1,8,2.6666666666666665
+162707.0,E. Wahi,116,Lens,61,Ligue 1,2023,3,2,1,8,2.6666666666666665
+162267.0,A. Truffert,94,Rennes,61,Ligue 1,2021,2,2,1,8,4.0
+162033.0,Sergio Arribas,723,Almeria,140,La Liga,2023,3,2,1,8,2.6666666666666665
+138835.0,F. Balogun,91,Monaco,61,Ligue 1,2023,2,2,1,8,4.0
+153430.0,A. Elanga,65,Nottingham Forest,39,Premier League,2023,4,0,4,8,2.0
+161904.0,B. Barcola,85,Paris Saint Germain,61,Ligue 1,2024,3,2,1,8,2.6666666666666665
+47499.0,E. Ünal,35,Bournemouth,39,Premier League,2024,3,2,1,8,2.6666666666666665
+161585.0,Francisco Conceição,496,Juventus,135,Serie A,2024,3,2,1,8,2.6666666666666665
+181421.0,A. Ezzalzouli,727,Osasuna,140,La Liga,2022,3,2,1,8,2.6666666666666665
+174565.0,H. Ekitiké,93,Reims,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+178749.0,L. Samardžić,494,Udinese,135,Serie A,2022,3,2,1,8,2.6666666666666665
+178077.0,K. Schade,55,Brentford,39,Premier League,2024,3,2,1,8,2.6666666666666665
+322.0,Mário Rui,492,Napoli,135,Serie A,2021,4,0,4,8,2.0
+46933.0,Luis Rioja,542,Alaves,140,La Liga,2023,3,2,1,8,2.6666666666666665
+271.0,L. Paredes,497,AS Roma,135,Serie A,2023,3,2,1,8,2.6666666666666665
+47471.0,Roger Martí,539,Levante,140,La Liga,2021,3,2,1,8,2.6666666666666665
+907.0,R. Lukaku,492,Napoli,135,Serie A,2024,3,2,1,8,2.6666666666666665
+510.0,S. Gnabry,157,Bayern München,78,Bundesliga,2022,3,2,1,8,2.6666666666666665
+511.0,L. Goretzka,157,Bayern München,78,Bundesliga,2023,3,2,1,8,2.6666666666666665
+19250.0,B. Brahimi,84,Nice,61,Ligue 1,2022,3,2,1,8,2.6666666666666665
+6002.0,E. Palacios,168,Bayer Leverkusen,78,Bundesliga,2021,3,2,1,8,2.6666666666666665
+3406.0,Frank Anguissa,492,Napoli,135,Serie A,2024,3,2,1,8,2.6666666666666665
+508.0,K. Coman,157,Bayern München,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+19362.0,J. Dasilva,55,Brentford,39,Premier League,2022,3,2,1,8,2.6666666666666665
+19399.0,F. Forestieri,494,Udinese,135,Serie A,2021,3,2,1,8,2.6666666666666665
+30488.0,R. Orsolini,500,Bologna,135,Serie A,2023,3,2,1,8,2.6666666666666665
+10329.0,João Pedro,38,Watford,39,Premier League,2021,3,2,1,8,2.6666666666666665
+284072.0,B. Dieng,97,Lorient,61,Ligue 1,2023,3,2,1,8,2.6666666666666665
+30484.0,Mattias Svanberg,161,VfL Wolfsburg,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+30435.0,D. Kulusevski,47,Tottenham,39,Premier League,2023,3,2,1,8,2.6666666666666665
+30537.0,D. Berardi,488,Sassuolo,135,Serie A,2022,2,2,1,8,4.0
+1696.0,S. Chukwueze,489,AC Milan,135,Serie A,2024,3,2,1,8,2.6666666666666665
+1696.0,S. Chukwueze,533,Villarreal,140,La Liga,2021,3,2,1,8,2.6666666666666665
+30543.0,G. Raspadori,492,Napoli,135,Serie A,2022,3,2,1,8,2.6666666666666665
+127619.0,J. Schöppner,180,1. FC Heidenheim,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+125171.0,J. Stanišić,168,Bayer Leverkusen,78,Bundesliga,2023,2,2,1,8,4.0
+106835.0,K. Mitoma,51,Brighton,39,Premier League,2024,3,2,1,8,2.6666666666666665
+715.0,C. Baumgartner,167,1899 Hoffenheim,78,Bundesliga,2021,2,2,1,8,4.0
+583.0,João Félix,530,Atletico Madrid,140,La Liga,2021,3,2,1,8,2.6666666666666665
+631.0,P. Foden,50,Manchester City,39,Premier League,2023,3,2,1,8,2.6666666666666665
+1938.0,R. Malinovskyi,499,Atalanta,135,Serie A,2021,3,2,1,8,2.6666666666666665
+24803.0,F. Kainz,192,1.FC Köln,78,Bundesliga,2023,3,2,1,8,2.6666666666666665
+25073.0,V. Janelt,55,Brentford,39,Premier League,2022,3,2,1,8,2.6666666666666665
+2678.0,Diogo Jota,40,Liverpool,39,Premier League,2021,3,2,1,8,2.6666666666666665
+24826.0,S. Michel,182,Union Berlin,78,Bundesliga,2021,2,2,1,8,4.0
+19194.0,T. Abraham,497,AS Roma,135,Serie A,2021,3,2,1,8,2.6666666666666665
+6716.0,A. Mac Allister,51,Brighton,39,Premier League,2021,3,2,1,8,2.6666666666666665
+21104.0,R. Kolo Muani,85,Paris Saint Germain,61,Ligue 1,2024,3,2,1,8,2.6666666666666665
+47472.0,Borja Mayoral,546,Getafe,140,La Liga,2021,3,2,1,8,2.6666666666666665
+47495.0,Sergi Guardiola,728,Rayo Vallecano,140,La Liga,2021,3,2,1,8,2.6666666666666665
+1119.0,K. Ajer,55,Brentford,39,Premier League,2023,3,2,1,8,2.6666666666666665
+46689.0,Antonio Puertas,715,Granada CF,140,La Liga,2021,2,2,1,8,4.0
+47294.0,I. Williams,531,Athletic Club,140,La Liga,2021,3,2,1,8,2.6666666666666665
+47264.0,Hugo Duro,532,Valencia,140,La Liga,2023,3,2,1,8,2.6666666666666665
+47237.0,Luis Javier Suárez,715,Granada CF,140,La Liga,2021,3,2,1,8,2.6666666666666665
+973.0,M. Weiser,162,Werder Bremen,78,Bundesliga,2024,3,2,1,8,2.6666666666666665
+1138.0,T. Weah,79,Lille,61,Ligue 1,2021,3,2,1,8,2.6666666666666665
+927.0,Lee Kang-In,798,Mallorca,140,La Liga,2022,3,2,1,8,2.6666666666666665
+1149.0,Dayot Upamecano,157,Bayern München,78,Bundesliga,2021,3,0,4,8,2.6666666666666665
+25.0,M. Reus,165,Borussia Dortmund,78,Bundesliga,2021,3,2,1,8,2.6666666666666665
+18766.0,Dominic Calvert-Lewin,45,Everton,39,Premier League,2021,3,2,1,8,2.6666666666666665
+18767.0,A. Lookman,499,Atalanta,135,Serie A,2022,3,2,1,8,2.6666666666666665
+25313.0,J. Beste,180,1. FC Heidenheim,78,Bundesliga,2023,3,2,1,8,2.6666666666666665
+322560.0,L. Stassin,1063,Saint Etienne,61,Ligue 1,2024,3,2,1,8,2.6666666666666665
+335051.0,João Neves,85,Paris Saint Germain,61,Ligue 1,2024,3,0,4,8,2.6666666666666665
+83.0,A. Danjuma,533,Villarreal,140,La Liga,2021,3,2,1,8,2.6666666666666665
+56.0,A. Griezmann,530,Atletico Madrid,140,La Liga,2023,3,2,1,8,2.6666666666666665
+18.0,J. Sancho,49,Chelsea,39,Premier League,2024,3,2,1,8,2.6666666666666665
+57.0,N. Kalinić,504,Verona,135,Serie A,2021,3,2,1,8,2.6666666666666665
+59.0,Álvaro Morata,530,Atletico Madrid,140,La Liga,2023,3,2,1,8,2.6666666666666665
+52.0,Sergio Camello,728,Rayo Vallecano,140,La Liga,2022,2,2,1,8,4.0
+9.0,A. Hakimi,85,Paris Saint Germain,61,Ligue 1,2024,3,1,2,7,2.3333333333333335
+9.0,A. Hakimi,85,Paris Saint Germain,61,Ligue 1,2021,3,1,2,7,2.3333333333333335
+334334.0,K. Topp,162,Werder Bremen,78,Bundesliga,2024,3,1,2,7,2.3333333333333335
+18883.0,D. Solanke,35,Bournemouth,39,Premier League,2022,3,1,2,7,2.3333333333333335
+18809.0,Deulofeu,494,Udinese,135,Serie A,2021,3,1,2,7,2.3333333333333335
+2206.0,B. Bourigeaud,94,Rennes,61,Ligue 1,2021,3,1,2,7,2.3333333333333335
+18778.0,H. Barnes,46,Leicester,39,Premier League,2021,3,1,2,7,2.3333333333333335
+25646.0,A. Pléa,163,Borussia Mönchengladbach,78,Bundesliga,2024,3,1,2,7,2.3333333333333335
+25928.0,K. Onisiwo,164,FSV Mainz 05,78,Bundesliga,2021,3,1,2,7,2.3333333333333335
+1942.0,J. Ito,93,Reims,61,Ligue 1,2023,3,1,2,7,2.3333333333333335
+25928.0,K. Onisiwo,164,FSV Mainz 05,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+25914.0,Aarón Martín,164,FSV Mainz 05,78,Bundesliga,2022,3,1,2,7,2.3333333333333335
+128.0,Jordi Alba,529,Barcelona,140,La Liga,2021,2,1,2,7,3.5
+1942.0,J. Ito,93,Reims,61,Ligue 1,2022,3,1,2,7,2.3333333333333335
+989.0,K. Volland,182,Union Berlin,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+19025.0,T. Cairney,36,Fulham,39,Premier League,2023,3,1,2,7,2.3333333333333335
+18970.0,P. Groß,51,Brighton,39,Premier League,2021,2,1,2,7,3.5
+3007.0,P. Frankowski,116,Lens,61,Ligue 1,2021,3,1,2,7,2.3333333333333335
+10077.0,Luis Henrique,81,Marseille,61,Ligue 1,2024,3,1,2,7,2.3333333333333335
+301771.0,S. Adingra,51,Brighton,39,Premier League,2024,3,1,2,7,2.3333333333333335
+149.0,Ivan Rakitić,536,Sevilla,140,La Liga,2021,3,1,2,7,2.3333333333333335
+121.0,S. Jovetić,159,Hertha Berlin,78,Bundesliga,2022,3,1,2,7,2.3333333333333335
+1912.0,D. Payet,81,Marseille,61,Ligue 1,2022,2,1,2,7,3.5
+122233.0,Marcos André,532,Valencia,140,La Liga,2021,3,1,2,7,2.3333333333333335
+644.0,L. Sané,157,Bayern München,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+645.0,R. Sterling,49,Chelsea,39,Premier League,2023,3,1,2,7,2.3333333333333335
+583.0,João Félix,529,Barcelona,140,La Liga,2023,3,1,2,7,2.3333333333333335
+629.0,K. De Bruyne,50,Manchester City,39,Premier League,2021,3,1,2,7,2.3333333333333335
+659.0,M. Caqueret,80,Lyon,61,Ligue 1,2022,3,1,2,7,2.3333333333333335
+608.0,Lucas Boyé,797,Elche,140,La Liga,2021,3,1,2,7,2.3333333333333335
+24809.0,L. Schaub,192,1.FC Köln,78,Bundesliga,2021,3,1,2,7,2.3333333333333335
+1864.0,Pedro Neto,39,Wolves,39,Premier League,2023,3,1,2,7,2.3333333333333335
+19192.0,J. Ramsey,66,Aston Villa,39,Premier League,2022,3,1,2,7,2.3333333333333335
+138787.0,A. Gordon,34,Newcastle,39,Premier League,2023,3,1,2,7,2.3333333333333335
+510.0,S. Gnabry,157,Bayern München,78,Bundesliga,2021,3,1,2,7,2.3333333333333335
+19245.0,M. Tavernier,35,Bournemouth,39,Premier League,2024,3,1,2,7,2.3333333333333335
+30509.0,A. Belotti,497,AS Roma,135,Serie A,2023,2,1,2,7,3.5
+7562.0,R. Schmid,162,Werder Bremen,78,Bundesliga,2023,2,1,2,7,3.5
+18930.0,M. Vydra,44,Burnley,39,Premier League,2021,3,1,2,7,2.3333333333333335
+30456.0,R. Saponara,502,Fiorentina,135,Serie A,2022,2,1,2,7,3.5
+30484.0,Mattias Svanberg,161,VfL Wolfsburg,78,Bundesliga,2022,3,1,2,7,2.3333333333333335
+174.0,C. Eriksen,33,Manchester United,39,Premier League,2024,3,1,2,7,2.3333333333333335
+30490.0,N. Sansone,500,Bologna,135,Serie A,2021,3,1,2,7,2.3333333333333335
+30490.0,N. Sansone,500,Bologna,135,Serie A,2022,3,1,2,7,2.3333333333333335
+46733.0,Raíllo,798,Mallorca,140,La Liga,2023,3,1,2,7,2.3333333333333335
+47516.0,Aleix García,547,Girona,140,La Liga,2023,3,1,2,7,2.3333333333333335
+47294.0,I. Williams,531,Athletic Club,140,La Liga,2023,3,1,2,7,2.3333333333333335
+47323.0,Mikel Oyarzabal,548,Real Sociedad,140,La Liga,2024,3,1,2,7,2.3333333333333335
+984.0,J. Brandt,165,Borussia Dortmund,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+1831.0,A. Rebić,489,AC Milan,135,Serie A,2022,2,1,2,7,3.5
+30533.0,Manuel Locatelli,496,Juventus,135,Serie A,2021,3,1,2,7,2.3333333333333335
+31042.0,G. Di Lorenzo,492,Napoli,135,Serie A,2022,3,1,2,7,2.3333333333333335
+726.0,A. Kramarić,167,1899 Hoffenheim,78,Bundesliga,2024,3,1,2,7,2.3333333333333335
+717.0,K. Demirbay,168,Bayer Leverkusen,78,Bundesliga,2021,3,1,2,7,2.3333333333333335
+30879.0,A. Petagna,1579,Monza,135,Serie A,2022,3,1,2,7,2.3333333333333335
+6056.0,N. Domínguez,500,Bologna,135,Serie A,2022,3,1,2,7,2.3333333333333335
+1700.0,Iván Martín,547,Girona,140,La Liga,2022,2,1,2,7,3.5
+30810.0,R. Mandragora,502,Fiorentina,135,Serie A,2022,3,1,2,7,2.3333333333333335
+19617.0,M. Olise,52,Crystal Palace,39,Premier League,2021,2,1,2,7,3.5
+19617.0,M. Olise,157,Bayern München,78,Bundesliga,2024,3,1,2,7,2.3333333333333335
+2763.0,M. Pašalić,499,Atalanta,135,Serie A,2023,3,1,2,7,2.3333333333333335
+2735.0,Pierre-Emile Højbjerg,47,Tottenham,39,Premier League,2022,3,1,2,7,2.3333333333333335
+66817.0,N. Krstović,867,Lecce,135,Serie A,2024,3,1,2,7,2.3333333333333335
+754.0,L. Modrić,541,Real Madrid,140,La Liga,2023,3,1,2,7,2.3333333333333335
+747.0,Casemiro,33,Manchester United,39,Premier League,2022,3,1,2,7,2.3333333333333335
+745.0,Isco,543,Real Betis,140,La Liga,2024,3,1,2,7,2.3333333333333335
+19586.0,E. Eze,52,Crystal Palace,39,Premier League,2024,3,1,2,7,2.3333333333333335
+6067.0,T. Almada,80,Lyon,61,Ligue 1,2024,2,1,2,7,3.5
+61418.0,O. Bukari,83,Nantes,61,Ligue 1,2021,3,1,2,7,2.3333333333333335
+792.0,J. Kluivert,84,Nice,61,Ligue 1,2021,3,1,2,7,2.3333333333333335
+64309.0,Manu Sánchez,727,Osasuna,140,La Liga,2021,3,1,2,7,2.3333333333333335
+201.0,Marcelo Brozović,505,Inter,135,Serie A,2022,3,1,2,7,2.3333333333333335
+203.0,R. Gagliardini,505,Inter,135,Serie A,2021,3,1,2,7,2.3333333333333335
+283.0,T. Alexander-Arnold,40,Liverpool,39,Premier League,2024,3,1,2,7,2.3333333333333335
+1639.0,M. Brescianini,512,Frosinone,135,Serie A,2023,3,1,2,7,2.3333333333333335
+1640.0,H. Çalhanoğlu,505,Inter,135,Serie A,2024,3,1,2,7,2.3333333333333335
+177807.0,J. Njinmah,162,Werder Bremen,78,Bundesliga,2024,3,1,2,7,2.3333333333333335
+289.0,A. Robertson,40,Liverpool,39,Premier League,2021,3,1,2,7,2.3333333333333335
+1156.0,T. Krauß,164,FSV Mainz 05,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+329.0,P. Zieliński,492,Napoli,135,Serie A,2022,3,1,2,7,2.3333333333333335
+177807.0,J. Njinmah,162,Werder Bremen,78,Bundesliga,2023,2,1,2,7,3.5
+46764.0,Brian Oliván,540,Espanyol,140,La Liga,2022,3,1,2,7,2.3333333333333335
+46743.0,Salva Sevilla,798,Mallorca,140,La Liga,2021,3,1,2,7,2.3333333333333335
+897.0,M. Greenwood,546,Getafe,140,La Liga,2023,3,1,2,7,2.3333333333333335
+957.0,D. Sow,169,Eintracht Frankfurt,78,Bundesliga,2021,3,1,2,7,2.3333333333333335
+2724.0,L. Digne,66,Aston Villa,39,Premier League,2023,3,1,2,7,2.3333333333333335
+22261.0,A. Thomasson,116,Lens,61,Ligue 1,2024,3,1,2,7,2.3333333333333335
+22264.0,Ludovic Ajorque,95,Strasbourg,61,Ligue 1,2021,3,1,2,7,2.3333333333333335
+1457.0,Henrikh Mkhitaryan,497,AS Roma,135,Serie A,2021,3,1,2,7,2.3333333333333335
+22097.0,Arnaud Nordin,82,Montpellier,61,Ligue 1,2023,3,1,2,7,2.3333333333333335
+22244.0,A. Caci,95,Strasbourg,61,Ligue 1,2021,3,1,2,7,2.3333333333333335
+47579.0,E. Ávila,727,Osasuna,140,La Liga,2023,3,1,2,7,2.3333333333333335
+53535.0,E. Shomurodov,490,Cagliari,135,Serie A,2023,3,1,2,7,2.3333333333333335
+51494.0,M. Ugarte,33,Manchester United,39,Premier League,2024,3,1,2,7,2.3333333333333335
+37938.0,S. Becker,182,Union Berlin,78,Bundesliga,2021,3,1,2,7,2.3333333333333335
+39115.0,A. Dønnum,96,Toulouse,61,Ligue 1,2024,3,1,2,7,2.3333333333333335
+512.0,Jeong Wooyeong,172,VfB Stuttgart,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+1417.0,Alexis Saelemaekers,489,AC Milan,135,Serie A,2022,3,1,2,7,2.3333333333333335
+1422.0,J. Doku,50,Manchester City,39,Premier League,2023,2,1,2,7,3.5
+46170.0,I. Ilić,503,Torino,135,Serie A,2023,3,1,2,7,2.3333333333333335
+484.0,A. Miranchuk,499,Atalanta,135,Serie A,2023,3,1,2,7,2.3333333333333335
+136117.0,Rodrigo Riquelme,530,Atletico Madrid,140,La Liga,2023,3,1,2,7,2.3333333333333335
+187214.0,Carlos Vicente,542,Alaves,140,La Liga,2024,2,1,2,7,3.5
+283.0,T. Alexander-Arnold,40,Liverpool,39,Premier League,2021,3,1,2,7,2.3333333333333335
+162887.0,E. Millot,172,VfB Stuttgart,78,Bundesliga,2024,2,1,2,7,3.5
+522.0,T. Müller,157,Bayern München,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+925.0,Gonçalo Guedes,533,Villarreal,140,La Liga,2023,2,1,2,7,3.5
+162016.0,Xavi Simons,173,RB Leipzig,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+20784.0,F. Honorat,163,Borussia Mönchengladbach,78,Bundesliga,2023,2,1,2,7,3.5
+25297.0,M. Gregoritsch,160,SC Freiburg,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+133729.0,T. Noslin,487,Lazio,135,Serie A,2024,3,1,2,7,2.3333333333333335
+129718.0,J. Bellingham,165,Borussia Dortmund,78,Bundesliga,2021,3,1,2,7,2.3333333333333335
+25242.0,M. Bülter,167,1899 Hoffenheim,78,Bundesliga,2023,3,1,2,7,2.3333333333333335
+538.0,F. de Jong,529,Barcelona,140,La Liga,2024,2,1,2,7,3.5
+545.0,N. Mazraoui,157,Bayern München,78,Bundesliga,2022,2,1,2,7,3.5
+346866.0,S. Mbangula,496,Juventus,135,Serie A,2024,3,1,2,7,2.3333333333333335
+15811.0,A. Dovbyk,547,Girona,140,La Liga,2023,2,1,2,7,3.5
+2459.0,D. Machís,715,Granada CF,140,La Liga,2021,3,1,2,7,2.3333333333333335
+18781.0,D. Gray,45,Everton,39,Premier League,2021,3,1,2,7,2.3333333333333335
+18843.0,J. Schlupp,52,Crystal Palace,39,Premier League,2023,3,1,2,7,2.3333333333333335
+18753.0,Adama Traoré,36,Fulham,39,Premier League,2023,3,1,2,7,2.3333333333333335
+18746.0,M. Gibbs-White,65,Nottingham Forest,39,Premier League,2022,3,1,2,7,2.3333333333333335
+352990.0,A. Salama,77,Angers,61,Ligue 1,2022,2,2,0,6,3.0
+18781.0,D. Gray,45,Everton,39,Premier League,2022,2,2,0,6,3.0
+18819.0,M. Antonio,48,West Ham,39,Premier League,2022,2,2,0,6,3.0
+18741.0,C. Coady,39,Wolves,39,Premier League,2021,2,2,0,6,3.0
+18746.0,M. Gibbs-White,65,Nottingham Forest,39,Premier League,2023,2,2,0,6,3.0
+18746.0,M. Gibbs-White,65,Nottingham Forest,39,Premier League,2024,3,0,3,6,2.0
+15812.0,P. Onuachu,41,Southampton,39,Premier League,2024,2,2,0,6,3.0
+15797.0,J. Cajuste,93,Reims,61,Ligue 1,2021,2,2,0,6,3.0
+86.0,L. Openda,173,RB Leipzig,78,Bundesliga,2024,2,2,0,6,3.0
+176.0,Erik Lamela,536,Sevilla,140,La Liga,2021,2,2,0,6,3.0
+2475.0,R. Pereyra,494,Udinese,135,Serie A,2022,3,0,3,6,2.0
+25533.0,N. Schmidt,162,Werder Bremen,78,Bundesliga,2022,2,2,0,6,3.0
+2287.0,R. Barkley,1359,Luton,39,Premier League,2023,2,2,0,6,3.0
+25635.0,J. Hofmann,163,Borussia Mönchengladbach,78,Bundesliga,2022,3,0,3,6,2.0
+2299.0,Pedro,487,Lazio,135,Serie A,2022,2,2,0,6,3.0
+2291.0,M. Kovačić,50,Manchester City,39,Premier League,2024,2,2,0,6,3.0
+2294.0,Willian,36,Fulham,39,Premier League,2023,2,2,0,6,3.0
+25.0,M. Reus,165,Borussia Dortmund,78,Bundesliga,2023,2,2,0,6,3.0
+53.0,Á. Correa,530,Atletico Madrid,140,La Liga,2022,2,2,0,6,3.0
+430816.0,N. Edjouma,96,Toulouse,61,Ligue 1,2024,2,2,0,6,3.0
+400948.0,Assane Diao,895,Como,135,Serie A,2024,2,2,0,6,3.0
+402168.0,Arkaitz Mariezkurrena,548,Real Sociedad,140,La Liga,2024,2,2,0,6,3.0
+343684.0,T. Barry,533,Villarreal,140,La Liga,2024,2,2,0,6,3.0
+345748.0,C. Gómez,94,Rennes,61,Ligue 1,2024,2,2,0,6,3.0
+47422.0,Youssef En-Nesyri,536,Sevilla,140,La Liga,2022,2,2,0,6,3.0
+47422.0,Youssef En-Nesyri,536,Sevilla,140,La Liga,2023,2,2,0,6,3.0
+47396.0,Kike García,727,Osasuna,140,La Liga,2021,2,2,0,6,3.0
+928.0,Dani Parejo,533,Villarreal,140,La Liga,2024,2,2,0,6,3.0
+219.0,M. Politano,492,Napoli,135,Serie A,2023,2,2,0,6,3.0
+284072.0,B. Dieng,77,Angers,61,Ligue 1,2024,2,2,0,6,3.0
+30396.0,C. Biraghi,502,Fiorentina,135,Serie A,2022,2,2,0,6,3.0
+26343.0,S. Tigges,192,1.FC Köln,78,Bundesliga,2023,2,2,0,6,3.0
+21497.0,L. Blas,94,Rennes,61,Ligue 1,2024,2,2,0,6,3.0
+986.0,J. Pohjanpalo,517,Venezia,135,Serie A,2024,2,2,0,6,3.0
+987.0,Paulinho,168,Bayer Leverkusen,78,Bundesliga,2021,1,2,0,6,6.0
+982.0,L. Alario,168,Bayer Leverkusen,78,Bundesliga,2021,2,2,0,6,3.0
+47414.0,Gerard Gumbau,797,Elche,140,La Liga,2021,3,0,3,6,2.0
+47349.0,Javi Puado,540,Espanyol,140,La Liga,2021,2,2,0,6,3.0
+1014.0,S. Sohm,523,Parma,135,Serie A,2024,2,2,0,6,3.0
+1096.0,Dominik Szoboszlai,173,RB Leipzig,78,Bundesliga,2021,3,0,3,6,2.0
+19134.0,P. Bamford,63,Leeds,39,Premier League,2021,2,2,0,6,3.0
+19124.0,P. Jansson,55,Brentford,39,Premier League,2021,2,2,0,6,3.0
+19128.0,J. Harrison,63,Leeds,39,Premier League,2021,2,2,0,6,3.0
+8451.0,Aurélio Buta,169,Eintracht Frankfurt,78,Bundesliga,2022,2,2,0,6,3.0
+8489.0,J. David,79,Lille,61,Ligue 1,2021,2,2,0,6,3.0
+19185.0,K. Davis,494,Udinese,135,Serie A,2024,2,2,0,6,3.0
+19170.0,M. Rogers,66,Aston Villa,39,Premier League,2024,3,0,3,6,2.0
+152856.0,Evanilson,35,Bournemouth,39,Premier League,2024,2,2,0,6,3.0
+120.0,W. Geubbels,83,Nantes,61,Ligue 1,2021,2,2,0,6,3.0
+21104.0,R. Kolo Muani,169,Eintracht Frankfurt,78,Bundesliga,2022,2,2,0,6,3.0
+21103.0,A. Touré,111,Le Havre,61,Ligue 1,2024,2,2,0,6,3.0
+21592.0,G. Laborde,84,Nice,61,Ligue 1,2022,2,2,0,6,3.0
+18970.0,P. Groß,165,Borussia Dortmund,78,Bundesliga,2024,2,0,3,6,3.0
+10135.0,Bruno Guimarães,34,Newcastle,39,Premier League,2023,2,2,0,6,3.0
+19053.0,Abdelhamid Sabiri,498,Sampdoria,135,Serie A,2021,2,2,0,6,3.0
+19006.0,R. Healey,96,Toulouse,61,Ligue 1,2022,2,2,0,6,3.0
+141901.0,Jota Silva,65,Nottingham Forest,39,Premier League,2024,2,2,0,6,3.0
+142691.0,Alexsandro Ribeiro,79,Lille,61,Ligue 1,2022,2,2,0,6,3.0
+144319.0,S. Soumano,97,Lorient,61,Ligue 1,2021,2,2,0,6,3.0
+410.0,D. Caligiuri,170,FC Augsburg,78,Bundesliga,2021,2,2,0,6,3.0
+152654.0,Jeremie Frimpong,168,Bayer Leverkusen,78,Bundesliga,2023,2,2,0,6,3.0
+501.0,M. Hummels,165,Borussia Dortmund,78,Bundesliga,2023,2,2,0,6,3.0
+135775.0,Ansu Fati,529,Barcelona,140,La Liga,2021,2,2,0,6,3.0
+583.0,João Félix,49,Chelsea,39,Premier League,2022,2,2,0,6,3.0
+22015.0,B. Dia,514,Salernitana,135,Serie A,2023,1,2,0,6,6.0
+1358.0,E. Elmas,492,Napoli,135,Serie A,2023,2,2,0,6,3.0
+44814.0,L. Ferguson,500,Bologna,135,Serie A,2023,2,2,0,6,3.0
+195962.0,Chiquinho,39,Wolves,39,Premier League,2021,2,0,3,6,3.0
+283.0,T. Alexander-Arnold,40,Liverpool,39,Premier League,2023,2,2,0,6,3.0
+202838.0,D. Huseinbašić,192,1.FC Köln,78,Bundesliga,2022,2,2,0,6,3.0
+203040.0,T. Lemperle,192,1.FC Köln,78,Bundesliga,2021,2,2,0,6,3.0
+203762.0,E. Emegha,95,Strasbourg,61,Ligue 1,2024,2,2,0,6,3.0
+162946.0,B. Hollerbach,182,Union Berlin,78,Bundesliga,2024,2,2,0,6,3.0
+144740.0,F. Dele-Bashiru,487,Lazio,135,Serie A,2024,2,2,0,6,3.0
+529.0,N. Tagliafico,80,Lyon,61,Ligue 1,2023,2,2,0,6,3.0
+513.0,Renato Sanches,85,Paris Saint Germain,61,Ligue 1,2022,2,2,0,6,3.0
+2924.0,A. Januzaj,534,Las Palmas,140,La Liga,2024,2,2,0,6,3.0
+2864.0,A. Isak,34,Newcastle,39,Premier League,2024,2,2,0,6,3.0
+2781.0,M. Simon,83,Nantes,61,Ligue 1,2022,2,2,0,6,3.0
+2797.0,A. Finnbogason,170,FC Augsburg,78,Bundesliga,2021,2,2,0,6,3.0
+20761.0,F. Sotoca,116,Lens,61,Ligue 1,2021,2,2,0,6,3.0
+20961.0,Mounaim El Idrissy,98,Ajaccio,61,Ligue 1,2022,2,2,0,6,3.0
+153066.0,Fábio Carvalho,40,Liverpool,39,Premier League,2022,2,2,0,6,3.0
+153066.0,Fábio Carvalho,55,Brentford,39,Premier League,2024,2,2,0,6,3.0
+158644.0,M. Beier,167,1899 Hoffenheim,78,Bundesliga,2023,2,2,0,6,3.0
+162028.0,Juanmi Latasa,546,Getafe,140,La Liga,2023,2,2,0,6,3.0
+161919.0,Y. Moukoko,165,Borussia Dortmund,78,Bundesliga,2023,2,2,0,6,3.0
+161907.0,Malo Gusto,80,Lyon,61,Ligue 1,2021,3,0,3,6,2.0
+47547.0,Álex Moreno,543,Real Betis,140,La Liga,2021,2,2,0,6,3.0
+47551.0,Raúl de Tomás,540,Espanyol,140,La Liga,2021,2,2,0,6,3.0
+900.0,J. Lingard,33,Manchester United,39,Premier League,2021,2,2,0,6,3.0
+49583.0,A. Abdi,84,Nice,61,Ligue 1,2024,2,2,0,6,3.0
+50048.0,V. Muriqi,798,Mallorca,140,La Liga,2022,2,2,0,6,3.0
+48497.0,C. Itten,178,SpVgg Greuther Furth,78,Bundesliga,2021,2,2,0,6,3.0
+22169.0,W. Cyprien,83,Nantes,61,Ligue 1,2021,2,2,0,6,3.0
+2738.0,C. Gytkjær,517,Venezia,135,Serie A,2024,2,2,0,6,3.0
+874.0,Cristiano Ronaldo,33,Manchester United,39,Premier League,2021,2,2,0,6,3.0
+51449.0,Gastón Álvarez,546,Getafe,140,La Liga,2022,2,2,0,6,3.0
+786.0,N. Zaniolo,66,Aston Villa,39,Premier League,2023,2,2,0,6,3.0
+762.0,Vinícius Júnior,541,Real Madrid,140,La Liga,2022,3,0,3,6,2.0
+792.0,J. Kluivert,35,Bournemouth,39,Premier League,2023,2,2,0,6,3.0
+782.0,L. Pellegrini,497,AS Roma,135,Serie A,2023,2,2,0,6,3.0
+47579.0,E. Ávila,727,Osasuna,140,La Liga,2021,2,2,0,6,3.0
+47553.0,Bebé,728,Rayo Vallecano,140,La Liga,2023,2,2,0,6,3.0
+37117.0,Danilho Doekhi,182,Union Berlin,78,Bundesliga,2022,2,2,0,6,3.0
+36980.0,M. Thorsby,498,Sampdoria,135,Serie A,2021,2,2,0,6,3.0
+39071.0,V. Boniface,168,Bayer Leverkusen,78,Bundesliga,2023,2,2,0,6,3.0
+41577.0,Nuno Tavares,81,Marseille,61,Ligue 1,2022,2,2,0,6,3.0
+39095.0,E. Rashani,99,Clermont Foot,61,Ligue 1,2023,1,2,0,6,6.0
+22102.0,Wahbi Khazri,1063,Saint Etienne,61,Ligue 1,2021,2,2,0,6,3.0
+22136.0,0                         B. Diakité,79,Lille,61,Ligue 1,2023,2,2,0,6,3.0
+3175.0,Z. Ferhat,77,Angers,61,Ligue 1,2024,2,2,0,6,3.0
+538.0,F. de Jong,529,Barcelona,140,La Liga,2022,3,0,3,6,2.0
+138777.0,T. Anjorin,511,Empoli,135,Serie A,2024,2,2,0,6,3.0
+508.0,K. Coman,157,Bayern München,78,Bundesliga,2021,2,2,0,6,3.0
+842.0,N. Vlašić,503,Torino,135,Serie A,2024,2,2,0,6,3.0
+853.0,L. Bonucci,496,Juventus,135,Serie A,2021,2,2,0,6,3.0
+181908.0,J. Thielmann,192,1.FC Köln,78,Bundesliga,2021,2,2,0,6,3.0
+43246.0,A. Laïdouni,182,Union Berlin,78,Bundesliga,2022,2,2,0,6,3.0
+44814.0,L. Ferguson,500,Bologna,135,Serie A,2022,2,2,0,6,3.0
+1153.0,A. Haidara,173,RB Leipzig,78,Bundesliga,2021,2,2,0,6,3.0
+47013.0,Rafa Mir,536,Sevilla,140,La Liga,2021,2,2,0,6,3.0
+1467.0,A. Lacazette,42,Arsenal,39,Premier League,2021,2,2,0,6,3.0
+1467.0,A. Lacazette,80,Lyon,61,Ligue 1,2024,2,2,0,6,3.0
+1460.0,B. Saka,42,Arsenal,39,Premier League,2023,3,0,3,6,2.0
+1639.0,M. Brescianini,499,Atalanta,135,Serie A,2024,2,2,0,6,3.0
+1640.0,H. Çalhanoğlu,505,Inter,135,Serie A,2023,2,2,0,6,3.0
+1635.0,T. Bakayoko,97,Lorient,61,Ligue 1,2023,2,2,0,6,3.0
+328.0,Fabián Ruiz,492,Napoli,135,Serie A,2021,2,2,0,6,3.0
+325.0,G. Gaetano,490,Cagliari,135,Serie A,2024,3,0,3,6,2.0
+177665.0,A. Stach,164,FSV Mainz 05,78,Bundesliga,2021,3,0,3,6,2.0
+174724.0,F. Magri,96,Toulouse,61,Ligue 1,2023,2,2,0,6,3.0
+174724.0,F. Magri,96,Toulouse,61,Ligue 1,2024,2,2,0,6,3.0
+178077.0,K. Schade,160,SC Freiburg,78,Bundesliga,2021,2,2,0,6,3.0
+290.0,Virgil van Dijk,40,Liverpool,39,Premier League,2024,2,2,0,6,3.0
+299.0,Fabinho,40,Liverpool,39,Premier League,2021,2,2,0,6,3.0
+47438.0,M. Jensen,55,Brentford,39,Premier League,2022,2,2,0,6,3.0
+47440.0,Brais Méndez,538,Celta Vigo,140,La Liga,2021,2,2,0,6,3.0
+907.0,R. Lukaku,49,Chelsea,39,Premier League,2021,2,2,0,6,3.0
+908.0,A. Martial,33,Manchester United,39,Premier League,2022,1,2,0,6,6.0
+3033.0,C. Bakambu,543,Real Betis,140,La Liga,2024,2,2,0,6,3.0
+182519.0,Alberto Moleiro,534,Las Palmas,140,La Liga,2024,2,2,0,6,3.0
+182602.0,Julen Lobete,548,Real Sociedad,140,La Liga,2021,2,2,0,6,3.0
+276.0,Neymar,85,Paris Saint Germain,61,Ligue 1,2022,3,0,3,6,2.0
+32862.0,T. Kubo,548,Real Sociedad,140,La Liga,2022,2,2,0,6,3.0
+1455.0,A. Iwobi,36,Fulham,39,Premier League,2023,2,2,0,6,3.0
+32196.0,M. Aramu,517,Venezia,135,Serie A,2021,2,2,0,6,3.0
+47530.0,Sergio Akieme,93,Reims,61,Ligue 1,2023,2,2,0,6,3.0
+904.0,P. Pogba,33,Manchester United,39,Premier League,2021,2,0,3,6,3.0
+879.0,S. Mavididi,82,Montpellier,61,Ligue 1,2021,2,2,0,6,3.0
+47445.0,Iago Aspas,538,Celta Vigo,140,La Liga,2021,2,2,0,6,3.0
+47461.0,E. Bardhi,539,Levante,140,La Liga,2021,2,2,0,6,3.0
+24147.0,M. Camara,106,Stade Brestois 29,61,Ligue 1,2024,2,2,0,6,3.0
+23643.0,M. Guilavogui,116,Lens,61,Ligue 1,2023,2,2,0,6,3.0
+24797.0,Dominick Drexler,174,FC Schalke 04,78,Bundesliga,2022,2,2,0,6,3.0
+24798.0,C. Führich,172,VfB Stuttgart,78,Bundesliga,2024,3,0,3,6,2.0
+24288.0,M. Bayo,79,Lille,61,Ligue 1,2024,2,2,0,6,3.0
+30789.0,C. Kouamé,502,Fiorentina,135,Serie A,2023,2,2,0,6,3.0
+1725.0,D. Ljubičić,192,1.FC Köln,78,Bundesliga,2022,2,2,0,6,3.0
+30845.0,E. Gyasi,515,Spezia,135,Serie A,2021,2,2,0,6,3.0
+56851.0,M. Folorunsho,504,Verona,135,Serie A,2023,2,2,0,6,3.0
+57446.0,A. Adams,82,Montpellier,61,Ligue 1,2023,2,2,0,6,3.0
+19759.0,L. Berry,1359,Luton,39,Premier League,2023,2,2,0,6,3.0
+19802.0,J. Brown,1359,Luton,39,Premier League,2023,2,2,0,6,3.0
+19617.0,M. Olise,52,Crystal Palace,39,Premier League,2022,2,2,0,6,3.0
+20530.0,A. Jallow,112,Metz,61,Ligue 1,2023,2,2,0,6,3.0
+2781.0,M. Simon,83,Nantes,61,Ligue 1,2021,2,2,0,6,3.0
+24147.0,M. Camara,106,Stade Brestois 29,61,Ligue 1,2022,2,2,0,6,3.0
+270139.0,J. O'Brien,45,Everton,39,Premier League,2024,2,2,0,6,3.0
+216.0,M. Icardi,85,Paris Saint Germain,61,Ligue 1,2021,2,2,0,6,3.0
+202.0,A. Candreva,514,Salernitana,135,Serie A,2022,2,2,0,6,3.0
+277.0,M. Diaby,168,Bayer Leverkusen,78,Bundesliga,2021,2,2,0,6,3.0
+31318.0,M'Bala Nzola,502,Fiorentina,135,Serie A,2023,2,2,0,6,3.0
+794.0,P. Schick,168,Bayer Leverkusen,78,Bundesliga,2024,2,2,0,6,3.0
+833.0,Jaka Bijol,494,Udinese,135,Serie A,2022,2,2,0,6,3.0
+791.0,S. El Shaarawy,497,AS Roma,135,Serie A,2022,2,2,0,6,3.0
+1469.0,D. Welbeck,51,Brighton,39,Premier League,2022,2,2,0,6,3.0
+31406.0,U. Sadiq,532,Valencia,140,La Liga,2024,2,2,0,6,3.0
+257.0,Marquinhos,85,Paris Saint Germain,61,Ligue 1,2021,2,2,0,6,3.0
+243.0,Z. Aboukhlal,96,Toulouse,61,Ligue 1,2024,2,2,0,6,3.0
+265363.0,Tiago Tomás,172,VfB Stuttgart,78,Bundesliga,2021,2,2,0,6,3.0
+249.0,D. Malen,66,Aston Villa,39,Premier League,2024,2,2,0,6,3.0
+249.0,D. Malen,165,Borussia Dortmund,78,Bundesliga,2021,2,2,0,6,3.0
+269163.0,W. Swedberg,538,Celta Vigo,140,La Liga,2023,2,2,0,6,3.0
+1831.0,A. Rebić,489,AC Milan,135,Serie A,2021,2,2,0,6,3.0
+1836.0,F. Acerbi,487,Lazio,135,Serie A,2021,2,2,0,6,3.0
+30543.0,G. Raspadori,488,Sassuolo,135,Serie A,2021,2,2,0,6,3.0
+30530.0,L. Sernicola,520,Cremonese,135,Serie A,2022,2,2,0,6,3.0
+1844.0,A. Marušić,487,Lazio,135,Serie A,2024,2,2,0,6,3.0
+1854.0,J. Correa,505,Inter,135,Serie A,2021,1,2,0,6,6.0
+30537.0,D. Berardi,488,Sassuolo,135,Serie A,2023,2,2,0,6,3.0
+47418.0,Mikel Vesga,531,Athletic Club,140,La Liga,2022,2,2,0,6,3.0
+69971.0,T. Moffi,97,Lorient,61,Ligue 1,2021,2,2,0,6,3.0
+733.0,Dani Carvajal,541,Real Madrid,140,La Liga,2023,2,2,0,6,3.0
+792.0,J. Kluivert,532,Valencia,140,La Liga,2022,2,2,0,6,3.0
+30822.0,T. Augello,490,Cagliari,135,Serie A,2024,3,0,3,6,2.0
+30836.0,Giulio Maggiore,514,Salernitana,135,Serie A,2023,2,2,0,6,3.0
+1600.0,K. Tsimikas,40,Liverpool,39,Premier League,2022,2,0,3,6,3.0
+31057.0,H. Traoré,488,Sassuolo,135,Serie A,2021,2,2,0,6,3.0
+1830.0,Gonçalo Paciência,176,VfL Bochum,78,Bundesliga,2023,2,2,0,6,3.0
+668.0,N. Fekir,543,Real Betis,140,La Liga,2022,2,2,0,6,3.0
+697.0,M. Solomon,36,Fulham,39,Premier League,2022,2,2,0,6,3.0
+666.0,M. Dembélé,80,Lyon,61,Ligue 1,2022,2,2,0,6,3.0
+757.0,Lucas Vázquez,541,Real Madrid,140,La Liga,2021,2,2,0,6,3.0
+752.0,Toni Kroos,541,Real Madrid,140,La Liga,2023,3,0,3,6,2.0
+67939.0,Aimar Oroz,727,Osasuna,140,La Liga,2022,3,0,3,6,2.0
+725.0,R. Hack,163,Borussia Mönchengladbach,78,Bundesliga,2023,1,2,0,6,6.0
+69971.0,T. Moffi,84,Nice,61,Ligue 1,2023,1,2,0,6,6.0
+30848.0,D. Okereke,520,Cremonese,135,Serie A,2022,2,2,0,6,3.0
+30879.0,A. Petagna,492,Napoli,135,Serie A,2021,2,2,0,6,3.0
+30815.0,K. Lasagna,504,Verona,135,Serie A,2021,3,0,3,6,2.0
+3432.0,A. Waris,95,Strasbourg,61,Ligue 1,2021,2,2,0,6,3.0
+80434.0,T. Čvančara,163,Borussia Mönchengladbach,78,Bundesliga,2023,2,2,0,6,3.0
+90590.0,G. Rutter,51,Brighton,39,Premier League,2024,2,2,0,6,3.0
+85041.0,A. Gouiri,94,Rennes,61,Ligue 1,2023,2,2,0,6,3.0
+667.0,Memphis Depay,530,Atletico Madrid,140,La Liga,2022,2,2,0,6,3.0
+47500.0,D. Verde,515,Spezia,135,Serie A,2021,2,2,0,6,3.0
+47514.0,Valery,798,Mallorca,140,La Liga,2024,2,2,0,6,3.0
+30542.0,J. Odgaard,500,Bologna,135,Serie A,2023,2,2,0,6,3.0
+1697.0,Pablo Fornals,48,West Ham,39,Premier League,2021,2,2,0,6,3.0
+30440.0,R. Piccoli,490,Cagliari,135,Serie A,2024,2,2,0,6,3.0
+30440.0,R. Piccoli,511,Empoli,135,Serie A,2022,2,2,0,6,3.0
+30436.0,M. Pessina,1579,Monza,135,Serie A,2022,2,2,0,6,3.0
+30435.0,D. Kulusevski,47,Tottenham,39,Premier League,2024,2,2,0,6,3.0
+1221.0,S. Azmoun,168,Bayer Leverkusen,78,Bundesliga,2022,2,2,0,6,3.0
+47291.0,Gorka Guruzeta,531,Athletic Club,140,La Liga,2022,2,2,0,6,3.0
+47264.0,Hugo Duro,532,Valencia,140,La Liga,2021,1,2,0,6,6.0
+1101.0,Takumi Minamino,40,Liverpool,39,Premier League,2021,2,2,0,6,3.0
+47298.0,Aritz Elustondo,548,Real Sociedad,140,La Liga,2021,2,2,0,6,3.0
+46751.0,Abdón Prats,798,Mallorca,140,La Liga,2021,2,2,0,6,3.0
+146751.0,Raúl García,727,Osasuna,140,La Liga,2023,2,2,0,6,3.0
+146751.0,Raúl García,727,Osasuna,140,La Liga,2024,2,2,0,6,3.0
+978.0,K. Havertz,49,Chelsea,39,Premier League,2021,2,2,0,6,3.0
+978.0,K. Havertz,49,Chelsea,39,Premier League,2022,2,2,0,6,3.0
+47323.0,Mikel Oyarzabal,548,Real Sociedad,140,La Liga,2023,2,2,0,6,3.0
+974.0,C. Aránguiz,168,Bayer Leverkusen,78,Bundesliga,2021,3,0,3,6,2.0
+978.0,K. Havertz,42,Arsenal,39,Premier League,2024,2,2,0,6,3.0
+47181.0,Toni Martínez,542,Alaves,140,La Liga,2024,2,2,0,6,3.0
+1167.0,Y. Poulsen,173,RB Leipzig,78,Bundesliga,2023,2,2,0,6,3.0
+1167.0,Y. Poulsen,173,RB Leipzig,78,Bundesliga,2024,2,2,0,6,3.0
+1148.0,Willi Orbán,173,RB Leipzig,78,Bundesliga,2021,2,2,0,6,3.0
+1148.0,Willi Orbán,173,RB Leipzig,78,Bundesliga,2022,2,2,0,6,3.0
+1124.0,O. Burke,162,Werder Bremen,78,Bundesliga,2022,2,2,0,6,3.0
+1135.0,O. Édouard,52,Crystal Palace,39,Premier League,2023,2,2,0,6,3.0
+47317.0,Barrenetxea,548,Real Sociedad,140,La Liga,2022,2,2,0,6,3.0
+47319.0,Willian José,543,Real Betis,140,La Liga,2023,2,2,0,6,3.0
+47311.0,Mikel Merino,42,Arsenal,39,Premier League,2024,1,2,0,6,6.0
+47315.0,Martín Zubimendi,548,Real Sociedad,140,La Liga,2023,2,2,0,6,3.0
+6503.0,N. Molina,494,Udinese,135,Serie A,2021,2,2,0,6,3.0
+19268.0,J. Brownhill,44,Burnley,39,Premier League,2023,2,2,0,6,3.0
+30510.0,Álex Berenguer,531,Athletic Club,140,La Liga,2023,2,2,0,6,3.0
+24815.0,Christopher Antwi-Adjei,176,VfL Bochum,78,Bundesliga,2023,2,2,0,6,3.0
+2678.0,Diogo Jota,40,Liverpool,39,Premier League,2024,2,2,0,6,3.0
+24845.0,Julian Ryerson,165,Borussia Dortmund,78,Bundesliga,2023,2,2,0,6,3.0
+24903.0,R. Andrich,168,Bayer Leverkusen,78,Bundesliga,2023,2,2,0,6,3.0
+30413.0,M. Pjaca,503,Torino,135,Serie A,2021,2,2,0,6,3.0
+19461.0,L. Nmecha,161,VfL Wolfsburg,78,Bundesliga,2024,1,2,0,6,6.0
+3407.0,S. Bahoken,77,Angers,61,Ligue 1,2021,2,2,0,6,3.0
+3430.0,C. Ekuban,495,Genoa,135,Serie A,2023,2,2,0,6,3.0
+138787.0,A. Gordon,45,Everton,39,Premier League,2021,2,2,0,6,3.0
+521.0,R. Lewandowski,529,Barcelona,140,La Liga,2024,2,2,0,6,3.0
+8598.0,T. Awoniyi,65,Nottingham Forest,39,Premier League,2023,2,2,0,6,3.0
+19220.0,Mason Mount,49,Chelsea,39,Premier League,2021,1,2,0,6,6.0
+8624.0,F. Tardieu,110,Estac Troyes,61,Ligue 1,2021,2,2,0,6,3.0
+18931.0,C. Wood,65,Nottingham Forest,39,Premier League,2023,2,2,0,6,3.0
+10097.0,Éderson,499,Atalanta,135,Serie A,2023,2,2,0,6,3.0
+10135.0,Bruno Guimarães,34,Newcastle,39,Premier League,2021,2,2,0,6,3.0
+9938.0,Arthur Cabral,502,Fiorentina,135,Serie A,2022,2,2,0,6,3.0
+8793.0,T. Henry,517,Venezia,135,Serie A,2021,2,2,0,6,3.0
+8794.0,G. Hirst,57,Ipswich,39,Premier League,2024,2,2,0,6,3.0
+1807.0,E. Ndicka,497,AS Roma,135,Serie A,2023,3,0,3,6,2.0
+19461.0,L. Nmecha,161,VfL Wolfsburg,78,Bundesliga,2022,2,2,0,6,3.0
+30462.0,M. Gabbiadini,498,Sampdoria,135,Serie A,2021,2,2,0,6,3.0
+281795.0,Y. Asprilla,547,Girona,140,La Liga,2024,2,2,0,6,3.0
+176.0,Erik Lamela,536,Sevilla,140,La Liga,2022,2,2,0,6,3.0
+14405.0,Myrto Uzuni,715,Granada CF,140,La Liga,2023,2,2,0,6,3.0
+10316.0,Caio Henrique,91,Monaco,61,Ligue 1,2024,3,0,3,6,2.0
+15592.0,J. Stage,162,Werder Bremen,78,Bundesliga,2023,2,2,0,6,3.0
+18955.0,D. Ings,66,Aston Villa,39,Premier League,2021,2,2,0,6,3.0
+18963.0,L. Dunk,51,Brighton,39,Premier League,2023,2,2,0,6,3.0
+2218.0,I. Sarr,52,Crystal Palace,39,Premier League,2024,2,2,0,6,3.0
+1946.0,L. Trossard,51,Brighton,39,Premier League,2021,2,2,0,6,3.0
+28325.0,M. Blažič,77,Angers,61,Ligue 1,2022,2,2,0,6,3.0
+285909.0,Pablo Torre,529,Barcelona,140,La Liga,2024,1,2,0,6,6.0
+307123.0,N. O'Reilly,50,Manchester City,39,Premier League,2024,2,2,0,6,3.0
+291964.0,A. Güler,541,Real Madrid,140,La Liga,2023,2,2,0,6,3.0
+134.0,Juan Miranda,500,Bologna,135,Serie A,2024,3,0,3,6,2.0
+137.0,Sergi Roberto,529,Barcelona,140,La Liga,2023,2,2,0,6,3.0
+122468.0,Saúl Coco,503,Torino,135,Serie A,2024,2,2,0,6,3.0
+127011.0,Andrea Cambiaso,495,Genoa,135,Serie A,2021,3,0,3,6,2.0
+125743.0,Beto,494,Udinese,135,Serie A,2022,2,2,0,6,3.0
+640.0,Fernandinho,50,Manchester City,39,Premier League,2021,2,2,0,6,3.0
+19408.0,R. Burke,1359,Luton,39,Premier League,2023,3,0,3,6,2.0
+26315.0,N. González,502,Fiorentina,135,Serie A,2023,2,2,0,6,3.0
+26343.0,S. Tigges,165,Borussia Dortmund,78,Bundesliga,2021,2,2,0,6,3.0
+26303.0,B. Sosa,172,VfB Stuttgart,78,Bundesliga,2021,3,0,3,6,2.0
+608.0,Lucas Boyé,797,Elche,140,La Liga,2022,2,2,0,6,3.0
+612.0,E. Ponce,797,Elche,140,La Liga,2022,2,2,0,6,3.0
+626.0,J. Stones,50,Manchester City,39,Premier League,2024,2,2,0,6,3.0
+636.0,Bernardo Silva,50,Manchester City,39,Premier League,2021,2,2,0,6,3.0
+107153.0,Kike Pérez,797,Elche,140,La Liga,2021,1,2,0,6,6.0
+104853.0,Asier Villalibre,531,Athletic Club,140,La Liga,2021,2,2,0,6,3.0
+122657.0,Randy Nteka,728,Rayo Vallecano,140,La Liga,2024,1,2,0,6,6.0
+125743.0,Beto,45,Everton,39,Premier League,2023,2,2,0,6,3.0
+1863.0,C. Immobile,487,Lazio,135,Serie A,2023,2,2,0,6,3.0
+30422.0,Robin Gosens,505,Inter,135,Serie A,2022,2,2,0,6,3.0
+30415.0,Dušan Vlahović,502,Fiorentina,135,Serie A,2021,2,2,0,6,3.0
+30420.0,E. Delprato,523,Parma,135,Serie A,2024,2,2,0,6,3.0
+1922.0,Florian Thauvin,494,Udinese,135,Serie A,2024,2,2,0,6,3.0
+1910.0,Maxime López,488,Sassuolo,135,Serie A,2021,2,2,0,6,3.0
+1911.0,L. Ocampos,536,Sevilla,140,La Liga,2023,2,2,0,6,3.0
+1926.0,J. Aidoo,538,Celta Vigo,140,La Liga,2022,2,2,0,6,3.0
+336564.0,W. Odobert,110,Estac Troyes,61,Ligue 1,2022,2,2,0,6,3.0
+332308.0,Unai Gómez,531,Athletic Club,140,La Liga,2023,2,2,0,6,3.0
+18805.0,A. Doucouré,45,Everton,39,Premier League,2021,2,2,0,6,3.0
+103.0,Jean-Eudes Aholou,95,Strasbourg,61,Ligue 1,2022,1,2,0,6,6.0
+17597.0,Dara O'Shea,44,Burnley,39,Premier League,2023,2,2,0,6,3.0
+14.0,Mahmoud Dahoud,165,Borussia Dortmund,78,Bundesliga,2021,2,2,0,6,3.0
+374058.0,L. Camara,91,Monaco,61,Ligue 1,2024,2,2,0,6,3.0
+443676.0,B. Guirassy,83,Nantes,61,Ligue 1,2024,2,2,0,6,3.0
+343027.0,D. Doué,94,Rennes,61,Ligue 1,2022,2,2,0,6,3.0
+343189.0,G. Gineitis,503,Torino,135,Serie A,2024,2,2,0,6,3.0
+343320.0,Eliesse Ben Seghir,91,Monaco,61,Ligue 1,2024,1,2,0,6,6.0
+315699.0,Javi Guerra,532,Valencia,140,La Liga,2023,2,2,0,6,3.0
+150.0,Arthur,502,Fiorentina,135,Serie A,2023,2,2,0,6,3.0
+147.0,Philippe Coutinho,529,Barcelona,140,La Liga,2021,2,2,0,6,3.0
+322630.0,G. Fabbian,500,Bologna,135,Serie A,2023,2,2,0,6,3.0
+334362.0,D. Downs,192,1.FC Köln,78,Bundesliga,2023,2,2,0,6,3.0
+26249.0,J. Haberer,160,SC Freiburg,78,Bundesliga,2021,2,2,0,6,3.0
+26252.0,R. Sallai,160,SC Freiburg,78,Bundesliga,2023,2,2,0,6,3.0
+2219.0,J. Siebatcheu,163,Borussia Mönchengladbach,78,Bundesliga,2023,2,2,0,6,3.0
+2214.0,Romain Del Castillo,106,Stade Brestois 29,61,Ligue 1,2023,2,2,0,6,3.0
+2215.0,A. Laurienté,488,Sassuolo,135,Serie A,2022,3,0,3,6,2.0
+342038.0,F. Afena-Gyan,497,AS Roma,135,Serie A,2021,1,2,0,6,6.0
+342177.0,N. Weiper,164,FSV Mainz 05,78,Bundesliga,2022,2,2,0,6,3.0
+119.0,Radamel Falcao,728,Rayo Vallecano,140,La Liga,2022,2,2,0,6,3.0
+2059.0,W. Ben Yedder,91,Monaco,61,Ligue 1,2023,2,2,0,6,3.0
+2032.0,J. Strand Larsen,538,Celta Vigo,140,La Liga,2023,2,2,0,6,3.0
+30407.0,Christian Nørgaard,55,Brentford,39,Premier League,2024,2,2,0,6,3.0
+30409.0,J. Veretout,81,Marseille,61,Ligue 1,2022,2,2,0,6,3.0
+25925.0,J. Boëtius,164,FSV Mainz 05,78,Bundesliga,2021,2,2,0,6,3.0
+25914.0,Aarón Martín,495,Genoa,135,Serie A,2024,3,0,3,6,2.0
+25917.0,Ridle Baku,161,VfL Wolfsburg,78,Bundesliga,2022,2,2,0,6,3.0
+26260.0,L. Waldschmidt,192,1.FC Köln,78,Bundesliga,2023,2,2,0,6,3.0
+18870.0,D. Brooks,35,Bournemouth,39,Premier League,2024,2,2,0,6,3.0
+18881.0,J. King,38,Watford,39,Premier League,2021,1,2,0,6,6.0
+18788.0,J. Vardy,46,Leicester,39,Premier League,2022,2,2,0,6,3.0
+1166.0,T. Werner,47,Tottenham,39,Premier League,2023,2,2,0,6,3.0
+20732.0,G. Perrin,108,Auxerre,61,Ligue 1,2021,2,2,0,6,3.0
+20665.0,J. Bellegarde,39,Wolves,39,Premier League,2023,2,2,0,6,3.0
+20782.0,F. Ayé,108,Auxerre,61,Ligue 1,2024,2,2,0,6,3.0
+20784.0,F. Honorat,163,Borussia Mönchengladbach,78,Bundesliga,2024,2,2,0,6,3.0
+665.0,M. Cornet,44,Burnley,39,Premier League,2021,2,2,0,6,3.0
+25297.0,M. Gregoritsch,170,FC Augsburg,78,Bundesliga,2021,2,2,0,6,3.0
+25298.0,A. Hahn,170,FC Augsburg,78,Bundesliga,2022,2,2,0,6,3.0
+25192.0,K. Behrens,182,Union Berlin,78,Bundesliga,2021,2,2,0,6,3.0
+2575.0,J. Porozo,110,Estac Troyes,61,Ligue 1,2022,2,2,0,6,3.0
+2598.0,R. Doan,160,SC Freiburg,78,Bundesliga,2022,2,2,0,6,3.0
+25307.0,M. Richter,159,Hertha Berlin,78,Bundesliga,2022,2,2,0,6,3.0
+2449.0,Y. Herrera,547,Girona,140,La Liga,2022,2,2,0,6,3.0
+128582.0,Jorge de Frutos,728,Rayo Vallecano,140,La Liga,2023,2,2,0,6,3.0
+128398.0,Oihan Sancet,531,Athletic Club,140,La Liga,2023,2,2,0,6,3.0
+129670.0,N. Mbuku,93,Reims,61,Ligue 1,2021,2,2,0,6,3.0
+129678.0,A. Ounahi,77,Angers,61,Ligue 1,2021,2,2,0,6,3.0
+129169.0,A. Zaroury,116,Lens,61,Ligue 1,2024,2,2,0,6,3.0
+129643.0,E. Ferguson,51,Brighton,39,Premier League,2022,2,2,0,6,3.0
+129688.0,I. Lihadji,79,Lille,61,Ligue 1,2021,3,0,3,6,2.0
+533.0,R. Kristensen,63,Leeds,39,Premier League,2022,2,2,0,6,3.0
+56.0,A. Griezmann,530,Atletico Madrid,140,La Liga,2022,3,0,3,6,2.0
+44.0,Rodri,50,Manchester City,39,Premier League,2021,2,2,0,6,3.0
+45.0,T. Lemar,530,Atletico Madrid,140,La Liga,2021,2,2,0,6,3.0
+7562.0,R. Schmid,162,Werder Bremen,78,Bundesliga,2024,2,2,0,6,3.0
+7722.0,S. Kalajdzic,39,Wolves,39,Premier League,2023,2,2,0,6,3.0
+7722.0,S. Kalajdzic,172,VfB Stuttgart,78,Bundesliga,2021,2,2,0,6,3.0
+7073.0,M. Grüll,162,Werder Bremen,78,Bundesliga,2024,2,2,0,6,3.0
+6662.0,S. Pierotti,867,Lecce,135,Serie A,2024,2,2,0,6,3.0
+368030.0,E. Kroupi,97,Lorient,61,Ligue 1,2023,2,1,1,5,2.5
+53.0,Á. Correa,530,Atletico Madrid,140,La Liga,2023,1,1,1,5,5.0
+50.0,Koke,530,Atletico Madrid,140,La Liga,2024,2,1,1,5,2.5
+343027.0,D. Doué,94,Rennes,61,Ligue 1,2023,2,1,1,5,2.5
+343202.0,Á. Rodríguez,541,Real Madrid,140,La Liga,2022,2,1,1,5,2.5
+12667.0,Jonathan Viera,534,Las Palmas,140,La Liga,2023,1,1,1,5,5.0
+284322.0,K. Mainoo,33,Manchester United,39,Premier League,2023,2,1,1,5,2.5
+284324.0,A. Garnacho,33,Manchester United,39,Premier League,2023,2,1,1,5,2.5
+277191.0,A. Sima,77,Angers,61,Ligue 1,2022,2,1,1,5,2.5
+278128.0,Josh Wilson-Esbrand,93,Reims,61,Ligue 1,2023,2,1,1,5,2.5
+278133.0,O. Bobb,50,Manchester City,39,Premier League,2023,2,1,1,5,2.5
+275651.0,A. Bonny,523,Parma,135,Serie A,2024,2,1,1,5,2.5
+272460.0,Q. Merlin,83,Nantes,61,Ligue 1,2021,2,1,1,5,2.5
+248.0,H. Lozano,492,Napoli,135,Serie A,2021,2,1,1,5,2.5
+8683.0,I. Cardona,1063,Saint Etienne,61,Ligue 1,2024,2,1,1,5,2.5
+8959.0,A. Beck,180,1. FC Heidenheim,78,Bundesliga,2024,2,1,1,5,2.5
+9938.0,Arthur Cabral,502,Fiorentina,135,Serie A,2021,2,1,1,5,2.5
+18961.0,Dan Burn,34,Newcastle,39,Premier League,2023,2,1,1,5,2.5
+18907.0,Joselu,541,Real Madrid,140,La Liga,2023,2,1,1,5,2.5
+15286.0,Mousa Al-Taamari,82,Montpellier,61,Ligue 1,2024,2,1,1,5,2.5
+10494.0,Matheus Henrique,488,Sassuolo,135,Serie A,2022,2,1,1,5,2.5
+200873.0,M. Bamba,97,Lorient,61,Ligue 1,2023,2,1,1,5,2.5
+196855.0,J. Anthony,35,Bournemouth,39,Premier League,2022,2,1,1,5,2.5
+193617.0,T. Louchet,84,Nice,61,Ligue 1,2023,2,1,1,5,2.5
+184226.0,Yéremy Pino,533,Villarreal,140,La Liga,2021,2,1,1,5,2.5
+266813.0,W. Bondo,1579,Monza,135,Serie A,2023,2,1,1,5,2.5
+237129.0,P. Sarr,47,Tottenham,39,Premier League,2024,2,1,1,5,2.5
+263481.0,L. Colombo,867,Lecce,135,Serie A,2022,2,1,1,5,2.5
+258.0,Juan Bernat,85,Paris Saint Germain,61,Ligue 1,2022,2,1,1,5,2.5
+183799.0,Nico Williams,531,Athletic Club,140,La Liga,2024,2,1,1,5,2.5
+182603.0,Jon Olasagasti,548,Real Sociedad,140,La Liga,2024,2,1,1,5,2.5
+182219.0,Álex Baena,533,Villarreal,140,La Liga,2024,1,1,1,5,5.0
+307.0,X. Shaqiri,80,Lyon,61,Ligue 1,2021,1,1,1,5,5.0
+318.0,K. Koulibaly,492,Napoli,135,Serie A,2021,2,1,1,5,2.5
+248.0,H. Lozano,492,Napoli,135,Serie A,2022,2,1,1,5,2.5
+206254.0,Miloš Kerkez,35,Bournemouth,39,Premier League,2024,2,1,1,5,2.5
+231029.0,N. Tella,168,Bayer Leverkusen,78,Bundesliga,2023,2,1,1,5,2.5
+2671.0,Jaime Mata,546,Getafe,140,La Liga,2022,2,1,1,5,2.5
+1807.0,E. Ndicka,169,Eintracht Frankfurt,78,Bundesliga,2021,2,1,1,5,2.5
+30490.0,N. Sansone,867,Lecce,135,Serie A,2023,2,1,1,5,2.5
+30497.0,Bremer,496,Juventus,135,Serie A,2022,2,1,1,5,2.5
+30498.0,L. De Silvestri,500,Bologna,135,Serie A,2021,2,1,1,5,2.5
+30484.0,Mattias Svanberg,500,Bologna,135,Serie A,2021,2,1,1,5,2.5
+30462.0,M. Gabbiadini,498,Sampdoria,135,Serie A,2022,2,1,1,5,2.5
+30438.0,N. Cambiaghi,500,Bologna,135,Serie A,2024,2,1,1,5,2.5
+25030.0,A. Voglsammer,182,Union Berlin,78,Bundesliga,2021,2,1,1,5,2.5
+24913.0,N. Dovedan,180,1. FC Heidenheim,78,Bundesliga,2023,2,1,1,5,2.5
+24955.0,M. Honsak,180,1. FC Heidenheim,78,Bundesliga,2024,2,1,1,5,2.5
+24962.0,L. Bénes,182,Union Berlin,78,Bundesliga,2024,2,1,1,5,2.5
+24903.0,R. Andrich,168,Bayer Leverkusen,78,Bundesliga,2021,2,1,1,5,2.5
+24868.0,J. Vagnoman,172,VfB Stuttgart,78,Bundesliga,2022,1,1,1,5,5.0
+2710.0,S. Boufal,77,Angers,61,Ligue 1,2022,2,1,1,5,2.5
+2677.0,João Moutinho,39,Wolves,39,Premier League,2021,2,1,1,5,2.5
+1861.0,F. Caicedo,495,Genoa,135,Serie A,2021,2,1,1,5,2.5
+1864.0,Pedro Neto,49,Chelsea,39,Premier League,2024,2,1,1,5,2.5
+30422.0,Robin Gosens,502,Fiorentina,135,Serie A,2024,2,1,1,5,2.5
+30414.0,G. Simeone,492,Napoli,135,Serie A,2024,2,1,1,5,2.5
+2478.0,D. Benedetto,797,Elche,140,La Liga,2021,2,1,1,5,2.5
+2483.0,D. Machado,116,Lens,61,Ligue 1,2024,2,1,1,5,2.5
+25011.0,A. Pieper,162,Werder Bremen,78,Bundesliga,2022,2,1,1,5,2.5
+25025.0,Fabian Klos,188,Arminia Bielefeld,78,Bundesliga,2021,2,1,1,5,2.5
+26248.0,V. Grifo,160,SC Freiburg,78,Bundesliga,2023,2,1,1,5,2.5
+26171.0,P. Tietz,170,FC Augsburg,78,Bundesliga,2023,2,1,1,5,2.5
+2118.0,Răzvan Marin,490,Cagliari,135,Serie A,2024,2,1,1,5,2.5
+2056.0,Pablo Sarabia,39,Wolves,39,Premier League,2023,1,1,1,5,5.0
+2056.0,Pablo Sarabia,39,Wolves,39,Premier League,2024,2,1,1,5,2.5
+26302.0,Pablo Maffeo,798,Mallorca,140,La Liga,2021,2,1,1,5,2.5
+1930.0,J. Mæhle,499,Atalanta,135,Serie A,2021,1,1,1,5,5.0
+1914.0,M. Sanson,84,Nice,61,Ligue 1,2023,2,1,1,5,2.5
+1493.0,Marcos Acuña,536,Sevilla,140,La Liga,2022,2,1,1,5,2.5
+1468.0,E. Nketiah,42,Arsenal,39,Premier League,2022,2,1,1,5,2.5
+1468.0,E. Nketiah,52,Crystal Palace,39,Premier League,2024,2,1,1,5,2.5
+31146.0,S. Tonali,489,AC Milan,135,Serie A,2022,2,1,1,5,2.5
+31146.0,S. Tonali,489,AC Milan,135,Serie A,2021,2,1,1,5,2.5
+1646.0,Lucas Paquetá,48,West Ham,39,Premier League,2023,2,1,1,5,2.5
+1651.0,K. Piątek,514,Salernitana,135,Serie A,2022,2,1,1,5,2.5
+1586.0,Tello,543,Real Betis,140,La Liga,2021,2,1,1,5,2.5
+22266.0,S. Grandsir,111,Le Havre,61,Ligue 1,2023,2,1,1,5,2.5
+23120.0,Q. Boisgard,97,Lorient,61,Ligue 1,2021,1,1,1,5,5.0
+2777.0,I. Success,494,Udinese,135,Serie A,2023,2,1,1,5,2.5
+2778.0,K. Ịheanachọ,46,Leicester,39,Premier League,2021,2,1,1,5,2.5
+2762.0,J. Brekalo,503,Torino,135,Serie A,2021,2,1,1,5,2.5
+2734.0,P. Billing,35,Bournemouth,39,Premier League,2023,2,1,1,5,2.5
+1478.0,Abdu Conté,110,Estac Troyes,61,Ligue 1,2022,2,1,1,5,2.5
+1489.0,N. Gudelj,536,Sevilla,140,La Liga,2022,2,1,1,5,2.5
+30937.0,M. Zaccagni,487,Lazio,135,Serie A,2021,2,1,1,5,2.5
+30937.0,M. Zaccagni,487,Lazio,135,Serie A,2024,2,1,1,5,2.5
+30807.0,S. Fofana,116,Lens,61,Ligue 1,2022,2,1,1,5,2.5
+30803.0,A. Barák,502,Fiorentina,135,Serie A,2023,2,1,1,5,2.5
+1702.0,Alfonso Pedraza,533,Villarreal,140,La Liga,2021,2,1,1,5,2.5
+1672.0,D. Sinani,186,FC St. Pauli,78,Bundesliga,2024,2,1,1,5,2.5
+2614.0,N. Nández,490,Cagliari,135,Serie A,2023,2,1,1,5,2.5
+24798.0,C. Führich,172,VfB Stuttgart,78,Bundesliga,2022,1,1,1,5,5.0
+1697.0,Pablo Fornals,48,West Ham,39,Premier League,2022,2,1,1,5,2.5
+30562.0,João Pedro,490,Cagliari,135,Serie A,2021,2,1,1,5,2.5
+30553.0,C. Lykogiannis,500,Bologna,135,Serie A,2023,2,1,1,5,2.5
+30558.0,N. Barella,505,Inter,135,Serie A,2023,2,1,1,5,2.5
+1826.0,S. Haller,165,Borussia Dortmund,78,Bundesliga,2022,2,1,1,5,2.5
+31028.0,L. Štulac,511,Empoli,135,Serie A,2021,2,1,1,5,2.5
+30922.0,D. Faraoni,504,Verona,135,Serie A,2021,2,1,1,5,2.5
+30932.0,Liam Henderson,511,Empoli,135,Serie A,2021,2,1,1,5,2.5
+41157.0,André Almeida,532,Valencia,140,La Liga,2022,2,1,1,5,2.5
+39121.0,C. Ejuke,536,Sevilla,140,La Liga,2024,2,1,1,5,2.5
+39245.0,Ibrahima Kone,97,Lorient,61,Ligue 1,2021,2,1,1,5,2.5
+39073.0,J. Hauge,169,Eintracht Frankfurt,78,Bundesliga,2021,2,1,1,5,2.5
+37938.0,S. Becker,182,Union Berlin,78,Bundesliga,2022,2,1,1,5,2.5
+37161.0,L. Sinisterra,35,Bournemouth,39,Premier League,2024,1,1,1,5,5.0
+36986.0,D. Johnsen,517,Venezia,135,Serie A,2021,2,1,1,5,2.5
+37122.0,Matúš Bero,176,VfL Bochum,78,Bundesliga,2023,2,1,1,5,2.5
+22148.0,N. Ngoumou,163,Borussia Mönchengladbach,78,Bundesliga,2023,2,1,1,5,2.5
+22170.0,P. Lees-Melou,106,Stade Brestois 29,61,Ligue 1,2022,2,1,1,5,2.5
+22170.0,P. Lees-Melou,106,Stade Brestois 29,61,Ligue 1,2024,2,1,1,5,2.5
+22136.0,0                         B. Diakité,79,Lille,61,Ligue 1,2024,2,1,1,5,2.5
+22097.0,Arnaud Nordin,82,Montpellier,61,Ligue 1,2022,2,1,1,5,2.5
+41323.0,Mama Baldé,110,Estac Troyes,61,Ligue 1,2022,2,1,1,5,2.5
+41552.0,P. Ciss,728,Rayo Vallecano,140,La Liga,2021,1,1,1,5,5.0
+41552.0,P. Ciss,728,Rayo Vallecano,140,La Liga,2024,2,1,1,5,2.5
+31561.0,I. Nestorovski,494,Udinese,135,Serie A,2022,2,1,1,5,2.5
+1580.0,William Carvalho,543,Real Betis,140,La Liga,2021,2,1,1,5,2.5
+1496.0,Raphinha,63,Leeds,39,Premier League,2021,2,1,1,5,2.5
+2729.0,Joachim Andersen,52,Crystal Palace,39,Premier League,2023,2,1,1,5,2.5
+22247.0,Kenny Lala,106,Stade Brestois 29,61,Ligue 1,2023,2,1,1,5,2.5
+22247.0,Kenny Lala,106,Stade Brestois 29,61,Ligue 1,2024,2,1,1,5,2.5
+22236.0,Rafael Leão,489,AC Milan,135,Serie A,2023,2,1,1,5,2.5
+22173.0,A. Saint-Maximin,34,Newcastle,39,Premier League,2022,2,1,1,5,2.5
+1460.0,B. Saka,42,Arsenal,39,Premier League,2024,2,1,1,5,2.5
+1455.0,A. Iwobi,45,Everton,39,Premier League,2021,2,1,1,5,2.5
+32887.0,Y. Sugawara,41,Southampton,39,Premier League,2024,2,1,1,5,2.5
+32940.0,Ado Onaiwu,108,Auxerre,61,Ligue 1,2024,2,1,1,5,2.5
+31692.0,M. Đurić,1579,Monza,135,Serie A,2023,2,1,1,5,2.5
+31743.0,A. La Mantia,511,Empoli,135,Serie A,2021,2,1,1,5,2.5
+31624.0,Gabriel Strefezza,895,Como,135,Serie A,2024,2,1,1,5,2.5
+31642.0,L. Ranieri,502,Fiorentina,135,Serie A,2023,2,1,1,5,2.5
+2906.0,Lee Jae-Sung,164,FSV Mainz 05,78,Bundesliga,2021,2,1,1,5,2.5
+21587.0,Ellyes Skhiri,192,1.FC Köln,78,Bundesliga,2021,2,1,1,5,2.5
+1166.0,T. Werner,49,Chelsea,39,Premier League,2021,2,1,1,5,2.5
+1166.0,T. Werner,173,RB Leipzig,78,Bundesliga,2022,2,1,1,5,2.5
+1159.0,M. Sabitzer,157,Bayern München,78,Bundesliga,2021,2,1,1,5,2.5
+1159.0,M. Sabitzer,157,Bayern München,78,Bundesliga,2022,2,1,1,5,2.5
+1152.0,E. Forsberg,173,RB Leipzig,78,Bundesliga,2022,2,1,1,5,2.5
+1153.0,A. Haidara,173,RB Leipzig,78,Bundesliga,2022,2,1,1,5,2.5
+22015.0,B. Dia,487,Lazio,135,Serie A,2024,2,1,1,5,2.5
+21714.0,Sory Kaba,534,Las Palmas,140,La Liga,2023,2,1,1,5,2.5
+21618.0,J. Allevinah,99,Clermont Foot,61,Ligue 1,2021,2,1,1,5,2.5
+21694.0,N. Aguerd,94,Rennes,61,Ligue 1,2021,2,1,1,5,2.5
+2933.0,B. Chilwell,49,Chelsea,39,Premier League,2022,1,1,1,5,5.0
+2934.0,M. Keane,45,Everton,39,Premier League,2022,2,1,1,5,2.5
+2935.0,Harry Maguire,33,Manchester United,39,Premier League,2023,2,1,1,5,2.5
+2926.0,Y. Tielemans,46,Leicester,39,Premier League,2021,2,1,1,5,2.5
+1422.0,J. Doku,50,Manchester City,39,Premier League,2024,2,1,1,5,2.5
+1422.0,J. Doku,94,Rennes,61,Ligue 1,2021,2,1,1,5,2.5
+1358.0,E. Elmas,492,Napoli,135,Serie A,2021,2,1,1,5,2.5
+2823.0,S. Lukić,503,Torino,135,Serie A,2021,2,1,1,5,2.5
+2862.0,S. Andersson,192,1.FC Köln,78,Bundesliga,2021,2,1,1,5,2.5
+2821.0,M. Veljković,162,Werder Bremen,78,Bundesliga,2022,2,1,1,5,2.5
+2806.0,Fabian Schär,34,Newcastle,39,Premier League,2023,2,1,1,5,2.5
+2781.0,M. Simon,83,Nantes,61,Ligue 1,2023,1,1,1,5,5.0
+1323.0,Dani Olmo,173,RB Leipzig,78,Bundesliga,2021,2,1,1,5,2.5
+1302.0,J. Wind,161,VfL Wolfsburg,78,Bundesliga,2023,2,1,1,5,2.5
+1276.0,S. Kalu,78,Bordeaux,61,Ligue 1,2021,2,1,1,5,2.5
+46658.0,Rubén García,727,Osasuna,140,La Liga,2023,2,1,1,5,2.5
+46660.0,Javi Martínez,727,Osasuna,140,La Liga,2021,2,1,1,5,2.5
+46666.0,Roberto Torres,727,Osasuna,140,La Liga,2021,1,1,1,5,5.0
+46687.0,Montoro,715,Granada CF,140,La Liga,2021,2,1,1,5,2.5
+41725.0,Fábio Vieira,42,Arsenal,39,Premier League,2023,2,1,1,5,2.5
+21497.0,L. Blas,83,Nantes,61,Ligue 1,2021,2,1,1,5,2.5
+21437.0,D. Bouanga,1063,Saint Etienne,61,Ligue 1,2021,2,1,1,5,2.5
+21154.0,F. Tait,94,Rennes,61,Ligue 1,2022,2,1,1,5,2.5
+3007.0,P. Frankowski,116,Lens,61,Ligue 1,2024,2,1,1,5,2.5
+910.0,A. Sánchez,505,Inter,135,Serie A,2023,2,1,1,5,2.5
+47440.0,Brais Méndez,548,Real Sociedad,140,La Liga,2024,2,1,1,5,2.5
+47445.0,Iago Aspas,538,Celta Vigo,140,La Liga,2022,2,1,1,5,2.5
+931.0,Ferran Torres,529,Barcelona,140,La Liga,2022,2,1,1,5,2.5
+983.0,Leon Bailey,66,Aston Villa,39,Premier League,2024,2,1,1,5,2.5
+47341.0,Marc Roca,63,Leeds,39,Premier League,2022,2,1,1,5,2.5
+47317.0,Barrenetxea,548,Real Sociedad,140,La Liga,2024,1,1,1,5,5.0
+933.0,K. Gameiro,95,Strasbourg,61,Ligue 1,2023,2,1,1,5,2.5
+928.0,Dani Parejo,533,Villarreal,140,La Liga,2021,2,1,1,5,2.5
+47422.0,Youssef En-Nesyri,536,Sevilla,140,La Liga,2021,2,1,1,5,2.5
+1096.0,Dominik Szoboszlai,40,Liverpool,39,Premier League,2023,2,1,1,5,2.5
+21451.0,R. Ripart,110,Estac Troyes,61,Ligue 1,2022,2,1,1,5,2.5
+1101.0,Takumi Minamino,91,Monaco,61,Ligue 1,2023,2,1,1,5,2.5
+1103.0,H. Wolf,163,Borussia Mönchengladbach,78,Bundesliga,2022,2,1,1,5,2.5
+1119.0,K. Ajer,55,Brentford,39,Premier League,2021,2,1,1,5,2.5
+1098.0,P. Daka,46,Leicester,39,Premier League,2021,2,1,1,5,2.5
+47300.0,T. Hernández,489,AC Milan,135,Serie A,2021,2,1,1,5,2.5
+47300.0,T. Hernández,489,AC Milan,135,Serie A,2022,2,1,1,5,2.5
+1188.0,E. Botheim,514,Salernitana,135,Serie A,2022,2,1,1,5,2.5
+1208.0,Hernani,523,Parma,135,Serie A,2024,2,1,1,5,2.5
+46979.0,Iván Sánchez,720,Valladolid,140,La Liga,2024,2,1,1,5,2.5
+47002.0,Fidel,797,Elche,140,La Liga,2021,2,1,1,5,2.5
+46769.0,Álex Fernández,724,Cadiz,140,La Liga,2021,2,1,1,5,2.5
+46746.0,A. Budimir,727,Osasuna,140,La Liga,2024,2,1,1,5,2.5
+46733.0,Raíllo,798,Mallorca,140,La Liga,2022,2,1,1,5,2.5
+46709.0,Álvaro Tejero,540,Espanyol,140,La Liga,2024,2,1,1,5,2.5
+46731.0,P. Estupiñán,51,Brighton,39,Premier League,2022,2,1,1,5,2.5
+1101.0,Takumi Minamino,91,Monaco,61,Ligue 1,2022,1,1,1,5,5.0
+864.0,E. Can,165,Borussia Dortmund,78,Bundesliga,2021,2,1,1,5,2.5
+842.0,N. Vlašić,503,Torino,135,Serie A,2022,2,1,1,5,2.5
+48648.0,D. Ndoye,500,Bologna,135,Serie A,2024,2,1,1,5,2.5
+48471.0,R. Vargas,170,FC Augsburg,78,Bundesliga,2022,2,1,1,5,2.5
+48392.0,E. Zhegrova,79,Lille,61,Ligue 1,2024,2,1,1,5,2.5
+48193.0,P. Almqvist,523,Parma,135,Serie A,2024,2,1,1,5,2.5
+48193.0,P. Almqvist,867,Lecce,135,Serie A,2023,2,1,1,5,2.5
+47582.0,C. Hernández,543,Real Betis,140,La Liga,2024,2,1,1,5,2.5
+20696.0,P. Gueye,536,Sevilla,140,La Liga,2022,2,1,1,5,2.5
+20732.0,G. Perrin,108,Auxerre,61,Ligue 1,2022,2,1,1,5,2.5
+20665.0,J. Bellegarde,95,Strasbourg,61,Ligue 1,2021,2,1,1,5,2.5
+20677.0,G. Kyei,99,Clermont Foot,61,Ligue 1,2022,2,1,1,5,2.5
+20600.0,Romain Perraud,543,Real Betis,140,La Liga,2024,1,1,1,5,5.0
+3336.0,Falaye Sacko,82,Montpellier,61,Ligue 1,2022,2,1,1,5,2.5
+873.0,F. Bernardeschi,496,Juventus,135,Serie A,2021,2,1,1,5,2.5
+858.0,M. De Sciglio,496,Juventus,135,Serie A,2021,2,1,1,5,2.5
+47499.0,E. Ünal,35,Bournemouth,39,Premier League,2023,2,1,1,5,2.5
+918.0,José Gayà,532,Valencia,140,La Liga,2021,2,1,1,5,2.5
+919.0,Hugo Guillamón,532,Valencia,140,La Liga,2022,2,1,1,5,2.5
+2937.0,D. Rice,42,Arsenal,39,Premier League,2024,2,1,1,5,2.5
+20858.0,M. Barreto,98,Ajaccio,61,Ligue 1,2022,2,1,1,5,2.5
+20866.0,B. Touré,108,Auxerre,61,Ligue 1,2021,2,1,1,5,2.5
+20780.0,Mathias Pereira Lage,77,Angers,61,Ligue 1,2021,2,1,1,5,2.5
+20780.0,Mathias Pereira Lage,106,Stade Brestois 29,61,Ligue 1,2023,2,1,1,5,2.5
+933.0,K. Gameiro,95,Strasbourg,61,Ligue 1,2021,2,1,1,5,2.5
+897.0,M. Greenwood,33,Manchester United,39,Premier League,2021,2,1,1,5,2.5
+886.0,Diogo Dalot,33,Manchester United,39,Premier League,2023,2,1,1,5,2.5
+47533.0,Alejandro Catena,727,Osasuna,140,La Liga,2023,2,1,1,5,2.5
+47541.0,Santi Comesaña,533,Villarreal,140,La Liga,2024,2,1,1,5,2.5
+47520.0,Portu,547,Girona,140,La Liga,2024,2,1,1,5,2.5
+47522.0,Douglas Luiz,66,Aston Villa,39,Premier League,2022,2,1,1,5,2.5
+47494.0,Miguel de la Fuente,537,Leganes,140,La Liga,2024,2,1,1,5,2.5
+744.0,Brahim Díaz,541,Real Madrid,140,La Liga,2024,1,1,1,5,5.0
+66019.0,Adam Hložek,168,Bayer Leverkusen,78,Bundesliga,2022,2,1,1,5,2.5
+66019.0,Adam Hložek,168,Bayer Leverkusen,78,Bundesliga,2023,2,1,1,5,2.5
+63577.0,M. Mudryk,49,Chelsea,39,Premier League,2023,2,1,1,5,2.5
+61224.0,L. Lochoshvili,520,Cremonese,135,Serie A,2022,2,1,1,5,2.5
+727.0,R. Nelson,36,Fulham,39,Premier League,2024,2,1,1,5,2.5
+723.0,Joelinton,34,Newcastle,39,Premier League,2022,2,1,1,5,2.5
+723.0,Joelinton,34,Newcastle,39,Premier League,2024,2,1,1,5,2.5
+20529.0,G. Hein,112,Metz,61,Ligue 1,2024,1,1,1,5,5.0
+19959.0,B. White,42,Arsenal,39,Premier League,2023,2,1,1,5,2.5
+19974.0,I. Toney,55,Brentford,39,Premier League,2023,2,1,1,5,2.5
+20110.0,S. Baptiste,55,Brentford,39,Premier League,2023,2,1,1,5,2.5
+19808.0,C. Woodrow,1359,Luton,39,Premier League,2023,2,1,1,5,2.5
+19586.0,E. Eze,52,Crystal Palace,39,Premier League,2023,2,1,1,5,2.5
+19545.0,R. James,49,Chelsea,39,Premier League,2021,2,1,1,5,2.5
+754.0,L. Modrić,541,Real Madrid,140,La Liga,2022,2,1,1,5,2.5
+56396.0,Junior Messias,489,AC Milan,135,Serie A,2021,2,1,1,5,2.5
+51095.0,A. Elis,78,Bordeaux,61,Ligue 1,2021,2,1,1,5,2.5
+50852.0,Joseph Scally,163,Borussia Mönchengladbach,78,Bundesliga,2023,2,1,1,5,2.5
+3246.0,N. Pépé,42,Arsenal,39,Premier League,2021,2,1,1,5,2.5
+3173.0,I. Bennacer,489,AC Milan,135,Serie A,2021,1,1,1,5,5.0
+20589.0,B. Mbeumo,55,Brentford,39,Premier League,2021,2,1,1,5,2.5
+20537.0,I. Niane,77,Angers,61,Ligue 1,2024,2,1,1,5,2.5
+20526.0,F. Boulaya,112,Metz,61,Ligue 1,2021,2,1,1,5,2.5
+47574.0,Moi Gómez,533,Villarreal,140,La Liga,2021,2,1,1,5,2.5
+47576.0,Gonzalo Melero,723,Almeria,140,La Liga,2022,2,1,1,5,2.5
+47543.0,Álvaro García,728,Rayo Vallecano,140,La Liga,2023,2,1,1,5,2.5
+791.0,S. El Shaarawy,497,AS Roma,135,Serie A,2024,2,1,1,5,2.5
+782.0,L. Pellegrini,497,AS Roma,135,Serie A,2022,2,1,1,5,2.5
+786.0,N. Zaniolo,499,Atalanta,135,Serie A,2024,2,1,1,5,2.5
+51617.0,D. Núñez,40,Liverpool,39,Premier League,2022,2,1,1,5,2.5
+53535.0,E. Shomurodov,497,AS Roma,135,Serie A,2024,2,1,1,5,2.5
+3428.0,J. Ayew,52,Crystal Palace,39,Premier League,2023,2,1,1,5,2.5
+19365.0,C. Ogbene,1359,Luton,39,Premier League,2023,2,1,1,5,2.5
+19361.0,S. Benrahma,48,West Ham,39,Premier League,2022,2,1,1,5,2.5
+643.0,Gabriel Jesus,50,Manchester City,39,Premier League,2021,2,1,1,5,2.5
+644.0,L. Sané,157,Bayern München,78,Bundesliga,2022,2,1,1,5,2.5
+127817.0,P. Hincapié,168,Bayer Leverkusen,78,Bundesliga,2023,2,1,1,5,2.5
+126936.0,Samuel Lino,530,Atletico Madrid,140,La Liga,2024,1,1,1,5,5.0
+126642.0,P. Wimmer,161,VfL Wolfsburg,78,Bundesliga,2022,2,1,1,5,2.5
+83831.0,I. Kebbal,93,Reims,61,Ligue 1,2021,2,1,1,5,2.5
+84082.0,R. Faivre,97,Lorient,61,Ligue 1,2023,2,1,1,5,2.5
+72388.0,G. Charpentier,523,Parma,135,Serie A,2024,2,1,1,5,2.5
+736.0,Fran García,728,Rayo Vallecano,140,La Liga,2022,2,1,1,5,2.5
+6085.0,C. Benavídez,542,Alaves,140,La Liga,2024,1,1,1,5,5.0
+6011.0,R. Borré,169,Eintracht Frankfurt,78,Bundesliga,2021,2,1,1,5,2.5
+5996.0,Enzo Fernández,49,Chelsea,39,Premier League,2023,2,1,1,5,2.5
+3428.0,J. Ayew,52,Crystal Palace,39,Premier League,2022,2,1,1,5,2.5
+714.0,N. Amiri,164,FSV Mainz 05,78,Bundesliga,2024,2,1,1,5,2.5
+690.0,V. Kovalenko,515,Spezia,135,Serie A,2021,2,1,1,5,2.5
+101814.0,Ronald Araújo,529,Barcelona,140,La Liga,2023,2,1,1,5,2.5
+90617.0,Lassine Sinayoko,108,Auxerre,61,Ligue 1,2024,2,1,1,5,2.5
+87324.0,A. Flips,93,Reims,61,Ligue 1,2022,2,1,1,5,2.5
+84082.0,R. Faivre,106,Stade Brestois 29,61,Ligue 1,2024,2,1,1,5,2.5
+84128.0,Y. Gboho,96,Toulouse,61,Ligue 1,2023,2,1,1,5,2.5
+85041.0,A. Gouiri,94,Rennes,61,Ligue 1,2022,2,1,1,5,2.5
+724.0,I. Belfodil,159,Hertha Berlin,78,Bundesliga,2021,2,1,1,5,2.5
+70100.0,J. Zirkzee,500,Bologna,135,Serie A,2022,2,1,1,5,2.5
+70100.0,J. Zirkzee,33,Manchester United,39,Premier League,2024,2,1,1,5,2.5
+67971.0,Marc Guéhi,52,Crystal Palace,39,Premier League,2021,2,1,1,5,2.5
+67973.0,I. Ugbo,110,Estac Troyes,61,Ligue 1,2022,2,1,1,5,2.5
+757.0,Lucas Vázquez,541,Real Madrid,140,La Liga,2023,2,1,1,5,2.5
+752.0,Toni Kroos,541,Real Madrid,140,La Liga,2022,2,1,1,5,2.5
+709.0,Pavel Kadeřábek,167,1899 Hoffenheim,78,Bundesliga,2023,2,1,1,5,2.5
+7591.0,S. Lovrić,494,Udinese,135,Serie A,2022,2,1,1,5,2.5
+7106.0,K. Yeboah,170,FC Augsburg,78,Bundesliga,2022,2,1,1,5,2.5
+6716.0,A. Mac Allister,40,Liverpool,39,Premier League,2023,2,1,1,5,2.5
+8683.0,I. Cardona,106,Stade Brestois 29,61,Ligue 1,2021,2,1,1,5,2.5
+511.0,L. Goretzka,157,Bayern München,78,Bundesliga,2024,2,1,1,5,2.5
+508.0,K. Coman,157,Bayern München,78,Bundesliga,2022,2,1,1,5,2.5
+138815.0,T. Lamptey,51,Brighton,39,Premier League,2024,2,1,1,5,2.5
+137302.0,C. Archer,62,Sheffield Utd,39,Premier League,2023,2,1,1,5,2.5
+129033.0,J. Gvardiol,173,RB Leipzig,78,Bundesliga,2021,2,1,1,5,2.5
+129072.0,Y. Vertessen,182,Union Berlin,78,Bundesliga,2023,2,1,1,5,2.5
+129033.0,J. Gvardiol,50,Manchester City,39,Premier League,2023,1,1,1,5,5.0
+128461.0,N. Zortea,512,Frosinone,135,Serie A,2023,2,1,1,5,2.5
+128478.0,W. Cheddira,540,Espanyol,140,La Liga,2024,2,1,1,5,2.5
+128533.0,J. Leweling,182,Union Berlin,78,Bundesliga,2022,2,1,1,5,2.5
+128384.0,Vitinha,85,Paris Saint Germain,61,Ligue 1,2023,2,1,1,5,2.5
+128384.0,Vitinha,85,Paris Saint Germain,61,Ligue 1,2024,2,1,1,5,2.5
+659.0,M. Caqueret,80,Lyon,61,Ligue 1,2023,2,1,1,5,2.5
+665.0,M. Cornet,495,Genoa,135,Serie A,2024,2,1,1,5,2.5
+653.0,Ferland Mendy,541,Real Madrid,140,La Liga,2021,2,1,1,5,2.5
+643.0,Gabriel Jesus,42,Arsenal,39,Premier League,2023,2,1,1,5,2.5
+548.0,H. Ziyech,49,Chelsea,39,Premier League,2021,2,1,1,5,2.5
+129718.0,J. Bellingham,165,Borussia Dortmund,78,Bundesliga,2022,2,1,1,5,2.5
+131546.0,Isi Palazón,728,Rayo Vallecano,140,La Liga,2021,2,1,1,5,2.5
+129711.0,B. Johnson,47,Tottenham,39,Premier League,2024,2,1,1,5,2.5
+126936.0,Samuel Lino,530,Atletico Madrid,140,La Liga,2023,2,1,1,5,2.5
+119232.0,Dani Gómez,539,Levante,140,La Liga,2021,2,1,1,5,2.5
+104853.0,Asier Villalibre,531,Athletic Club,140,La Liga,2023,2,1,1,5,2.5
+106257.0,A. Gabrielloni,895,Como,135,Serie A,2024,1,1,1,5,5.0
+106725.0,K. Lewis-Potter,55,Brentford,39,Premier League,2024,2,1,1,5,2.5
+631.0,P. Foden,50,Manchester City,39,Premier League,2022,2,1,1,5,2.5
+618.0,Danilo,496,Juventus,135,Serie A,2021,2,1,1,5,2.5
+618.0,Danilo,496,Juventus,135,Serie A,2022,2,1,1,5,2.5
+372.0,Éder Militão,541,Real Madrid,140,La Liga,2021,2,1,1,5,2.5
+333.0,A. Milik,496,Juventus,135,Serie A,2023,2,1,1,5,2.5
+349.0,A. Terzić,502,Fiorentina,135,Serie A,2022,2,1,1,5,2.5
+328.0,Fabián Ruiz,85,Paris Saint Germain,61,Ligue 1,2023,2,1,1,5,2.5
+325.0,G. Gaetano,492,Napoli,135,Serie A,2022,2,1,1,5,2.5
+272.0,A. Rabiot,496,Juventus,135,Serie A,2023,2,1,1,5,2.5
+275.0,E. Choupo-Moting,157,Bayern München,78,Bundesliga,2023,2,1,1,5,2.5
+269.0,C. Nkunku,49,Chelsea,39,Premier League,2024,2,1,1,5,2.5
+19134.0,P. Bamford,63,Leeds,39,Premier League,2022,2,1,1,5,2.5
+19116.0,L. Ayling,63,Leeds,39,Premier League,2021,2,1,1,5,2.5
+10036.0,Douglas Augusto,83,Nantes,61,Ligue 1,2024,2,1,1,5,2.5
+289.0,A. Robertson,40,Liverpool,39,Premier League,2023,2,1,1,5,2.5
+290.0,Virgil van Dijk,40,Liverpool,39,Premier League,2021,2,1,1,5,2.5
+178749.0,L. Samardžić,499,Atalanta,135,Serie A,2024,2,1,1,5,2.5
+178077.0,K. Schade,55,Brentford,39,Premier League,2023,2,1,1,5,2.5
+174565.0,H. Ekitiké,85,Paris Saint Germain,61,Ligue 1,2022,1,1,1,5,5.0
+163032.0,F. Rieder,172,VfB Stuttgart,78,Bundesliga,2024,2,1,1,5,2.5
+158644.0,M. Beier,165,Borussia Dortmund,78,Bundesliga,2024,1,1,1,5,5.0
+156490.0,N. Nkounkou,169,Eintracht Frankfurt,78,Bundesliga,2023,2,1,1,5,2.5
+147859.0,C. De Ketelaere,499,Atalanta,135,Serie A,2024,2,1,1,5,2.5
+8492.0,A. Sørloth,548,Real Sociedad,140,La Liga,2022,2,1,1,5,2.5
+8486.0,E. Smith,186,FC St. Pauli,78,Bundesliga,2024,2,1,1,5,2.5
+19163.0,J. Murphy,34,Newcastle,39,Premier League,2023,2,1,1,5,2.5
+19128.0,J. Harrison,63,Leeds,39,Premier League,2022,2,1,1,5,2.5
+137303.0,E. Guessand,83,Nantes,61,Ligue 1,2022,2,1,1,5,2.5
+137303.0,E. Guessand,84,Nice,61,Ligue 1,2021,2,1,1,5,2.5
+137303.0,E. Guessand,84,Nice,61,Ligue 1,2024,2,1,1,5,2.5
+136723.0,N. Madueke,49,Chelsea,39,Premier League,2023,2,1,1,5,2.5
+502.0,J. Kimmich,157,Bayern München,78,Bundesliga,2022,2,1,1,5,2.5
+483.0,K. Kvaratskhelia,492,Napoli,135,Serie A,2023,2,1,1,5,2.5
+421.0,Breel Embolo,91,Monaco,61,Ligue 1,2024,2,1,1,5,2.5
+138816.0,I. Maatsen,165,Borussia Dortmund,78,Bundesliga,2023,2,1,1,5,2.5
+18870.0,D. Brooks,35,Bournemouth,39,Premier League,2023,2,1,1,5,2.5
+18816.0,A. Masuaku,48,West Ham,39,Premier League,2021,2,1,1,5,2.5
+18805.0,A. Doucouré,45,Everton,39,Premier League,2023,2,1,1,5,2.5
+17756.0,O. Afolayan,186,FC St. Pauli,78,Bundesliga,2024,2,1,1,5,2.5
+59.0,Álvaro Morata,496,Juventus,135,Serie A,2021,2,1,1,5,2.5
+358628.0,Samuel Omorodion,542,Alaves,140,La Liga,2023,2,1,1,5,2.5
+356888.0,N. Pisilli,497,AS Roma,135,Serie A,2024,2,1,1,5,2.5
+341646.0,V. Carboni,1579,Monza,135,Serie A,2023,2,1,1,5,2.5
+324957.0,T. Rothe,182,Union Berlin,78,Bundesliga,2024,2,1,1,5,2.5
+325594.0,F. Lemaréchal,95,Strasbourg,61,Ligue 1,2024,2,1,1,5,2.5
+326068.0,K. Doumbia,106,Stade Brestois 29,61,Ligue 1,2023,2,1,1,5,2.5
+322929.0,I. Cissoko,96,Toulouse,61,Ligue 1,2023,2,1,1,5,2.5
+149.0,Ivan Rakitić,536,Sevilla,140,La Liga,2022,2,1,1,5,2.5
+149.0,Ivan Rakitić,536,Sevilla,140,La Liga,2023,2,1,1,5,2.5
+153.0,O. Dembélé,529,Barcelona,140,La Liga,2022,2,1,1,5,2.5
+18895.0,Florian Lejeune,728,Rayo Vallecano,140,La Liga,2023,2,1,1,5,2.5
+284797.0,Dango Ouattara,97,Lorient,61,Ligue 1,2021,2,1,1,5,2.5
+104.0,Carlos Vinícius,36,Fulham,39,Premier League,2022,2,1,1,5,2.5
+107.0,S. Diop,84,Nice,61,Ligue 1,2024,2,1,1,5,2.5
+98.0,B. Henrichs,173,RB Leipzig,78,Bundesliga,2021,2,1,1,5,2.5
+336585.0,Mateus Fernandes,41,Southampton,39,Premier League,2024,2,1,1,5,2.5
+334037.0,T. George,49,Chelsea,39,Premier League,2024,2,1,1,5,2.5
+328648.0,S. Babicka,96,Toulouse,61,Ligue 1,2024,2,1,1,5,2.5
+327631.0,H. Diarra,95,Strasbourg,61,Ligue 1,2023,2,1,1,5,2.5
+219.0,M. Politano,492,Napoli,135,Serie A,2022,2,1,1,5,2.5
+226.0,D. Dumfries,505,Inter,135,Serie A,2023,2,1,1,5,2.5
+128.0,Jordi Alba,529,Barcelona,140,La Liga,2022,2,1,1,5,2.5
+296560.0,Jackson Tchatchoua,504,Verona,135,Serie A,2024,2,1,1,5,2.5
+291476.0,D. Fofana,44,Burnley,39,Premier League,2023,2,1,1,5,2.5
+291649.0,Vanderson,91,Monaco,61,Ligue 1,2021,2,1,1,5,2.5
+286894.0,J. Gittens,165,Borussia Dortmund,78,Bundesliga,2022,2,1,1,5,2.5
+286474.0,M. Cancellieri,511,Empoli,135,Serie A,2023,2,1,1,5,2.5
+2493.0,L. Muriel,499,Atalanta,135,Serie A,2023,2,1,1,5,2.5
+2495.0,D. Zapata,499,Atalanta,135,Serie A,2022,2,1,1,5,2.5
+2522.0,A. Sanabria,503,Torino,135,Serie A,2022,2,1,1,5,2.5
+2489.0,L. Díaz,40,Liverpool,39,Premier League,2021,2,1,1,5,2.5
+2218.0,I. Sarr,81,Marseille,61,Ligue 1,2023,2,1,1,5,2.5
+2214.0,Romain Del Castillo,106,Stade Brestois 29,61,Ligue 1,2024,2,1,1,5,2.5
+2218.0,I. Sarr,38,Watford,39,Premier League,2021,2,1,1,5,2.5
+26258.0,N. Petersen,160,SC Freiburg,78,Bundesliga,2021,2,1,1,5,2.5
+2413.0,Richarlison,47,Tottenham,39,Premier League,2022,2,1,1,5,2.5
+25408.0,M. Arnold,161,VfL Wolfsburg,78,Bundesliga,2023,1,1,1,5,5.0
+25389.0,I. Bebou,167,1899 Hoffenheim,78,Bundesliga,2021,2,1,1,5,2.5
+25366.0,Kevin Akpoguma,167,1899 Hoffenheim,78,Bundesliga,2021,2,1,1,5,2.5
+25368.0,Waldemar Anton,172,VfB Stuttgart,78,Bundesliga,2022,2,1,1,5,2.5
+25345.0,K. Rekik,536,Sevilla,140,La Liga,2022,2,1,1,5,2.5
+25183.0,P. Förster,176,VfL Bochum,78,Bundesliga,2022,2,1,1,5,2.5
+25192.0,K. Behrens,182,Union Berlin,78,Bundesliga,2022,2,1,1,5,2.5
+2299.0,Pedro,487,Lazio,135,Serie A,2021,2,1,1,5,2.5
+2291.0,M. Kovačić,49,Chelsea,39,Premier League,2022,2,1,1,5,2.5
+2295.0,O. Giroud,489,AC Milan,135,Serie A,2021,2,1,1,5,2.5
+25635.0,J. Hofmann,168,Bayer Leverkusen,78,Bundesliga,2024,2,1,1,5,2.5
+25461.0,K. Stöger,164,FSV Mainz 05,78,Bundesliga,2021,2,1,1,5,2.5
+25461.0,K. Stöger,176,VfL Bochum,78,Bundesliga,2022,2,1,1,5,2.5
+2473.0,M. Lanzini,48,West Ham,39,Premier League,2021,2,1,1,5,2.5
+2467.0,Lisandro Martínez,33,Manchester United,39,Premier League,2024,2,1,1,5,2.5
+342035.0,C. Volpato,497,AS Roma,135,Serie A,2022,1,1,1,5,5.0
+340152.0,S. Idumbo,536,Sevilla,140,La Liga,2024,2,1,1,5,2.5
+340626.0,Fermín López,529,Barcelona,140,La Liga,2024,2,1,1,5,2.5
+386828.0,Lamine Yamal,529,Barcelona,140,La Liga,2023,2,1,1,5,2.5
+399906.0,O. Maamma,82,Montpellier,61,Ligue 1,2024,2,1,1,5,2.5
+25.0,M. Reus,165,Borussia Dortmund,78,Bundesliga,2022,2,1,1,5,2.5
+26.0,M. Wolf,165,Borussia Dortmund,78,Bundesliga,2022,2,1,1,5,2.5
+22.0,J. Bruun Larsen,167,1899 Hoffenheim,78,Bundesliga,2021,2,1,1,5,2.5
+286475.0,E. Bove,497,AS Roma,135,Serie A,2023,2,0,2,4,2.0
+131546.0,Isi Palazón,728,Rayo Vallecano,140,La Liga,2022,2,0,2,4,2.0
+47266.0,Ángel,798,Mallorca,140,La Liga,2021,2,0,2,4,2.0
+288055.0,Ângelo,95,Strasbourg,61,Ligue 1,2023,2,0,2,4,2.0
+129695.0,D. Bakwa,95,Strasbourg,61,Ligue 1,2023,2,0,2,4,2.0
+288.0,Alberto Moreno,533,Villarreal,140,La Liga,2023,2,0,2,4,2.0
+7305.0,B. Pichler,191,Holstein Kiel,78,Bundesliga,2024,2,0,2,4,2.0
+6716.0,A. Mac Allister,40,Liverpool,39,Premier League,2024,2,0,2,4,2.0
+934.0,Santi Mina,538,Celta Vigo,140,La Liga,2021,2,0,2,4,2.0
+536.0,D. Sinkgraven,168,Bayer Leverkusen,78,Bundesliga,2022,2,0,2,4,2.0
+180731.0,Lorenz Assignon,94,Rennes,61,Ligue 1,2021,1,0,2,4,4.0
+548.0,H. Ziyech,49,Chelsea,39,Premier League,2022,2,0,2,4,2.0
+1159.0,M. Sabitzer,165,Borussia Dortmund,78,Bundesliga,2023,2,0,2,4,2.0
+3430.0,C. Ekuban,495,Genoa,135,Serie A,2024,1,0,2,4,4.0
+1173.0,B. Meling,94,Rennes,61,Ligue 1,2021,2,0,2,4,2.0
+19428.0,J. Bowen,48,West Ham,39,Premier League,2023,2,0,2,4,2.0
+30687.0,S. Bastoni,515,Spezia,135,Serie A,2021,2,0,2,4,2.0
+1138.0,T. Weah,79,Lille,61,Ligue 1,2022,1,0,2,4,4.0
+6662.0,S. Pierotti,867,Lecce,135,Serie A,2023,2,0,2,4,2.0
+46930.0,E. Demirović,160,SC Freiburg,78,Bundesliga,2021,2,0,2,4,2.0
+6057.0,P. Galdames,520,Cremonese,135,Serie A,2022,2,0,2,4,2.0
+5996.0,Enzo Fernández,49,Chelsea,39,Premier League,2024,2,0,2,4,2.0
+30810.0,R. Mandragora,502,Fiorentina,135,Serie A,2023,2,0,2,4,2.0
+719.0,F. Grillitsch,167,1899 Hoffenheim,78,Bundesliga,2023,2,0,2,4,2.0
+725.0,R. Hack,163,Borussia Mönchengladbach,78,Bundesliga,2024,2,0,2,4,2.0
+19569.0,J. Gelhardt,63,Leeds,39,Premier League,2022,2,0,2,4,2.0
+725.0,R. Hack,188,Arminia Bielefeld,78,Bundesliga,2021,2,0,2,4,2.0
+292.0,J. Henderson,40,Liverpool,39,Premier League,2021,2,0,2,4,2.0
+19829.0,A. Doughty,1359,Luton,39,Premier League,2023,2,0,2,4,2.0
+19827.0,Josh Cullen,44,Burnley,39,Premier League,2023,2,0,2,4,2.0
+25155.0,T. Mohr,174,FC Schalke 04,78,Bundesliga,2022,2,0,2,4,2.0
+30937.0,M. Zaccagni,487,Lazio,135,Serie A,2022,2,0,2,4,2.0
+129676.0,P. Yade,110,Estac Troyes,61,Ligue 1,2022,2,0,2,4,2.0
+67972.0,C. Gallagher,530,Atletico Madrid,140,La Liga,2024,2,0,2,4,2.0
+753.0,Marcos Llorente,530,Atletico Madrid,140,La Liga,2024,2,0,2,4,2.0
+25008.0,J. Clauss,81,Marseille,61,Ligue 1,2022,2,0,2,4,2.0
+25073.0,V. Janelt,55,Brentford,39,Premier League,2023,2,0,2,4,2.0
+733.0,Dani Carvajal,541,Real Madrid,140,La Liga,2021,2,0,2,4,2.0
+8624.0,F. Tardieu,1063,Saint Etienne,61,Ligue 1,2024,2,0,2,4,2.0
+989.0,K. Volland,91,Monaco,61,Ligue 1,2021,2,0,2,4,2.0
+30558.0,N. Barella,505,Inter,135,Serie A,2024,2,0,2,4,2.0
+30558.0,N. Barella,505,Inter,135,Serie A,2022,2,0,2,4,2.0
+47336.0,Darder,540,Espanyol,140,La Liga,2021,2,0,2,4,2.0
+308836.0,M. Keita,523,Parma,135,Serie A,2024,2,0,2,4,2.0
+47336.0,Darder,798,Mallorca,140,La Liga,2024,2,0,2,4,2.0
+25408.0,M. Arnold,161,VfL Wolfsburg,78,Bundesliga,2024,2,0,2,4,2.0
+25348.0,V. Darida,159,Hertha Berlin,78,Bundesliga,2021,2,0,2,4,2.0
+567.0,Rúben Dias,50,Manchester City,39,Premier League,2021,2,0,2,4,2.0
+50956.0,Cristian Cásseres Jr.,96,Toulouse,61,Ligue 1,2024,2,0,2,4,2.0
+563.0,Álex Grimaldo,168,Bayer Leverkusen,78,Bundesliga,2024,2,0,2,4,2.0
+137210.0,A. Stiller,172,VfB Stuttgart,78,Bundesliga,2024,2,0,2,4,2.0
+163069.0,L. Netz,163,Borussia Mönchengladbach,78,Bundesliga,2022,2,0,2,4,2.0
+322.0,Mário Rui,492,Napoli,135,Serie A,2022,2,0,2,4,2.0
+137129.0,A. Aouchiche,1063,Saint Etienne,61,Ligue 1,2021,1,0,2,4,4.0
+875.0,P. Dybala,497,AS Roma,135,Serie A,2024,2,0,2,4,2.0
+19071.0,E. Buendía,66,Aston Villa,39,Premier League,2021,2,0,2,4,2.0
+570.0,F. Cervi,538,Celta Vigo,140,La Liga,2022,2,0,2,4,2.0
+25353.0,V. Lazaro,503,Torino,135,Serie A,2023,1,0,2,4,4.0
+296667.0,Gavi,529,Barcelona,140,La Liga,2021,2,0,2,4,2.0
+25355.0,A. Maier,170,FC Augsburg,78,Bundesliga,2021,2,0,2,4,2.0
+25342.0,M. Mittelstädt,172,VfB Stuttgart,78,Bundesliga,2023,2,0,2,4,2.0
+25287.0,K. Danso,116,Lens,61,Ligue 1,2021,2,0,2,4,2.0
+30768.0,Pedro Pereira,1579,Monza,135,Serie A,2023,2,0,2,4,2.0
+1701.0,Manu Morlanes,798,Mallorca,140,La Liga,2023,2,0,2,4,2.0
+2601.0,Daichi Kamada,169,Eintracht Frankfurt,78,Bundesliga,2022,2,0,2,4,2.0
+30784.0,N. Rovella,495,Genoa,135,Serie A,2021,2,0,2,4,2.0
+30527.0,Rogério,488,Sassuolo,135,Serie A,2022,2,0,2,4,2.0
+30525.0,Pol Lirola,81,Marseille,61,Ligue 1,2024,2,0,2,4,2.0
+19245.0,M. Tavernier,35,Bournemouth,39,Premier League,2023,2,0,2,4,2.0
+61431.0,J. Kiwior,42,Arsenal,39,Premier League,2023,2,0,2,4,2.0
+174660.0,L. Rao-Lisoa,77,Angers,61,Ligue 1,2024,2,0,2,4,2.0
+19136.0,J. Clarke,57,Ipswich,39,Premier League,2024,2,0,2,4,2.0
+790.0,E. Džeko,505,Inter,135,Serie A,2022,2,0,2,4,2.0
+19179.0,T. Mings,66,Aston Villa,39,Premier League,2022,2,0,2,4,2.0
+385.0,Óliver Torres,536,Sevilla,140,La Liga,2021,2,0,2,4,2.0
+30533.0,Manuel Locatelli,496,Juventus,135,Serie A,2023,2,0,2,4,2.0
+1702.0,Alfonso Pedraza,533,Villarreal,140,La Liga,2022,2,0,2,4,2.0
+38750.0,B. Brobbey,173,RB Leipzig,78,Bundesliga,2021,2,0,2,4,2.0
+1454.0,M. Guendouzi,81,Marseille,61,Ligue 1,2022,2,0,2,4,2.0
+37236.0,A. Matusiwa,94,Rennes,61,Ligue 1,2024,2,0,2,4,2.0
+32034.0,A. Dossena,490,Cagliari,135,Serie A,2023,2,0,2,4,2.0
+1417.0,Alexis Saelemaekers,489,AC Milan,135,Serie A,2021,2,0,2,4,2.0
+2807.0,R. Freuler,499,Atalanta,135,Serie A,2021,2,0,2,4,2.0
+247.0,C. Gakpo,40,Liverpool,39,Premier League,2024,2,0,2,4,2.0
+21100.0,I. Louza,97,Lorient,61,Ligue 1,2023,2,0,2,4,2.0
+3247.0,W. Zaha,52,Crystal Palace,39,Premier League,2022,2,0,2,4,2.0
+21145.0,P. Capelle,77,Angers,61,Ligue 1,2022,2,0,2,4,2.0
+41323.0,Mama Baldé,106,Stade Brestois 29,61,Ligue 1,2024,2,0,2,4,2.0
+190485.0,Samuel Costa,798,Mallorca,140,La Liga,2024,2,0,2,4,2.0
+190686.0,S. Mara,41,Southampton,39,Premier League,2022,2,0,2,4,2.0
+185398.0,Isaac Romero,536,Sevilla,140,La Liga,2023,1,0,2,4,4.0
+285.0,K. Hoever,108,Auxerre,61,Ligue 1,2024,2,0,2,4,2.0
+286.0,J. Matip,40,Liverpool,39,Premier League,2021,2,0,2,4,2.0
+657.0,Kenny Tete,36,Fulham,39,Premier League,2022,2,0,2,4,2.0
+645.0,R. Sterling,49,Chelsea,39,Premier League,2022,2,0,2,4,2.0
+1325.0,K. Andrić,99,Clermont Foot,61,Ligue 1,2022,2,0,2,4,2.0
+1455.0,A. Iwobi,45,Everton,39,Premier League,2022,2,0,2,4,2.0
+1456.0,A. Maitland-Niles,80,Lyon,61,Ligue 1,2024,2,0,2,4,2.0
+1457.0,Henrikh Mkhitaryan,505,Inter,135,Serie A,2023,2,0,2,4,2.0
+22019.0,A. Zeneli,93,Reims,61,Ligue 1,2021,2,0,2,4,2.0
+108563.0,Rodrigo Zalazar,174,FC Schalke 04,78,Bundesliga,2022,2,0,2,4,2.0
+116117.0,Moisés Caicedo,49,Chelsea,39,Premier League,2023,2,0,2,4,2.0
+22171.0,J. Makengo,494,Udinese,135,Serie A,2021,2,0,2,4,2.0
+31543.0,Antonino Gallo,867,Lecce,135,Serie A,2023,2,0,2,4,2.0
+713.0,K. Vogt,167,1899 Hoffenheim,78,Bundesliga,2021,2,0,2,4,2.0
+38735.0,S. Dest,529,Barcelona,140,La Liga,2021,2,0,2,4,2.0
+2906.0,Lee Jae-Sung,164,FSV Mainz 05,78,Bundesliga,2024,2,0,2,4,2.0
+2926.0,Y. Tielemans,66,Aston Villa,39,Premier League,2024,2,0,2,4,2.0
+2926.0,Y. Tielemans,66,Aston Villa,39,Premier League,2023,2,0,2,4,2.0
+37890.0,Jerdy Schouten,500,Bologna,135,Serie A,2022,2,0,2,4,2.0
+2822.0,D. Lazović,504,Verona,135,Serie A,2021,2,0,2,4,2.0
+202844.0,N. Weißhaupt,160,SC Freiburg,78,Bundesliga,2023,2,0,2,4,2.0
+202838.0,D. Huseinbašić,192,1.FC Köln,78,Bundesliga,2023,2,0,2,4,2.0
+227.0,Angeliño,167,1899 Hoffenheim,78,Bundesliga,2022,2,0,2,4,2.0
+231029.0,N. Tella,168,Bayer Leverkusen,78,Bundesliga,2024,2,0,2,4,2.0
+22093.0,R. Cabella,79,Lille,61,Ligue 1,2024,2,0,2,4,2.0
+128398.0,Oihan Sancet,531,Athletic Club,140,La Liga,2021,2,0,2,4,2.0
+46742.0,Dani Rodríguez,798,Mallorca,140,La Liga,2023,2,0,2,4,2.0
+20665.0,J. Bellegarde,95,Strasbourg,61,Ligue 1,2022,2,0,2,4,2.0
+283.0,T. Alexander-Arnold,40,Liverpool,39,Premier League,2022,2,0,2,4,2.0
+20634.0,A. Claude-Maurice,84,Nice,61,Ligue 1,2021,2,0,2,4,2.0
+20761.0,F. Sotoca,116,Lens,61,Ligue 1,2023,2,0,2,4,2.0
+31042.0,G. Di Lorenzo,492,Napoli,135,Serie A,2023,2,0,2,4,2.0
+46759.0,Alfonso Espino,724,Cadiz,140,La Liga,2022,2,0,2,4,2.0
+184226.0,Yéremy Pino,533,Villarreal,140,La Liga,2022,2,0,2,4,2.0
+31042.0,G. Di Lorenzo,492,Napoli,135,Serie A,2021,2,0,2,4,2.0
+46731.0,P. Estupiñán,51,Brighton,39,Premier League,2023,2,0,2,4,2.0
+1580.0,William Carvalho,543,Real Betis,140,La Liga,2023,2,0,2,4,2.0
+46742.0,Dani Rodríguez,798,Mallorca,140,La Liga,2022,2,0,2,4,2.0
+31060.0,F. Caputo,498,Sampdoria,135,Serie A,2021,2,0,2,4,2.0
+174.0,C. Eriksen,55,Brentford,39,Premier League,2021,2,0,2,4,2.0
+1322.0,N. Moro,500,Bologna,135,Serie A,2022,2,0,2,4,2.0
+24888.0,Hwang Hee-Chan,39,Wolves,39,Premier League,2023,2,0,2,4,2.0
+47007.0,Iñigo Ruiz de Galarreta,531,Athletic Club,140,La Liga,2024,2,0,2,4,2.0
+182219.0,Álex Baena,533,Villarreal,140,La Liga,2023,2,0,2,4,2.0
+96331.0,K. Kouao,112,Metz,61,Ligue 1,2023,1,0,2,4,4.0
+641.0,O. Zinchenko,50,Manchester City,39,Premier League,2021,2,0,2,4,2.0
+31173.0,D. Frattesi,488,Sassuolo,135,Serie A,2021,2,0,2,4,2.0
+2763.0,M. Pašalić,499,Atalanta,135,Serie A,2024,2,0,2,4,2.0
+20784.0,F. Honorat,106,Stade Brestois 29,61,Ligue 1,2022,2,0,2,4,2.0
+20780.0,Mathias Pereira Lage,106,Stade Brestois 29,61,Ligue 1,2024,2,0,2,4,2.0
+22261.0,A. Thomasson,116,Lens,61,Ligue 1,2023,2,0,2,4,2.0
+91422.0,R. Bellanova,499,Atalanta,135,Serie A,2024,2,0,2,4,2.0
+2937.0,D. Rice,48,West Ham,39,Premier League,2021,2,0,2,4,2.0
+84082.0,R. Faivre,106,Stade Brestois 29,61,Ligue 1,2021,2,0,2,4,2.0
+1265.0,Y. Adli,502,Fiorentina,135,Serie A,2024,2,0,2,4,2.0
+43084.0,Ianis Hagi,542,Alaves,140,La Liga,2023,2,0,2,4,2.0
+22235.0,J. Bamba,79,Lille,61,Ligue 1,2022,2,0,2,4,2.0
+1468.0,E. Nketiah,42,Arsenal,39,Premier League,2023,2,0,2,4,2.0
+85041.0,A. Gouiri,94,Rennes,61,Ligue 1,2024,2,0,2,4,2.0
+24803.0,F. Kainz,192,1.FC Köln,78,Bundesliga,2021,2,0,2,4,2.0
+633.0,İ. Gündoğan,50,Manchester City,39,Premier League,2024,2,0,2,4,2.0
+629.0,K. De Bruyne,50,Manchester City,39,Premier League,2023,2,0,2,4,2.0
+128461.0,N. Zortea,514,Salernitana,135,Serie A,2021,2,0,2,4,2.0
+1265.0,Y. Adli,78,Bordeaux,61,Ligue 1,2021,2,0,2,4,2.0
+896.0,A. Gomes,79,Lille,61,Ligue 1,2022,2,0,2,4,2.0
+162128.0,W. Gnonto,63,Leeds,39,Premier League,2022,2,0,2,4,2.0
+26303.0,B. Sosa,172,VfB Stuttgart,78,Bundesliga,2022,2,0,2,4,2.0
+162267.0,A. Truffert,94,Rennes,61,Ligue 1,2022,2,0,2,4,2.0
+343027.0,D. Doué,85,Paris Saint Germain,61,Ligue 1,2024,2,0,2,4,2.0
+47543.0,Álvaro García,728,Rayo Vallecano,140,La Liga,2024,1,0,2,4,4.0
+902.0,N. Matić,33,Manchester United,39,Premier League,2021,2,0,2,4,2.0
+899.0,Andreas Pereira,36,Fulham,39,Premier League,2024,2,0,2,4,2.0
+30435.0,D. Kulusevski,47,Tottenham,39,Premier League,2021,2,0,2,4,2.0
+116.0,K. Thuram,496,Juventus,135,Serie A,2024,2,0,2,4,2.0
+326088.0,K. Fayad,82,Montpellier,61,Ligue 1,2022,2,0,2,4,2.0
+98.0,B. Henrichs,173,RB Leipzig,78,Bundesliga,2023,2,0,2,4,2.0
+505.0,D. Alaba,541,Real Madrid,140,La Liga,2021,2,0,2,4,2.0
+47547.0,Álex Moreno,543,Real Betis,140,La Liga,2022,1,0,2,4,4.0
+502.0,J. Kimmich,157,Bayern München,78,Bundesliga,2024,2,0,2,4,2.0
+502.0,J. Kimmich,157,Bayern München,78,Bundesliga,2023,2,0,2,4,2.0
+918.0,José Gayà,532,Valencia,140,La Liga,2022,2,0,2,4,2.0
+2278.0,Marcos Alonso,49,Chelsea,39,Premier League,2021,2,0,2,4,2.0
+2472.0,R. De Paul,530,Atletico Madrid,140,La Liga,2024,2,0,2,4,2.0
+18833.0,Lucas Pérez,724,Cadiz,140,La Liga,2021,2,0,2,4,2.0
+47582.0,C. Hernández,38,Watford,39,Premier League,2021,2,0,2,4,2.0
+502.0,J. Kimmich,157,Bayern München,78,Bundesliga,2021,2,0,2,4,2.0
+47553.0,Bebé,728,Rayo Vallecano,140,La Liga,2021,2,0,2,4,2.0
+145476.0,R. Khadra,93,Reims,61,Ligue 1,2023,2,0,2,4,2.0
+161904.0,B. Barcola,85,Paris Saint Germain,61,Ligue 1,2023,2,0,2,4,2.0
+158121.0,I. Jakobs,91,Monaco,61,Ligue 1,2022,2,0,2,4,2.0
+886.0,Diogo Dalot,33,Manchester United,39,Premier League,2024,2,0,2,4,2.0
+15745.0,M. Roerslev,55,Brentford,39,Premier League,2024,2,0,2,4,2.0
+409.0,N. Bentaleb,77,Angers,61,Ligue 1,2022,2,0,2,4,2.0
+432057.0,A. Haj Mohamed,523,Parma,135,Serie A,2024,1,0,2,4,4.0
+530.0,M. Bakker,79,Lille,61,Ligue 1,2024,2,0,2,4,2.0
+25646.0,A. Pléa,163,Borussia Mönchengladbach,78,Bundesliga,2022,2,0,2,4,2.0
+379329.0,Tiago Santos,79,Lille,61,Ligue 1,2023,2,0,2,4,2.0
+18901.0,S. Longstaff,34,Newcastle,39,Premier League,2023,2,0,2,4,2.0
+896.0,A. Gomes,79,Lille,61,Ligue 1,2023,2,0,2,4,2.0
+161922.0,A. Knauff,169,Eintracht Frankfurt,78,Bundesliga,2024,2,0,2,4,2.0
+18867.0,Diego Rico,546,Getafe,140,La Liga,2024,2,0,2,4,2.0
+18753.0,Adama Traoré,36,Fulham,39,Premier League,2024,2,0,2,4,2.0
+162106.0,Y. Musah,489,AC Milan,135,Serie A,2024,2,0,2,4,2.0
+1942.0,J. Ito,93,Reims,61,Ligue 1,2024,2,0,2,4,2.0
+48.0,Saúl Ñíguez,536,Sevilla,140,La Liga,2024,2,0,2,4,2.0
+2194.0,R. Bensebaini,165,Borussia Dortmund,78,Bundesliga,2024,2,0,2,4,2.0
+973.0,M. Weiser,162,Werder Bremen,78,Bundesliga,2023,2,0,2,4,2.0
+162173.0,S. Iling-Junior,496,Juventus,135,Serie A,2023,2,0,2,4,2.0
+369674.0,J. Bahoya,169,Eintracht Frankfurt,78,Bundesliga,2024,2,0,2,4,2.0
+2063.0,André Silva,173,RB Leipzig,78,Bundesliga,2024,2,0,2,4,2.0
+891.0,L. Shaw,33,Manchester United,39,Premier League,2022,2,0,2,4,2.0
+153465.0,N. Gioacchini,82,Montpellier,61,Ligue 1,2021,2,0,2,4,2.0
+111.0,Rony Lopes,110,Estac Troyes,61,Ligue 1,2022,2,0,2,4,2.0
+151.0,A. Vidal,505,Inter,135,Serie A,2021,2,0,2,4,2.0
+30510.0,Álex Berenguer,531,Athletic Club,140,La Liga,2021,2,0,2,4,2.0
+153.0,O. Dembélé,529,Barcelona,140,La Liga,2021,1,0,2,4,4.0
+18849.0,J. McArthur,52,Crystal Palace,39,Premier League,2021,2,0,2,4,2.0
+2286.0,D. Zappacosta,499,Atalanta,135,Serie A,2022,2,0,2,4,2.0
+18799.0,A. Masina,503,Torino,135,Serie A,2024,2,0,2,4,2.0
+47416.0,Óscar Rodríguez,537,Leganes,140,La Liga,2024,2,0,2,4,2.0
+47414.0,Gerard Gumbau,797,Elche,140,La Liga,2022,2,0,2,4,2.0
+56.0,A. Griezmann,530,Atletico Madrid,140,La Liga,2021,2,0,2,4,2.0
+26243.0,Nico Schlotterbeck,165,Borussia Dortmund,78,Bundesliga,2022,2,0,2,4,2.0
+1946.0,L. Trossard,42,Arsenal,39,Premier League,2024,2,0,2,4,2.0
+361497.0,Dean Huijsen,35,Bournemouth,39,Premier League,2024,2,0,2,4,2.0
+26244.0,P. Stenzel,172,VfB Stuttgart,78,Bundesliga,2023,2,0,2,4,2.0
+30456.0,R. Saponara,502,Fiorentina,135,Serie A,2021,2,0,2,4,2.0
+2472.0,R. De Paul,530,Atletico Madrid,140,La Liga,2022,2,0,2,4,2.0
+2280.0,César Azpilicueta,49,Chelsea,39,Premier League,2021,2,0,2,4,2.0
+501.0,M. Hummels,165,Borussia Dortmund,78,Bundesliga,2021,2,0,2,4,2.0
+68.0,Clinton Mata,80,Lyon,61,Ligue 1,2024,2,0,2,4,2.0
+18784.0,J. Maddison,47,Tottenham,39,Premier League,2023,2,0,2,4,2.0
+47349.0,Javi Puado,540,Espanyol,140,La Liga,2024,2,0,2,4,2.0
+325975.0,T. Bischof,167,1899 Hoffenheim,78,Bundesliga,2023,2,0,2,4,2.0
+25452.0,N. Gießelmann,182,Union Berlin,78,Bundesliga,2021,2,0,2,4,2.0
+85.0,C. Ngonge,504,Verona,135,Serie A,2023,2,0,2,4,2.0
+484.0,A. Miranchuk,503,Torino,135,Serie A,2022,2,0,2,4,2.0
+18809.0,Deulofeu,494,Udinese,135,Serie A,2022,1,0,2,4,4.0
+162012.0,M. Ruggeri,499,Atalanta,135,Serie A,2023,2,0,2,4,2.0
+2006.0,Burak Yılmaz,79,Lille,61,Ligue 1,2021,1,1,0,3,3.0
+31236.0,M. Coulibaly,514,Salernitana,135,Serie A,2021,1,1,0,3,3.0
+128582.0,Jorge de Frutos,728,Rayo Vallecano,140,La Liga,2024,1,1,0,3,3.0
+31226.0,A. Buongiorno,492,Napoli,135,Serie A,2024,1,1,0,3,3.0
+2056.0,Pablo Sarabia,85,Paris Saint Germain,61,Ligue 1,2021,1,1,0,3,3.0
+2036.0,Juan Soriano,727,Osasuna,140,La Liga,2024,1,1,0,3,3.0
+31273.0,Tommaso Pobega,489,AC Milan,135,Serie A,2022,1,1,0,3,3.0
+31273.0,Tommaso Pobega,500,Bologna,135,Serie A,2024,1,1,0,3,3.0
+31273.0,Tommaso Pobega,503,Torino,135,Serie A,2021,1,1,0,3,3.0
+31173.0,D. Frattesi,488,Sassuolo,135,Serie A,2022,1,1,0,3,3.0
+31094.0,A. Pinamonti,488,Sassuolo,135,Serie A,2022,1,1,0,3,3.0
+128582.0,Jorge de Frutos,539,Levante,140,La Liga,2021,1,1,0,3,3.0
+30414.0,G. Simeone,492,Napoli,135,Serie A,2023,1,1,0,3,3.0
+30415.0,Dušan Vlahović,496,Juventus,135,Serie A,2022,1,1,0,3,3.0
+30415.0,Dušan Vlahović,496,Juventus,135,Serie A,2021,1,1,0,3,3.0
+1646.0,Lucas Paquetá,48,West Ham,39,Premier League,2024,1,1,0,3,3.0
+583.0,João Félix,49,Chelsea,39,Premier League,2024,1,1,0,3,3.0
+663.0,M. Terrier,94,Rennes,61,Ligue 1,2023,1,1,0,3,3.0
+612.0,E. Ponce,797,Elche,140,La Liga,2021,1,1,0,3,3.0
+2118.0,Răzvan Marin,511,Empoli,135,Serie A,2022,1,1,0,3,3.0
+635.0,R. Mahrez,50,Manchester City,39,Premier League,2022,1,1,0,3,3.0
+128533.0,J. Leweling,178,SpVgg Greuther Furth,78,Bundesliga,2021,1,1,0,3,3.0
+616.0,Arijanet Murić,51,Brighton,39,Premier League,2023,1,1,0,3,3.0
+619.0,Eric García,529,Barcelona,140,La Liga,2024,1,1,0,3,3.0
+2063.0,André Silva,548,Real Sociedad,140,La Liga,2023,1,1,0,3,3.0
+1946.0,L. Trossard,51,Brighton,39,Premier League,2022,1,1,0,3,3.0
+1470.0,Luís Maximiano,531,Athletic Club,140,La Liga,2021,1,1,0,3,3.0
+128461.0,N. Zortea,499,Atalanta,135,Serie A,2023,1,1,0,3,3.0
+31318.0,M'Bala Nzola,515,Spezia,135,Serie A,2022,1,1,0,3,3.0
+1496.0,Raphinha,529,Barcelona,140,La Liga,2023,1,1,0,3,3.0
+128461.0,N. Zortea,490,Cagliari,135,Serie A,2024,1,1,0,3,3.0
+31318.0,M'Bala Nzola,116,Lens,61,Ligue 1,2024,1,1,0,3,3.0
+31318.0,M'Bala Nzola,515,Spezia,135,Serie A,2021,1,1,0,3,3.0
+2001.0,C. Larin,720,Valladolid,140,La Liga,2022,1,1,0,3,3.0
+2060.0,M. El Haddadi,546,Getafe,140,La Liga,2022,1,1,0,3,3.0
+31369.0,A. Schiavone,514,Salernitana,135,Serie A,2021,1,1,0,3,3.0
+129643.0,E. Ferguson,51,Brighton,39,Premier League,2023,1,1,0,3,3.0
+31436.0,F. Bonazzoli,514,Salernitana,135,Serie A,2022,1,1,0,3,3.0
+129033.0,J. Gvardiol,173,RB Leipzig,78,Bundesliga,2022,1,1,0,3,3.0
+129033.0,J. Gvardiol,50,Manchester City,39,Premier League,2024,1,1,0,3,3.0
+31493.0,F. Melegoni,495,Genoa,135,Serie A,2021,1,1,0,3,3.0
+2001.0,C. Larin,798,Mallorca,140,La Liga,2024,1,1,0,3,3.0
+128461.0,N. Zortea,499,Atalanta,135,Serie A,2022,1,1,0,3,3.0
+31730.0,L. Venuti,489,AC Milan,135,Serie A,2021,1,1,0,3,3.0
+31751.0,G. Altare,487,Lazio,135,Serie A,2024,1,1,0,3,3.0
+31751.0,G. Altare,490,Cagliari,135,Serie A,2021,1,1,0,3,3.0
+31507.0,R. Sottil,502,Fiorentina,135,Serie A,2024,1,1,0,3,3.0
+31521.0,A. Vogliacco,495,Genoa,135,Serie A,2024,1,1,0,3,3.0
+483.0,K. Kvaratskhelia,85,Paris Saint Germain,61,Ligue 1,2024,1,1,0,3,3.0
+31615.0,G. Castrovilli,502,Fiorentina,135,Serie A,2021,1,1,0,3,3.0
+1561.0,Marc Bartra,543,Real Betis,140,La Liga,2021,1,1,0,3,3.0
+1561.0,Marc Bartra,543,Real Betis,140,La Liga,2024,1,1,0,3,3.0
+1564.0,Junior Firpo,63,Leeds,39,Premier League,2022,1,1,0,3,3.0
+1567.0,A. Mandi,530,Atletico Madrid,140,La Liga,2021,1,1,0,3,3.0
+1578.0,G. Lo Celso,533,Villarreal,140,La Liga,2021,1,1,0,3,3.0
+1578.0,G. Lo Celso,533,Villarreal,140,La Liga,2022,1,1,0,3,3.0
+36922.0,S. van den Berg,174,FC Schalke 04,78,Bundesliga,2022,1,1,0,3,3.0
+152849.0,M. van de Ven,47,Tottenham,39,Premier League,2023,1,1,0,3,3.0
+30424.0,Ibañez,497,AS Roma,135,Serie A,2022,1,1,0,3,3.0
+37127.0,Martin Ødegaard,42,Arsenal,39,Premier League,2024,1,1,0,3,3.0
+37161.0,L. Sinisterra,35,Bournemouth,39,Premier League,2023,1,1,0,3,3.0
+35544.0,J. Vásquez,520,Cremonese,135,Serie A,2022,1,1,0,3,3.0
+36899.0,T. Koopmeiners,496,Juventus,135,Serie A,2024,1,1,0,3,3.0
+36899.0,T. Koopmeiners,499,Atalanta,135,Serie A,2023,1,1,0,3,3.0
+36907.0,M. Boadu,91,Monaco,61,Ligue 1,2022,1,1,0,3,3.0
+152669.0,D. Yongwa,97,Lorient,61,Ligue 1,2023,1,1,0,3,3.0
+36907.0,M. Boadu,91,Monaco,61,Ligue 1,2023,1,1,0,3,3.0
+36916.0,Kingsley Ehizibue,494,Udinese,135,Serie A,2022,1,1,0,3,3.0
+1463.0,J. Willock,34,Newcastle,39,Premier League,2023,1,1,0,3,3.0
+1464.0,G. Xhaka,42,Arsenal,39,Premier League,2022,1,1,0,3,3.0
+152654.0,Jeremie Frimpong,168,Bayer Leverkusen,78,Bundesliga,2022,1,1,0,3,3.0
+1464.0,G. Xhaka,168,Bayer Leverkusen,78,Bundesliga,2024,1,1,0,3,3.0
+157146.0,L. Pétrot,97,Lorient,61,Ligue 1,2021,1,1,0,3,3.0
+33019.0,K. Miyoshi,176,VfL Bochum,78,Bundesliga,2024,1,1,0,3,3.0
+36987.0,S. Lammers,511,Empoli,135,Serie A,2022,1,1,0,3,3.0
+30397.0,Federico Ceccherini,504,Verona,135,Serie A,2022,1,1,0,3,3.0
+31094.0,A. Pinamonti,488,Sassuolo,135,Serie A,2023,1,1,0,3,3.0
+2182.0,V. Tsyhankov,547,Girona,140,La Liga,2023,1,1,0,3,3.0
+642.0,S. Agüero,529,Barcelona,140,La Liga,2021,1,1,0,3,3.0
+30432.0,Marten de Roon,499,Atalanta,135,Serie A,2021,1,1,0,3,3.0
+649.0,J. Denayer,80,Lyon,61,Ligue 1,2021,1,1,0,3,3.0
+30431.0,A. Colpani,1579,Monza,135,Serie A,2022,1,1,0,3,3.0
+30428.0,J. Palomino,499,Atalanta,135,Serie A,2022,1,1,0,3,3.0
+30425.0,Gianluca Mancini,497,AS Roma,135,Serie A,2023,1,1,0,3,3.0
+637.0,F. Nmecha,161,VfL Wolfsburg,78,Bundesliga,2022,1,1,0,3,3.0
+637.0,F. Nmecha,165,Borussia Dortmund,78,Bundesliga,2024,1,1,0,3,3.0
+126642.0,P. Wimmer,188,Arminia Bielefeld,78,Bundesliga,2021,1,1,0,3,3.0
+126757.0,Lilian Brassier,106,Stade Brestois 29,61,Ligue 1,2023,1,1,0,3,3.0
+126936.0,Samuel Lino,532,Valencia,140,La Liga,2022,1,1,0,3,3.0
+30440.0,R. Piccoli,499,Atalanta,135,Serie A,2021,1,1,0,3,3.0
+31692.0,M. Đurić,514,Salernitana,135,Serie A,2021,1,1,0,3,3.0
+31624.0,Gabriel Strefezza,867,Lecce,135,Serie A,2023,1,1,0,3,3.0
+31624.0,Gabriel Strefezza,867,Lecce,135,Serie A,2022,1,1,0,3,3.0
+409.0,N. Bentaleb,79,Lille,61,Ligue 1,2024,1,1,0,3,3.0
+32862.0,T. Kubo,798,Mallorca,140,La Liga,2021,1,1,0,3,3.0
+32862.0,T. Kubo,548,Real Sociedad,140,La Liga,2024,1,1,0,3,3.0
+32034.0,A. Dossena,496,Juventus,135,Serie A,2023,1,1,0,3,3.0
+418.0,S. Serdar,159,Hertha Berlin,78,Bundesliga,2022,1,1,0,3,3.0
+126949.0,Chris Richards,167,1899 Hoffenheim,78,Bundesliga,2021,1,1,0,3,3.0
+125720.0,S. Conteh,180,1. FC Heidenheim,78,Bundesliga,2024,1,1,0,3,3.0
+123469.0,Z. Amdouni,44,Burnley,39,Premier League,2023,1,1,0,3,3.0
+123047.0,Sergio González,537,Leganes,140,La Liga,2024,1,1,0,3,3.0
+122468.0,Saúl Coco,490,Cagliari,135,Serie A,2024,1,1,0,3,3.0
+127579.0,Jacob Greaves,57,Ipswich,39,Premier League,2024,1,1,0,3,3.0
+127035.0,Federico Baschirotto,867,Lecce,135,Serie A,2024,1,1,0,3,3.0
+127011.0,Andrea Cambiaso,496,Juventus,135,Serie A,2024,1,1,0,3,3.0
+127011.0,Andrea Cambiaso,496,Juventus,135,Serie A,2023,1,1,0,3,3.0
+125743.0,Beto,45,Everton,39,Premier League,2024,1,1,0,3,3.0
+1696.0,S. Chukwueze,489,AC Milan,135,Serie A,2023,1,1,0,3,3.0
+1652.0,F. Tsadjout,520,Cremonese,135,Serie A,2022,1,1,0,3,3.0
+1828.0,Luka Jović,489,AC Milan,135,Serie A,2024,1,1,0,3,3.0
+1725.0,D. Ljubičić,192,1.FC Köln,78,Bundesliga,2021,1,1,0,3,3.0
+1709.0,K. Toko-Ekambi,80,Lyon,61,Ligue 1,2022,1,1,0,3,3.0
+1708.0,Dani Raba,537,Leganes,140,La Liga,2024,1,1,0,3,3.0
+1830.0,Gonçalo Paciência,169,Eintracht Frankfurt,78,Bundesliga,2021,1,1,0,3,3.0
+30525.0,Pol Lirola,85,Paris Saint Germain,61,Ligue 1,2024,1,1,0,3,3.0
+1617.0,Koka,111,Le Havre,61,Ligue 1,2024,1,1,0,3,3.0
+1831.0,A. Rebić,867,Lecce,135,Serie A,2024,1,1,0,3,3.0
+30523.0,G. Ferrari,488,Sassuolo,135,Serie A,2023,1,1,0,3,3.0
+30523.0,G. Ferrari,488,Sassuolo,135,Serie A,2021,1,1,0,3,3.0
+1854.0,J. Correa,505,Inter,135,Serie A,2022,1,1,0,3,3.0
+1841.0,Patric,487,Lazio,135,Serie A,2023,1,1,0,3,3.0
+30510.0,Álex Berenguer,531,Athletic Club,140,La Liga,2022,1,1,0,3,3.0
+1852.0,D. Cataldi,487,Lazio,135,Serie A,2021,1,1,0,3,3.0
+1850.0,M. Badelj,495,Genoa,135,Serie A,2021,1,1,0,3,3.0
+1830.0,Gonçalo Paciência,538,Celta Vigo,140,La Liga,2022,1,1,0,3,3.0
+538.0,F. de Jong,529,Barcelona,140,La Liga,2021,1,1,0,3,3.0
+30755.0,E. Vignato,511,Empoli,135,Serie A,2022,1,1,0,3,3.0
+30748.0,A. Dioussé,1063,Saint Etienne,61,Ligue 1,2021,1,1,0,3,3.0
+512.0,Jeong Wooyeong,182,Union Berlin,78,Bundesliga,2024,1,1,0,3,3.0
+519.0,C. Tolisso,80,Lyon,61,Ligue 1,2024,1,1,0,3,3.0
+30687.0,S. Bastoni,511,Empoli,135,Serie A,2023,1,1,0,3,3.0
+522.0,T. Müller,157,Bayern München,78,Bundesliga,2021,1,1,0,3,3.0
+522.0,T. Müller,157,Bayern München,78,Bundesliga,2022,1,1,0,3,3.0
+1825.0,Lucas Torró,727,Osasuna,140,La Liga,2023,1,1,0,3,3.0
+30615.0,L. Caldirola,1579,Monza,135,Serie A,2023,1,1,0,3,3.0
+30780.0,L. Mazzitelli,512,Frosinone,135,Serie A,2023,1,1,0,3,3.0
+30776.0,C. Romero,47,Tottenham,39,Premier League,2023,1,1,0,3,3.0
+522.0,T. Müller,157,Bayern München,78,Bundesliga,2024,1,1,0,3,3.0
+30772.0,K. Günter,489,AC Milan,135,Serie A,2021,1,1,0,3,3.0
+30768.0,Pedro Pereira,1579,Monza,135,Serie A,2024,1,1,0,3,3.0
+526.0,André Onana,499,Atalanta,135,Serie A,2022,1,1,0,3,3.0
+1700.0,Iván Martín,547,Girona,140,La Liga,2023,1,1,0,3,3.0
+30624.0,F. Bandinelli,511,Empoli,135,Serie A,2021,1,1,0,3,3.0
+30461.0,G. Defrel,488,Sassuolo,135,Serie A,2021,1,1,0,3,3.0
+30491.0,F. Santander,500,Bologna,135,Serie A,2021,1,1,0,3,3.0
+30497.0,Bremer,496,Juventus,135,Serie A,2023,1,1,0,3,3.0
+550.0,K. Dolberg,167,1899 Hoffenheim,78,Bundesliga,2022,1,1,0,3,3.0
+136087.0,F. Parisi,511,Empoli,135,Serie A,2022,1,1,0,3,3.0
+135844.0,J. Perea,172,VfB Stuttgart,78,Bundesliga,2022,1,1,0,3,3.0
+135519.0,G. Isaksen,487,Lazio,135,Serie A,2023,1,1,0,3,3.0
+581.0,Jota,94,Rennes,61,Ligue 1,2024,1,1,0,3,3.0
+1807.0,E. Ndicka,176,VfL Bochum,78,Bundesliga,2022,1,1,0,3,3.0
+30498.0,L. De Silvestri,500,Bologna,135,Serie A,2022,1,1,0,3,3.0
+137210.0,A. Stiller,168,Bayer Leverkusen,78,Bundesliga,2024,1,1,0,3,3.0
+137210.0,A. Stiller,167,1899 Hoffenheim,78,Bundesliga,2021,1,1,0,3,3.0
+508.0,K. Coman,157,Bayern München,78,Bundesliga,2023,1,1,0,3,3.0
+30498.0,L. De Silvestri,500,Bologna,135,Serie A,2023,1,1,0,3,3.0
+138786.0,E. Simms,45,Everton,39,Premier League,2022,1,1,0,3,3.0
+506.0,Niklas Süle,165,Borussia Dortmund,78,Bundesliga,2022,1,1,0,3,3.0
+138787.0,A. Gordon,34,Newcastle,39,Premier League,2024,1,1,0,3,3.0
+138780.0,Neco Williams,65,Nottingham Forest,39,Premier League,2024,1,1,0,3,3.0
+1844.0,A. Marušić,487,Lazio,135,Serie A,2023,1,1,0,3,3.0
+30535.0,S. Sensi,1579,Monza,135,Serie A,2022,1,1,0,3,3.0
+1809.0,Tuta,169,Eintracht Frankfurt,78,Bundesliga,2021,1,1,0,3,3.0
+30526.0,G. Magnani,511,Empoli,135,Serie A,2022,1,1,0,3,3.0
+30525.0,Pol Lirola,512,Frosinone,135,Serie A,2023,1,1,0,3,3.0
+1809.0,Tuta,169,Eintracht Frankfurt,78,Bundesliga,2023,1,1,0,3,3.0
+30543.0,G. Raspadori,492,Napoli,135,Serie A,2024,1,1,0,3,3.0
+30539.0,F. Di Francesco,867,Lecce,135,Serie A,2023,1,1,0,3,3.0
+30561.0,Alessandro Deiola,490,Cagliari,135,Serie A,2024,1,1,0,3,3.0
+30504.0,W. Singo,503,Torino,135,Serie A,2022,1,1,0,3,3.0
+30509.0,A. Belotti,895,Como,135,Serie A,2024,1,1,0,3,3.0
+30535.0,S. Sensi,1579,Monza,135,Serie A,2024,1,1,0,3,3.0
+30615.0,L. Caldirola,1579,Monza,135,Serie A,2022,1,1,0,3,3.0
+30603.0,Dany Mota,1579,Monza,135,Serie A,2024,1,1,0,3,3.0
+30603.0,Dany Mota,1579,Monza,135,Serie A,2023,1,1,0,3,3.0
+30603.0,Dany Mota,1579,Monza,135,Serie A,2022,1,1,0,3,3.0
+30573.0,L. Pavoletti,490,Cagliari,135,Serie A,2024,1,1,0,3,3.0
+30573.0,L. Pavoletti,490,Cagliari,135,Serie A,2021,1,1,0,3,3.0
+1825.0,Lucas Torró,727,Osasuna,140,La Liga,2022,1,1,0,3,3.0
+1638.0,G. Bonaventura,502,Fiorentina,135,Serie A,2022,1,1,0,3,3.0
+1638.0,G. Bonaventura,502,Fiorentina,135,Serie A,2021,1,1,0,3,3.0
+1627.0,D. Calabria,489,AC Milan,135,Serie A,2023,1,1,0,3,3.0
+30789.0,C. Kouamé,502,Fiorentina,135,Serie A,2022,1,1,0,3,3.0
+30785.0,A. Schäfer,182,Union Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+1746.0,J. Worrall,65,Nottingham Forest,39,Premier League,2022,1,1,0,3,3.0
+30434.0,J. Iličić,499,Atalanta,135,Serie A,2021,1,1,0,3,3.0
+1736.0,Wesley Foderingham,36,Fulham,39,Premier League,2023,1,1,0,3,3.0
+509.0,A. Davies,157,Bayern München,78,Bundesliga,2024,1,1,0,3,3.0
+30827.0,M. Erlić,498,Sampdoria,135,Serie A,2022,1,1,0,3,3.0
+30436.0,M. Pessina,499,Atalanta,135,Serie A,2021,1,1,0,3,3.0
+30810.0,R. Mandragora,502,Fiorentina,135,Serie A,2024,1,1,0,3,3.0
+1918.0,V. Germain,82,Montpellier,61,Ligue 1,2021,1,1,0,3,3.0
+30797.0,B. Nuytinck,494,Udinese,135,Serie A,2021,1,1,0,3,3.0
+30922.0,D. Faraoni,504,Verona,135,Serie A,2022,1,1,0,3,3.0
+1918.0,V. Germain,82,Montpellier,61,Ligue 1,2022,1,1,0,3,3.0
+30921.0,Paweł Dawidowicz,492,Napoli,135,Serie A,2023,1,1,0,3,3.0
+30827.0,M. Erlić,515,Spezia,135,Serie A,2021,1,1,0,3,3.0
+30444.0,Omar Colley,498,Sampdoria,135,Serie A,2022,1,1,0,3,3.0
+31023.0,Juraj Kucka,71,Norwich,39,Premier League,2021,1,1,0,3,3.0
+31023.0,Juraj Kucka,38,Watford,39,Premier League,2021,1,1,0,3,3.0
+31073.0,Edoardo Goldaniga,895,Como,135,Serie A,2024,1,1,0,3,3.0
+31060.0,F. Caputo,511,Empoli,135,Serie A,2023,1,1,0,3,3.0
+31060.0,F. Caputo,511,Empoli,135,Serie A,2022,1,1,0,3,3.0
+30447.0,N. Murru,498,Sampdoria,135,Serie A,2021,1,1,0,3,3.0
+31057.0,H. Traoré,108,Auxerre,61,Ligue 1,2024,1,1,0,3,3.0
+1638.0,G. Bonaventura,502,Fiorentina,135,Serie A,2023,1,1,0,3,3.0
+31056.0,Samuele Ricci,511,Empoli,135,Serie A,2021,1,1,0,3,3.0
+31056.0,Samuele Ricci,503,Torino,135,Serie A,2022,1,1,0,3,3.0
+1605.0,Daniel Podence,39,Wolves,39,Premier League,2022,1,1,0,3,3.0
+1590.0,José Sá,42,Arsenal,39,Premier League,2021,1,1,0,3,3.0
+1584.0,Loren Morón,540,Espanyol,140,La Liga,2021,1,1,0,3,3.0
+1642.0,F. Kessié,529,Barcelona,140,La Liga,2022,1,1,0,3,3.0
+1642.0,F. Kessié,489,AC Milan,135,Serie A,2021,1,1,0,3,3.0
+30460.0,G. Caprari,1579,Monza,135,Serie A,2022,1,1,0,3,3.0
+30460.0,G. Caprari,504,Verona,135,Serie A,2021,1,1,0,3,3.0
+147831.0,A. Kalimuendo,116,Lens,61,Ligue 1,2021,1,1,0,3,3.0
+131546.0,Isi Palazón,728,Rayo Vallecano,140,La Liga,2023,1,1,0,3,3.0
+389.0,Jesús Corona,536,Sevilla,140,La Liga,2022,1,1,0,3,3.0
+403.0,M. Nastasić,798,Mallorca,140,La Liga,2023,1,1,0,3,3.0
+131535.0,Álex Suárez,534,Las Palmas,140,La Liga,2023,1,1,0,3,3.0
+139001.0,Pablo Ibáñez,727,Osasuna,140,La Liga,2024,1,1,0,3,3.0
+140831.0,Zito Luvumbo,490,Cagliari,135,Serie A,2024,1,1,0,3,3.0
+129682.0,A. Adli,168,Bayer Leverkusen,78,Bundesliga,2024,1,1,0,3,3.0
+1920.0,Nemanja Radonjić,503,Torino,135,Serie A,2023,1,1,0,3,3.0
+530.0,M. Bakker,168,Bayer Leverkusen,78,Bundesliga,2022,1,1,0,3,3.0
+533.0,R. Kristensen,497,AS Roma,135,Serie A,2023,1,1,0,3,3.0
+532.0,M. de Ligt,157,Bayern München,78,Bundesliga,2023,1,1,0,3,3.0
+138822.0,A. Broja,49,Chelsea,39,Premier League,2022,1,1,0,3,3.0
+549.0,V. Černý,161,VfL Wolfsburg,78,Bundesliga,2023,1,1,0,3,3.0
+138835.0,F. Balogun,91,Monaco,61,Ligue 1,2024,1,1,0,3,3.0
+138859.0,Christoph Klarer,181,SV Darmstadt 98,78,Bundesliga,2023,1,1,0,3,3.0
+541.0,J. Ekkelenkamp,159,Hertha Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+142691.0,Alexsandro Ribeiro,108,Auxerre,61,Ligue 1,2024,1,1,0,3,3.0
+30433.0,P. Gómez,536,Sevilla,140,La Liga,2021,1,1,0,3,3.0
+30859.0,M. Fares,495,Genoa,135,Serie A,2021,1,1,0,3,3.0
+30433.0,P. Gómez,536,Sevilla,140,La Liga,2022,1,1,0,3,3.0
+30848.0,D. Okereke,517,Venezia,135,Serie A,2021,1,1,0,3,3.0
+30432.0,Marten de Roon,499,Atalanta,135,Serie A,2024,1,1,0,3,3.0
+1897.0,S. Mandanda,84,Nice,61,Ligue 1,2023,1,1,0,3,3.0
+30845.0,E. Gyasi,511,Empoli,135,Serie A,2023,1,1,0,3,3.0
+30836.0,Giulio Maggiore,515,Spezia,135,Serie A,2021,1,1,0,3,3.0
+133609.0,Pedri,529,Barcelona,140,La Liga,2023,1,1,0,3,3.0
+31003.0,S. Nwankwo,514,Salernitana,135,Serie A,2023,1,1,0,3,3.0
+30937.0,M. Zaccagni,504,Verona,135,Serie A,2021,1,1,0,3,3.0
+1902.0,Duje Ćaleta-Car,81,Marseille,61,Ligue 1,2021,1,1,0,3,3.0
+129678.0,A. Ounahi,81,Marseille,61,Ligue 1,2022,1,1,0,3,3.0
+1906.0,A. Rami,110,Estac Troyes,61,Ligue 1,2021,1,1,0,3,3.0
+1911.0,L. Ocampos,536,Sevilla,140,La Liga,2021,1,1,0,3,3.0
+1911.0,L. Ocampos,536,Sevilla,140,La Liga,2022,1,1,0,3,3.0
+129657.0,Enric Franquesa,537,Leganes,140,La Liga,2024,1,1,0,3,3.0
+129643.0,E. Ferguson,51,Brighton,39,Premier League,2024,1,1,0,3,3.0
+31009.0,A. Bastoni,505,Inter,135,Serie A,2023,1,1,0,3,3.0
+943.0,U. Garcia,81,Marseille,61,Ligue 1,2024,1,1,0,3,3.0
+937.0,Rubén Sobrino,724,Cadiz,140,La Liga,2022,1,1,0,3,3.0
+935.0,Rodrigo,63,Leeds,39,Premier League,2021,1,1,0,3,3.0
+931.0,Ferran Torres,50,Manchester City,39,Premier League,2021,1,1,0,3,3.0
+866.0,J. Cuadrado,496,Juventus,135,Serie A,2021,1,1,0,3,3.0
+864.0,E. Can,165,Borussia Dortmund,78,Bundesliga,2024,1,1,0,3,3.0
+864.0,E. Can,165,Borussia Dortmund,78,Bundesliga,2023,1,1,0,3,3.0
+50852.0,Joseph Scally,163,Borussia Mönchengladbach,78,Bundesliga,2021,1,1,0,3,3.0
+50739.0,B. Aaronson,182,Union Berlin,78,Bundesliga,2023,1,1,0,3,3.0
+50735.0,Mark McKenzie,96,Toulouse,61,Ligue 1,2024,1,1,0,3,3.0
+1440.0,R. Holding,42,Arsenal,39,Premier League,2022,1,1,0,3,3.0
+877.0,M. Kean,496,Juventus,135,Serie A,2021,1,1,0,3,3.0
+876.0,N. Fagioli,496,Juventus,135,Serie A,2022,1,1,0,3,3.0
+51266.0,G. Busio,517,Venezia,135,Serie A,2024,1,1,0,3,3.0
+51266.0,G. Busio,517,Venezia,135,Serie A,2021,1,1,0,3,3.0
+51016.0,T. Buchanan,533,Villarreal,140,La Liga,2024,1,1,0,3,3.0
+51016.0,T. Buchanan,505,Inter,135,Serie A,2023,1,1,0,3,3.0
+50873.0,G. Bello,176,VfL Bochum,78,Bundesliga,2021,1,1,0,3,3.0
+50856.0,V. Castellanos,547,Girona,140,La Liga,2022,1,1,0,3,3.0
+778.0,B. Cristante,497,AS Roma,135,Serie A,2021,1,1,0,3,3.0
+774.0,Juan Jesus,492,Napoli,135,Serie A,2023,1,1,0,3,3.0
+50502.0,Álvaro Negredo,724,Cadiz,140,La Liga,2022,1,1,0,3,3.0
+905.0,Fred,33,Manchester United,39,Premier League,2022,1,1,0,3,3.0
+905.0,Fred,33,Manchester United,39,Premier League,2021,1,1,0,3,3.0
+47487.0,Joaquín Fernández,530,Atletico Madrid,140,La Liga,2022,1,1,0,3,3.0
+47485.0,Rubén Alcaraz,724,Cadiz,140,La Liga,2022,1,1,0,3,3.0
+47478.0,Fernando Calero,540,Espanyol,140,La Liga,2024,1,1,0,3,3.0
+916.0,M. Diakhaby,532,Valencia,140,La Liga,2022,1,1,0,3,3.0
+914.0,Álex Centelles,723,Almeria,140,La Liga,2022,1,1,0,3,3.0
+909.0,M. Rashford,33,Manchester United,39,Premier League,2023,1,1,0,3,3.0
+906.0,T. Chong,1359,Luton,39,Premier League,2023,1,1,0,3,3.0
+47355.0,Rubén Duarte,542,Alaves,140,La Liga,2023,1,1,0,3,3.0
+945.0,J. Lotomba,84,Nice,61,Ligue 1,2023,1,1,0,3,3.0
+47350.0,Wu Lei,540,Espanyol,140,La Liga,2021,1,1,0,3,3.0
+1090.0,A. Bernede,504,Verona,135,Serie A,2024,1,1,0,3,3.0
+999.0,Bećir Omeragić,116,Lens,61,Ligue 1,2024,1,1,0,3,3.0
+47396.0,Kike García,727,Osasuna,140,La Liga,2022,1,1,0,3,3.0
+47388.0,Gonzalo Escalante,724,Cadiz,140,La Liga,2023,1,1,0,3,3.0
+47380.0,Marc Cucurella,49,Chelsea,39,Premier League,2024,1,1,0,3,3.0
+47361.0,D. Brašanac,727,Osasuna,140,La Liga,2022,1,1,0,3,3.0
+47361.0,D. Brašanac,537,Leganes,140,La Liga,2024,1,1,0,3,3.0
+928.0,Dani Parejo,533,Villarreal,140,La Liga,2023,1,1,0,3,3.0
+47421.0,G. Carrillo,797,Elche,140,La Liga,2021,1,1,0,3,3.0
+47416.0,Óscar Rodríguez,546,Getafe,140,La Liga,2023,1,1,0,3,3.0
+47353.0,Antonio Sivera,728,Rayo Vallecano,140,La Liga,2024,1,1,0,3,3.0
+56558.0,S. Esposito,515,Spezia,135,Serie A,2022,1,1,0,3,3.0
+56473.0,Matteo Gabbia,489,AC Milan,135,Serie A,2024,1,1,0,3,3.0
+744.0,Brahim Díaz,489,AC Milan,135,Serie A,2021,1,1,0,3,3.0
+66407.0,L. Krejčí,547,Girona,140,La Liga,2024,1,1,0,3,3.0
+64268.0,J. Mojica,798,Mallorca,140,La Liga,2024,1,1,0,3,3.0
+64255.0,G. Lloris,111,Le Havre,61,Ligue 1,2024,1,1,0,3,3.0
+64003.0,P. Struijk,63,Leeds,39,Premier League,2021,1,1,0,3,3.0
+63542.0,Martin Hongla,504,Verona,135,Serie A,2021,1,1,0,3,3.0
+747.0,Casemiro,33,Manchester United,39,Premier League,2024,1,1,0,3,3.0
+746.0,Marco Asensio,541,Real Madrid,140,La Liga,2021,1,1,0,3,3.0
+769.0,A. Florenzi,489,AC Milan,135,Serie A,2021,1,1,0,3,3.0
+47278.0,Dani Vivian,531,Athletic Club,140,La Liga,2022,1,1,0,3,3.0
+47277.0,Unai Núñez,530,Atletico Madrid,140,La Liga,2022,1,1,0,3,3.0
+47275.0,De Marcos,531,Athletic Club,140,La Liga,2021,1,1,0,3,3.0
+47271.0,Yeray Álvarez,531,Athletic Club,140,La Liga,2024,1,1,0,3,3.0
+47270.0,Unai Simón,798,Mallorca,140,La Liga,2021,1,1,0,3,3.0
+47294.0,I. Williams,531,Athletic Club,140,La Liga,2022,1,1,0,3,3.0
+47285.0,Unai López,728,Rayo Vallecano,140,La Liga,2024,1,1,0,3,3.0
+47285.0,Unai López,728,Rayo Vallecano,140,La Liga,2022,1,1,0,3,3.0
+47282.0,Raúl García,531,Athletic Club,140,La Liga,2022,1,1,0,3,3.0
+47278.0,Dani Vivian,531,Athletic Club,140,La Liga,2024,1,1,0,3,3.0
+745.0,Isco,541,Real Madrid,140,La Liga,2021,1,1,0,3,3.0
+762.0,Vinícius Júnior,541,Real Madrid,140,La Liga,2023,1,1,0,3,3.0
+51572.0,M. Viña,511,Empoli,135,Serie A,2023,1,1,0,3,3.0
+1148.0,Willi Orbán,173,RB Leipzig,78,Bundesliga,2024,1,1,0,3,3.0
+47319.0,Willian José,543,Real Betis,140,La Liga,2022,1,1,0,3,3.0
+47315.0,Martín Zubimendi,548,Real Sociedad,140,La Liga,2024,1,1,0,3,3.0
+47348.0,Borja Iglesias,538,Celta Vigo,140,La Liga,2024,1,1,0,3,3.0
+47329.0,Adrià Pedrosa,536,Sevilla,140,La Liga,2024,1,1,0,3,3.0
+47328.0,Óscar Duarte,539,Levante,140,La Liga,2021,1,1,0,3,3.0
+47324.0,Sandro Ramírez,534,Las Palmas,140,La Liga,2024,1,1,0,3,3.0
+989.0,K. Volland,93,Reims,61,Ligue 1,2021,1,1,0,3,3.0
+56560.0,Y. Maleh,502,Fiorentina,135,Serie A,2021,1,1,0,3,3.0
+984.0,J. Brandt,165,Borussia Dortmund,78,Bundesliga,2024,1,1,0,3,3.0
+982.0,L. Alario,169,Eintracht Frankfurt,78,Bundesliga,2022,1,1,0,3,3.0
+979.0,Dominik Kohr,164,FSV Mainz 05,78,Bundesliga,2022,1,1,0,3,3.0
+56396.0,Junior Messias,495,Genoa,135,Serie A,2024,1,1,0,3,3.0
+56396.0,Junior Messias,495,Genoa,135,Serie A,2023,1,1,0,3,3.0
+829.0,Rodrigo Becão,494,Udinese,135,Serie A,2021,1,1,0,3,3.0
+794.0,P. Schick,168,Bayer Leverkusen,78,Bundesliga,2023,1,1,0,3,3.0
+794.0,P. Schick,168,Bayer Leverkusen,78,Bundesliga,2022,1,1,0,3,3.0
+785.0,C. Ünder,81,Marseille,61,Ligue 1,2022,1,1,0,3,3.0
+61431.0,J. Kiwior,42,Arsenal,39,Premier League,2022,1,1,0,3,3.0
+61411.0,E. Mašović,176,VfL Bochum,78,Bundesliga,2022,1,1,0,3,3.0
+987.0,Paulinho,168,Bayer Leverkusen,78,Bundesliga,2022,1,1,0,3,3.0
+19.0,Julian Weigl,163,Borussia Mönchengladbach,78,Bundesliga,2022,1,1,0,3,3.0
+434352.0,A. Touré,112,Metz,61,Ligue 1,2024,1,1,0,3,3.0
+438281.0,A. Nagida,94,Rennes,61,Ligue 1,2024,1,1,0,3,3.0
+449662.0,M. Meïté,94,Rennes,61,Ligue 1,2024,1,1,0,3,3.0
+30.0,Santiago Arias,715,Granada CF,140,La Liga,2021,1,1,0,3,3.0
+24.0,M. Philipp,160,SC Freiburg,78,Bundesliga,2023,1,1,0,3,3.0
+395761.0,M. Lambourde,504,Verona,135,Serie A,2024,1,1,0,3,3.0
+392270.0,Marc Guiu,529,Barcelona,140,La Liga,2023,1,1,0,3,3.0
+386305.0,Jacobo Ramón,541,Real Madrid,140,La Liga,2024,1,1,0,3,3.0
+385569.0,E. Biumla,77,Angers,61,Ligue 1,2024,1,1,0,3,3.0
+47439.0,Stanislav Lobotka,492,Napoli,135,Serie A,2021,1,1,0,3,3.0
+405112.0,S. Fukuda,163,Borussia Mönchengladbach,78,Bundesliga,2024,1,1,0,3,3.0
+403889.0,P. Diallo,112,Metz,61,Ligue 1,2023,1,1,0,3,3.0
+402640.0,R. Esse,52,Crystal Palace,39,Premier League,2024,1,1,0,3,3.0
+400948.0,Assane Diao,543,Real Betis,140,La Liga,2024,1,1,0,3,3.0
+18742.0,M. Doherty,39,Wolves,39,Premier League,2023,1,1,0,3,3.0
+411702.0,Pau Cabanes,533,Villarreal,140,La Liga,2024,1,1,0,3,3.0
+409047.0,G. Leoni,523,Parma,135,Serie A,2024,1,1,0,3,3.0
+408870.0,I. Sané,112,Metz,61,Ligue 1,2023,1,1,0,3,3.0
+408540.0,K. Mutandwa,490,Cagliari,135,Serie A,2023,1,1,0,3,3.0
+406244.0,J. Manzambi,160,SC Freiburg,78,Bundesliga,2024,1,1,0,3,3.0
+383685.0,Y. Minteh,51,Brighton,39,Premier League,2024,1,1,0,3,3.0
+18776.0,Çağlar Söyüncü,46,Leicester,39,Premier League,2021,1,1,0,3,3.0
+15881.0,Morten Frendrup,489,AC Milan,135,Serie A,2024,1,1,0,3,3.0
+15874.0,A. Jung,162,Werder Bremen,78,Bundesliga,2023,1,1,0,3,3.0
+15848.0,Jacob Laursen,188,Arminia Bielefeld,78,Bundesliga,2021,1,1,0,3,3.0
+15799.0,F. Onyeka,55,Brentford,39,Premier League,2023,1,1,0,3,3.0
+109.0,A. Golovin,91,Monaco,61,Ligue 1,2023,1,1,0,3,3.0
+107.0,S. Diop,91,Monaco,61,Ligue 1,2021,1,1,0,3,3.0
+105.0,F. Ballo-Touré,489,AC Milan,135,Serie A,2022,1,1,0,3,3.0
+104.0,Carlos Vinícius,36,Fulham,39,Premier League,2023,1,1,0,3,3.0
+103.0,Jean-Eudes Aholou,95,Strasbourg,61,Ligue 1,2021,1,1,0,3,3.0
+20.0,A. Witsel,165,Borussia Dortmund,78,Bundesliga,2021,1,1,0,3,3.0
+340279.0,Vitor Roque,543,Real Betis,140,La Liga,2024,1,1,0,3,3.0
+339887.0,C. Uzun,169,Eintracht Frankfurt,78,Bundesliga,2024,1,1,0,3,3.0
+119.0,Radamel Falcao,728,Rayo Vallecano,140,La Liga,2023,1,1,0,3,3.0
+343332.0,Z. Savva,503,Torino,135,Serie A,2023,1,1,0,3,3.0
+343320.0,Eliesse Ben Seghir,91,Monaco,61,Ligue 1,2022,1,1,0,3,3.0
+342063.0,Diego Coppola,504,Verona,135,Serie A,2023,1,1,0,3,3.0
+48.0,Saúl Ñíguez,530,Atletico Madrid,140,La Liga,2023,1,1,0,3,3.0
+37.0,Nehuén Pérez,494,Udinese,135,Serie A,2022,1,1,0,3,3.0
+451504.0,J. Ekhator,495,Genoa,135,Serie A,2024,1,1,0,3,3.0
+382452.0,Patrick Dorgu,867,Lecce,135,Serie A,2023,1,1,0,3,3.0
+22.0,J. Bruun Larsen,44,Burnley,39,Premier League,2023,1,1,0,3,3.0
+340626.0,Fermín López,529,Barcelona,140,La Liga,2023,1,1,0,3,3.0
+48065.0,J. Nilsson,188,Arminia Bielefeld,78,Bundesliga,2021,1,1,0,3,3.0
+48471.0,R. Vargas,170,FC Augsburg,78,Bundesliga,2023,1,1,0,3,3.0
+48406.0,D. Črnigoj,517,Venezia,135,Serie A,2021,1,1,0,3,3.0
+48392.0,E. Zhegrova,79,Lille,61,Ligue 1,2023,1,1,0,3,3.0
+48392.0,E. Zhegrova,79,Lille,61,Ligue 1,2021,1,1,0,3,3.0
+48389.0,N. Okafor,489,AC Milan,135,Serie A,2024,1,1,0,3,3.0
+833.0,Jaka Bijol,895,Como,135,Serie A,2024,1,1,0,3,3.0
+48577.0,N. Bajrami,511,Empoli,135,Serie A,2022,1,1,0,3,3.0
+48577.0,N. Bajrami,488,Sassuolo,135,Serie A,2022,1,1,0,3,3.0
+48491.0,V. Sierro,96,Toulouse,61,Ligue 1,2024,1,1,0,3,3.0
+59.0,Álvaro Morata,489,AC Milan,135,Serie A,2024,1,1,0,3,3.0
+862.0,L. Spinazzola,497,AS Roma,135,Serie A,2023,1,1,0,3,3.0
+861.0,D. Rugani,496,Juventus,135,Serie A,2023,1,1,0,3,3.0
+853.0,L. Bonucci,496,Juventus,135,Serie A,2022,1,1,0,3,3.0
+842.0,N. Vlašić,48,West Ham,39,Premier League,2021,1,1,0,3,3.0
+972.0,J. Tah,168,Bayer Leverkusen,78,Bundesliga,2024,1,1,0,3,3.0
+972.0,J. Tah,168,Bayer Leverkusen,78,Bundesliga,2022,1,1,0,3,3.0
+972.0,J. Tah,168,Bayer Leverkusen,78,Bundesliga,2021,1,1,0,3,3.0
+47463.0,Pepelu,532,Valencia,140,La Liga,2023,1,1,0,3,3.0
+47460.0,Rober,539,Levante,140,La Liga,2021,1,1,0,3,3.0
+47451.0,Coke,539,Levante,140,La Liga,2021,1,1,0,3,3.0
+47440.0,Brais Méndez,548,Real Sociedad,140,La Liga,2023,1,1,0,3,3.0
+48491.0,V. Sierro,96,Toulouse,61,Ligue 1,2023,1,1,0,3,3.0
+52.0,Sergio Camello,728,Rayo Vallecano,140,La Liga,2024,1,1,0,3,3.0
+52.0,Sergio Camello,728,Rayo Vallecano,140,La Liga,2023,1,1,0,3,3.0
+49.0,T. Partey,42,Arsenal,39,Premier League,2024,1,1,0,3,3.0
+349232.0,A. Dembélé,503,Torino,135,Serie A,2024,1,1,0,3,3.0
+353943.0,Nacho Ferri,169,Eintracht Frankfurt,78,Bundesliga,2023,1,1,0,3,3.0
+353609.0,I. Sulemana,499,Atalanta,135,Serie A,2024,1,1,0,3,3.0
+350856.0,E. Nuamah,80,Lyon,61,Ligue 1,2024,1,1,0,3,3.0
+74.0,S. Amrabat,502,Fiorentina,135,Serie A,2021,1,1,0,3,3.0
+368260.0,G. Orban,80,Lyon,61,Ligue 1,2023,1,1,0,3,3.0
+364810.0,Abakar Sylla,95,Strasbourg,61,Ligue 1,2023,1,1,0,3,3.0
+48079.0,J. Karlsson,500,Bologna,135,Serie A,2024,1,1,0,3,3.0
+921.0,C. Piccini,532,Valencia,140,La Liga,2021,1,1,0,3,3.0
+47514.0,Valery,547,Girona,140,La Liga,2023,1,1,0,3,3.0
+47499.0,E. Ünal,546,Getafe,140,La Liga,2021,1,1,0,3,3.0
+47495.0,Sergi Guardiola,724,Cadiz,140,La Liga,2023,1,1,0,3,3.0
+47533.0,Alejandro Catena,728,Rayo Vallecano,140,La Liga,2022,1,1,0,3,3.0
+47520.0,Portu,548,Real Sociedad,140,La Liga,2021,1,1,0,3,3.0
+887.0,M. Darmian,523,Parma,135,Serie A,2024,1,1,0,3,3.0
+886.0,Diogo Dalot,33,Manchester United,39,Premier League,2022,1,1,0,3,3.0
+48378.0,S. Widmer,164,FSV Mainz 05,78,Bundesliga,2021,1,1,0,3,3.0
+48372.0,E. Cömert,532,Valencia,140,La Liga,2022,1,1,0,3,3.0
+48198.0,Í. Bergmann Jóhannesson,158,Fortuna Dusseldorf,78,Bundesliga,2023,1,1,0,3,3.0
+361497.0,Dean Huijsen,503,Torino,135,Serie A,2023,1,1,0,3,3.0
+104792.0,Chris Ramos,724,Cadiz,140,La Liga,2023,1,1,0,3,3.0
+101814.0,Ronald Araújo,529,Barcelona,140,La Liga,2021,1,1,0,3,3.0
+99576.0,O. Sahraoui,79,Lille,61,Ligue 1,2024,1,1,0,3,3.0
+696.0,Marcos Antônio,487,Lazio,135,Serie A,2022,1,1,0,3,3.0
+690.0,V. Kovalenko,511,Empoli,135,Serie A,2023,1,1,0,3,3.0
+679.0,Ismaily,79,Lille,61,Ligue 1,2022,1,1,0,3,3.0
+671.0,B. Traoré,66,Aston Villa,39,Premier League,2022,1,1,0,3,3.0
+668.0,N. Fekir,543,Real Betis,140,La Liga,2023,1,1,0,3,3.0
+104835.0,Darío Poveda,546,Getafe,140,La Liga,2021,1,1,0,3,3.0
+104821.0,Jon Guridi,548,Real Sociedad,140,La Liga,2021,1,1,0,3,3.0
+47302.0,Diego Llorente,497,AS Roma,135,Serie A,2023,1,1,0,3,3.0
+41157.0,André Almeida,532,Valencia,140,La Liga,2023,1,1,0,3,3.0
+41150.0,Edmond Tapsoba,173,RB Leipzig,78,Bundesliga,2024,1,1,0,3,3.0
+41146.0,F. Hanin,77,Angers,61,Ligue 1,2024,1,1,0,3,3.0
+41112.0,Trincão,39,Wolves,39,Premier League,2021,1,1,0,3,3.0
+41104.0,João Palhinha,63,Leeds,39,Premier League,2022,1,1,0,3,3.0
+1323.0,Dani Olmo,173,RB Leipzig,78,Bundesliga,2022,1,1,0,3,3.0
+41552.0,P. Ciss,728,Rayo Vallecano,140,La Liga,2023,1,1,0,3,3.0
+41300.0,Jubal,111,Le Havre,61,Ligue 1,2024,1,1,0,3,3.0
+41300.0,Jubal,108,Auxerre,61,Ligue 1,2022,1,1,0,3,3.0
+1408.0,S. Bornauw,170,FC Augsburg,78,Bundesliga,2023,1,1,0,3,3.0
+41300.0,Jubal,108,Auxerre,61,Ligue 1,2021,1,1,0,3,3.0
+84128.0,Y. Gboho,96,Toulouse,61,Ligue 1,2024,1,1,0,3,3.0
+41748.0,J. Onana,78,Bordeaux,61,Ligue 1,2021,1,1,0,3,3.0
+1445.0,K. Mavropanos,172,VfB Stuttgart,78,Bundesliga,2022,1,1,0,3,3.0
+1442.0,S. Kolašinac,81,Marseille,61,Ligue 1,2022,1,1,0,3,3.0
+46170.0,I. Ilić,503,Torino,135,Serie A,2022,1,1,0,3,3.0
+45892.0,A. Ilić,182,Union Berlin,78,Bundesliga,2024,1,1,0,3,3.0
+44871.0,Aaron Hickey,500,Bologna,135,Serie A,2021,1,1,0,3,3.0
+44811.0,S. McKenna,728,Rayo Vallecano,140,La Liga,2024,1,1,0,3,3.0
+46677.0,Víctor Díaz,715,Granada CF,140,La Liga,2021,1,1,0,3,3.0
+46658.0,Rubén García,727,Osasuna,140,La Liga,2022,1,1,0,3,3.0
+104821.0,Jon Guridi,542,Alaves,140,La Liga,2023,1,1,0,3,3.0
+46653.0,David García,727,Osasuna,140,La Liga,2021,1,1,0,3,3.0
+1266.0,T. Bašić,487,Lazio,135,Serie A,2022,1,1,0,3,3.0
+1257.0,Jules Koundé,543,Real Betis,140,La Liga,2022,1,1,0,3,3.0
+1243.0,Tomáš Souček,48,West Ham,39,Premier League,2024,1,1,0,3,3.0
+90731.0,L. Ritzka,186,FC St. Pauli,78,Bundesliga,2024,1,1,0,3,3.0
+90594.0,J. Dina Ebimbe,169,Eintracht Frankfurt,78,Bundesliga,2022,1,1,0,3,3.0
+90590.0,G. Rutter,167,1899 Hoffenheim,78,Bundesliga,2022,1,1,0,3,3.0
+93016.0,T. Dallinga,96,Toulouse,61,Ligue 1,2023,1,1,0,3,3.0
+93016.0,T. Dallinga,96,Toulouse,61,Ligue 1,2022,1,1,0,3,3.0
+91358.0,E. Valeri,520,Cremonese,135,Serie A,2022,1,1,0,3,3.0
+104821.0,Jon Guridi,542,Alaves,140,La Liga,2024,1,1,0,3,3.0
+46657.0,Nacho Vidal,727,Osasuna,140,La Liga,2023,1,1,0,3,3.0
+709.0,Pavel Kadeřábek,167,1899 Hoffenheim,78,Bundesliga,2024,1,1,0,3,3.0
+709.0,Pavel Kadeřábek,167,1899 Hoffenheim,78,Bundesliga,2022,1,1,0,3,3.0
+709.0,Pavel Kadeřábek,167,1899 Hoffenheim,78,Bundesliga,2021,1,1,0,3,3.0
+104941.0,Monchu,720,Valladolid,140,La Liga,2022,1,1,0,3,3.0
+716.0,L. Bittencourt,162,Werder Bremen,78,Bundesliga,2023,1,1,0,3,3.0
+715.0,C. Baumgartner,173,RB Leipzig,78,Bundesliga,2024,1,1,0,3,3.0
+118956.0,L. Banda,867,Lecce,135,Serie A,2022,1,1,0,3,3.0
+113581.0,T. Coulibaly,82,Montpellier,61,Ligue 1,2024,1,1,0,3,3.0
+108474.0,L. Kilian,192,1.FC Köln,78,Bundesliga,2021,1,1,0,3,3.0
+106835.0,K. Mitoma,51,Brighton,39,Premier League,2023,1,1,0,3,3.0
+1407.0,D. Appiah,85,Paris Saint Germain,61,Ligue 1,2021,1,1,0,3,3.0
+122233.0,Marcos André,532,Valencia,140,La Liga,2022,1,1,0,3,3.0
+122230.0,Manu Fuster,534,Las Palmas,140,La Liga,2024,1,1,0,3,3.0
+119685.0,D. Čolina,170,FC Augsburg,78,Bundesliga,2022,1,1,0,3,3.0
+119232.0,Dani Gómez,532,Valencia,140,La Liga,2024,1,1,0,3,3.0
+119213.0,Alfon González,538,Celta Vigo,140,La Liga,2024,1,1,0,3,3.0
+1462.0,L. Torreira,502,Fiorentina,135,Serie A,2021,1,1,0,3,3.0
+1461.0,Denis Suárez,533,Villarreal,140,La Liga,2024,1,1,0,3,3.0
+1459.0,A. Ramsey,84,Nice,61,Ligue 1,2022,1,1,0,3,3.0
+1457.0,Henrikh Mkhitaryan,505,Inter,135,Serie A,2022,1,1,0,3,3.0
+35544.0,J. Vásquez,495,Genoa,135,Serie A,2021,1,1,0,3,3.0
+106835.0,K. Mitoma,51,Brighton,39,Premier League,2022,1,1,0,3,3.0
+1370.0,A. Ayew,111,Le Havre,61,Ligue 1,2024,1,1,0,3,3.0
+1353.0,T. Arslan,494,Udinese,135,Serie A,2022,1,1,0,3,3.0
+1353.0,T. Arslan,494,Udinese,135,Serie A,2021,1,1,0,3,3.0
+153430.0,A. Elanga,65,Nottingham Forest,39,Premier League,2024,1,1,0,3,3.0
+1439.0,Héctor Bellerín,536,Sevilla,140,La Liga,2021,1,1,0,3,3.0
+1422.0,J. Doku,94,Rennes,61,Ligue 1,2022,1,1,0,3,3.0
+37651.0,J. Idzes,517,Venezia,135,Serie A,2024,1,1,0,3,3.0
+37437.0,A. Harroui,504,Verona,135,Serie A,2024,1,1,0,3,3.0
+37437.0,A. Harroui,488,Sassuolo,135,Serie A,2022,1,1,0,3,3.0
+37242.0,D. Burgzorg,164,FSV Mainz 05,78,Bundesliga,2021,1,1,0,3,3.0
+711.0,Stefan Posch,167,1899 Hoffenheim,78,Bundesliga,2021,1,1,0,3,3.0
+38734.0,Sven Botman,34,Newcastle,39,Premier League,2023,1,1,0,3,3.0
+38123.0,A. Hrustić,169,Eintracht Frankfurt,78,Bundesliga,2021,1,1,0,3,3.0
+39248.0,I. Wadji,1063,Saint Etienne,61,Ligue 1,2023,1,1,0,3,3.0
+39095.0,E. Rashani,99,Clermont Foot,61,Ligue 1,2022,1,1,0,3,3.0
+39071.0,V. Boniface,168,Bayer Leverkusen,78,Bundesliga,2024,1,1,0,3,3.0
+41104.0,João Palhinha,36,Fulham,39,Premier League,2023,1,1,0,3,3.0
+41104.0,João Palhinha,36,Fulham,39,Premier League,2022,1,1,0,3,3.0
+40419.0,Aleksandar Sedlar,542,Alaves,140,La Liga,2023,1,1,0,3,3.0
+714.0,N. Amiri,168,Bayer Leverkusen,78,Bundesliga,2022,1,1,0,3,3.0
+714.0,N. Amiri,168,Bayer Leverkusen,78,Bundesliga,2021,1,1,0,3,3.0
+711.0,Stefan Posch,500,Bologna,135,Serie A,2022,1,1,0,3,3.0
+37236.0,A. Matusiwa,93,Reims,61,Ligue 1,2023,1,1,0,3,3.0
+756.0,F. Valverde,541,Real Madrid,140,La Liga,2024,1,1,0,3,3.0
+754.0,L. Modrić,541,Real Madrid,140,La Liga,2024,1,1,0,3,3.0
+754.0,L. Modrić,541,Real Madrid,140,La Liga,2021,1,1,0,3,3.0
+67972.0,C. Gallagher,49,Chelsea,39,Premier League,2022,1,1,0,3,3.0
+67971.0,Marc Guéhi,51,Brighton,39,Premier League,2024,1,1,0,3,3.0
+67971.0,Marc Guéhi,42,Arsenal,39,Premier League,2022,1,1,0,3,3.0
+67955.0,Carles Pérez,546,Getafe,140,La Liga,2024,1,1,0,3,3.0
+67955.0,Carles Pérez,538,Celta Vigo,140,La Liga,2022,1,1,0,3,3.0
+67955.0,Carles Pérez,497,AS Roma,135,Serie A,2021,1,1,0,3,3.0
+70339.0,Shon Weissman,720,Valladolid,140,La Liga,2022,1,1,0,3,3.0
+85041.0,A. Gouiri,81,Marseille,61,Ligue 1,2024,1,1,0,3,3.0
+69971.0,T. Moffi,97,Lorient,61,Ligue 1,2022,1,1,0,3,3.0
+69971.0,T. Moffi,84,Nice,61,Ligue 1,2024,1,1,0,3,3.0
+727.0,R. Nelson,42,Arsenal,39,Premier League,2022,1,1,0,3,3.0
+723.0,Joelinton,34,Newcastle,39,Premier League,2023,1,1,0,3,3.0
+70747.0,J. Enciso,51,Brighton,39,Premier League,2022,1,1,0,3,3.0
+46849.0,Javi Hernández,724,Cadiz,140,La Liga,2023,1,1,0,3,3.0
+46824.0,Iván Alejo,724,Cadiz,140,La Liga,2021,1,1,0,3,3.0
+46808.0,Carlos Fernández,548,Real Sociedad,140,La Liga,2023,1,1,0,3,3.0
+46795.0,Domingos Duarte,546,Getafe,140,La Liga,2024,1,1,0,3,3.0
+46792.0,Pablo Marí,494,Udinese,135,Serie A,2021,1,1,0,3,3.0
+70315.0,Kirian Rodríguez,534,Las Palmas,140,La Liga,2023,1,1,0,3,3.0
+47301.0,Robin Le Normand,548,Real Sociedad,140,La Liga,2023,1,1,0,3,3.0
+47301.0,Robin Le Normand,538,Celta Vigo,140,La Liga,2022,1,1,0,3,3.0
+47300.0,T. Hernández,489,AC Milan,135,Serie A,2023,1,1,0,3,3.0
+1109.0,C. Gamboa,176,VfL Bochum,78,Bundesliga,2024,1,1,0,3,3.0
+1098.0,P. Daka,46,Leicester,39,Premier League,2024,1,1,0,3,3.0
+47309.0,Ander Guevara,542,Alaves,140,La Liga,2023,1,1,0,3,3.0
+1221.0,S. Azmoun,497,AS Roma,135,Serie A,2023,1,1,0,3,3.0
+1167.0,Y. Poulsen,173,RB Leipzig,78,Bundesliga,2021,1,1,0,3,3.0
+1157.0,K. Laimer,173,RB Leipzig,78,Bundesliga,2022,1,1,0,3,3.0
+47237.0,Luis Javier Suárez,81,Marseille,61,Ligue 1,2022,1,1,0,3,3.0
+67939.0,Aimar Oroz,727,Osasuna,140,La Liga,2024,1,1,0,3,3.0
+47182.0,Tete Morente,797,Elche,140,La Liga,2021,1,1,0,3,3.0
+47180.0,Cristian Herrera,534,Las Palmas,140,La Liga,2023,1,1,0,3,3.0
+47254.0,M. Olivera,492,Napoli,135,Serie A,2022,1,1,0,3,3.0
+47249.0,L. Cabrera,540,Espanyol,140,La Liga,2024,1,1,0,3,3.0
+47249.0,L. Cabrera,540,Espanyol,140,La Liga,2021,1,1,0,3,3.0
+47270.0,Unai Simón,530,Atletico Madrid,140,La Liga,2023,1,1,0,3,3.0
+47266.0,Ángel,798,Mallorca,140,La Liga,2022,1,1,0,3,3.0
+47264.0,Hugo Duro,532,Valencia,140,La Liga,2024,1,1,0,3,3.0
+47263.0,Samu Sáiz,547,Girona,140,La Liga,2022,1,1,0,3,3.0
+47262.0,Portillo,723,Almeria,140,La Liga,2022,1,1,0,3,3.0
+67940.0,José Gragera,540,Espanyol,140,La Liga,2022,1,1,0,3,3.0
+47182.0,Tete Morente,797,Elche,140,La Liga,2022,1,1,0,3,3.0
+46725.0,R. Manaj,515,Spezia,135,Serie A,2021,1,1,0,3,3.0
+46714.0,M. Malsa,539,Levante,140,La Liga,2021,1,1,0,3,3.0
+46769.0,Álex Fernández,724,Cadiz,140,La Liga,2022,1,1,0,3,3.0
+46759.0,Alfonso Espino,724,Cadiz,140,La Liga,2021,1,1,0,3,3.0
+46751.0,Abdón Prats,798,Mallorca,140,La Liga,2024,1,1,0,3,3.0
+46751.0,Abdón Prats,798,Mallorca,140,La Liga,2022,1,1,0,3,3.0
+46746.0,A. Budimir,727,Osasuna,140,La Liga,2021,1,1,0,3,3.0
+738.0,Sergio Ramos,529,Barcelona,140,La Liga,2023,1,1,0,3,3.0
+738.0,Sergio Ramos,85,Paris Saint Germain,61,Ligue 1,2022,1,1,0,3,3.0
+735.0,Nacho Fernández,541,Real Madrid,140,La Liga,2021,1,1,0,3,3.0
+46965.0,Gonzalo Verdú,797,Elche,140,La Liga,2022,1,1,0,3,3.0
+742.0,R. Varane,33,Manchester United,39,Premier League,2023,1,1,0,3,3.0
+84082.0,R. Faivre,80,Lyon,61,Ligue 1,2021,1,1,0,3,3.0
+84055.0,K. Bamba,83,Nantes,61,Ligue 1,2023,1,1,0,3,3.0
+81573.0,Omar Marmoush,161,VfL Wolfsburg,78,Bundesliga,2022,1,1,0,3,3.0
+80752.0,T. Tessmann,80,Lyon,61,Ligue 1,2024,1,1,0,3,3.0
+80434.0,T. Čvančara,163,Borussia Mönchengladbach,78,Bundesliga,2024,1,1,0,3,3.0
+76904.0,Halid Šabanović,77,Angers,61,Ligue 1,2022,1,1,0,3,3.0
+85772.0,J. Le Douaron,106,Stade Brestois 29,61,Ligue 1,2023,1,1,0,3,3.0
+85772.0,J. Le Douaron,106,Stade Brestois 29,61,Ligue 1,2022,1,1,0,3,3.0
+85772.0,J. Le Douaron,106,Stade Brestois 29,61,Ligue 1,2021,1,1,0,3,3.0
+85558.0,L. Mafouta,112,Metz,61,Ligue 1,2021,1,1,0,3,3.0
+72457.0,A. Tosin,97,Lorient,61,Ligue 1,2023,1,1,0,3,3.0
+46860.0,Javi Muñoz,534,Las Palmas,140,La Liga,2024,1,1,0,3,3.0
+46860.0,Javi Muñoz,534,Las Palmas,140,La Liga,2023,1,1,0,3,3.0
+47052.0,Álex Muñoz,534,Las Palmas,140,La Liga,2024,1,1,0,3,3.0
+47013.0,Rafa Mir,536,Sevilla,140,La Liga,2023,1,1,0,3,3.0
+47013.0,Rafa Mir,536,Sevilla,140,La Liga,2022,1,1,0,3,3.0
+47000.0,D. Blum,176,VfL Bochum,78,Bundesliga,2021,1,1,0,3,3.0
+47080.0,Jorge Sáenz,537,Leganes,140,La Liga,2024,1,1,0,3,3.0
+47056.0,Íñigo Eguaras,723,Almeria,140,La Liga,2022,1,1,0,3,3.0
+1314.0,Amir Rrahmani,492,Napoli,135,Serie A,2021,1,1,0,3,3.0
+1302.0,J. Wind,161,VfL Wolfsburg,78,Bundesliga,2022,1,1,0,3,3.0
+46733.0,Raíllo,798,Mallorca,140,La Liga,2021,1,1,0,3,3.0
+1282.0,J. Joronen,504,Verona,135,Serie A,2024,1,1,0,3,3.0
+1278.0,Y. Karamoh,503,Torino,135,Serie A,2022,1,1,0,3,3.0
+1278.0,Y. Karamoh,82,Montpellier,61,Ligue 1,2023,1,1,0,3,3.0
+1271.0,A. Tchouaméni,541,Real Madrid,140,La Liga,2023,1,1,0,3,3.0
+46710.0,Jérémie Bela,99,Clermont Foot,61,Ligue 1,2022,1,1,0,3,3.0
+1321.0,L. Majer,161,VfL Wolfsburg,78,Bundesliga,2023,1,1,0,3,3.0
+1321.0,L. Majer,94,Rennes,61,Ligue 1,2022,1,1,0,3,3.0
+1314.0,Amir Rrahmani,492,Napoli,135,Serie A,2023,1,1,0,3,3.0
+1314.0,Amir Rrahmani,492,Napoli,135,Serie A,2022,1,1,0,3,3.0
+46738.0,Martin Valjent,798,Mallorca,140,La Liga,2024,1,1,0,3,3.0
+46736.0,F. Russo,798,Mallorca,140,La Liga,2021,1,1,0,3,3.0
+1291.0,D. Vavro,161,VfL Wolfsburg,78,Bundesliga,2024,1,1,0,3,3.0
+19586.0,E. Eze,52,Crystal Palace,39,Premier League,2022,1,1,0,3,3.0
+19558.0,Sam Morsy,57,Ipswich,39,Premier League,2024,1,1,0,3,3.0
+19545.0,R. James,49,Chelsea,39,Premier League,2024,1,1,0,3,3.0
+19545.0,R. James,49,Chelsea,39,Premier League,2022,1,1,0,3,3.0
+19524.0,C. Adams,503,Torino,135,Serie A,2024,1,1,0,3,3.0
+19804.0,K. Moore,35,Bournemouth,39,Premier League,2023,1,1,0,3,3.0
+19804.0,K. Moore,35,Bournemouth,39,Premier League,2022,1,1,0,3,3.0
+19789.0,E. Pinnock,55,Brentford,39,Premier League,2022,1,1,0,3,3.0
+19789.0,E. Pinnock,34,Newcastle,39,Premier League,2022,1,1,0,3,3.0
+19617.0,M. Olise,52,Crystal Palace,39,Premier League,2023,1,1,0,3,3.0
+2201.0,Mexer,78,Bordeaux,61,Ligue 1,2021,1,1,0,3,3.0
+179.0,M. Sissoko,83,Nantes,61,Ligue 1,2022,1,1,0,3,3.0
+179.0,M. Sissoko,38,Watford,39,Premier League,2021,1,1,0,3,3.0
+178.0,Lucas Moura,47,Tottenham,39,Premier League,2022,1,1,0,3,3.0
+175.0,E. Dier,157,Bayern München,78,Bundesliga,2024,1,1,0,3,3.0
+175.0,E. Dier,34,Newcastle,39,Premier League,2021,1,1,0,3,3.0
+284797.0,Dango Ouattara,35,Bournemouth,39,Premier League,2022,1,1,0,3,3.0
+284492.0,Lewis Hall,34,Newcastle,39,Premier League,2023,1,1,0,3,3.0
+284406.0,A. Gilchrist,49,Chelsea,39,Premier League,2023,1,1,0,3,3.0
+286711.0,L. Gechter,159,Hertha Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+286710.0,D. Scherhant,159,Hertha Berlin,78,Bundesliga,2022,1,1,0,3,3.0
+19599.0,Emiliano Martínez,1359,Luton,39,Premier League,2023,1,1,0,3,3.0
+20572.0,Jimmy Giraudon,79,Lille,61,Ligue 1,2021,1,1,0,3,3.0
+20563.0,G. Charbonnier,108,Auxerre,61,Ligue 1,2021,1,1,0,3,3.0
+20551.0,M. Autret,108,Auxerre,61,Ligue 1,2022,1,1,0,3,3.0
+20537.0,I. Niane,112,Metz,61,Ligue 1,2021,1,1,0,3,3.0
+20525.0,M. Udol,112,Metz,61,Ligue 1,2024,1,1,0,3,3.0
+3165.0,Youcef Atal,84,Nice,61,Ligue 1,2021,1,1,0,3,3.0
+3099.0,Y. Ndayishimiye,84,Nice,61,Ligue 1,2024,1,1,0,3,3.0
+3080.0,M. Munetsi,93,Reims,61,Ligue 1,2024,1,1,0,3,3.0
+20592.0,Y. Touzghar,110,Estac Troyes,61,Ligue 1,2021,1,1,0,3,3.0
+20576.0,Y. Salmier,110,Estac Troyes,61,Ligue 1,2022,1,1,0,3,3.0
+19599.0,Emiliano Martínez,42,Arsenal,39,Premier League,2022,1,1,0,3,3.0
+3292.0,L. Mothiba,95,Strasbourg,61,Ligue 1,2023,1,1,0,3,3.0
+3292.0,L. Mothiba,95,Strasbourg,61,Ligue 1,2022,1,1,0,3,3.0
+3246.0,N. Pépé,84,Nice,61,Ligue 1,2022,1,1,0,3,3.0
+6050.0,Lautaro Giannetti,492,Napoli,135,Serie A,2024,1,1,0,3,3.0
+6010.0,L. Beltrán,502,Fiorentina,135,Serie A,2023,1,1,0,3,3.0
+6009.0,J. Alvarez,50,Manchester City,39,Premier League,2022,1,1,0,3,3.0
+4399.0,H. Boudaoui,84,Nice,61,Ligue 1,2021,1,1,0,3,3.0
+19524.0,C. Adams,41,Southampton,39,Premier League,2022,1,1,0,3,3.0
+19524.0,C. Adams,41,Southampton,39,Premier League,2021,1,1,0,3,3.0
+19484.0,Adam Armstrong,41,Southampton,39,Premier League,2024,1,1,0,3,3.0
+6221.0,L. Valenti,523,Parma,135,Serie A,2024,1,1,0,3,3.0
+3292.0,L. Mothiba,110,Estac Troyes,61,Ligue 1,2021,1,1,0,3,3.0
+297311.0,Kike Salas,536,Sevilla,140,La Liga,2023,1,1,0,3,3.0
+296458.0,D. Jebbison,35,Bournemouth,39,Premier League,2024,1,1,0,3,3.0
+293604.0,Javi Llabrés,798,Mallorca,140,La Liga,2023,1,1,0,3,3.0
+305834.0,Andrey Santos,95,Strasbourg,61,Ligue 1,2023,1,1,0,3,3.0
+305803.0,Kaiky,723,Almeria,140,La Liga,2023,1,1,0,3,3.0
+304853.0,A. Scott,35,Bournemouth,39,Premier League,2023,1,1,0,3,3.0
+304383.0,T. Allende,538,Celta Vigo,140,La Liga,2023,1,1,0,3,3.0
+302432.0,A. Bianco,1579,Monza,135,Serie A,2024,1,1,0,3,3.0
+297579.0,C. Traorè,489,AC Milan,135,Serie A,2023,1,1,0,3,3.0
+297311.0,Kike Salas,536,Sevilla,140,La Liga,2024,1,1,0,3,3.0
+286639.0,Bryan Zaragoza,715,Granada CF,140,La Liga,2023,1,1,0,3,3.0
+8683.0,I. Cardona,1063,Saint Etienne,61,Ligue 1,2023,1,1,0,3,3.0
+8683.0,I. Cardona,170,FC Augsburg,78,Bundesliga,2022,1,1,0,3,3.0
+8673.0,O. Deman,162,Werder Bremen,78,Bundesliga,2023,1,1,0,3,3.0
+8627.0,T. Bongonda,724,Cadiz,140,La Liga,2022,1,1,0,3,3.0
+19220.0,Mason Mount,33,Manchester United,39,Premier League,2023,1,1,0,3,3.0
+19209.0,Fikayo Tomori,489,AC Milan,135,Serie A,2023,1,1,0,3,3.0
+19202.0,L. Buchanan,162,Werder Bremen,78,Bundesliga,2022,1,1,0,3,3.0
+19201.0,J. Bogle,62,Sheffield Utd,39,Premier League,2023,1,1,0,3,3.0
+19194.0,T. Abraham,497,AS Roma,135,Serie A,2023,1,1,0,3,3.0
+19281.0,A. Semenyo,35,Bournemouth,39,Premier League,2022,1,1,0,3,3.0
+19268.0,J. Brownhill,44,Burnley,39,Premier League,2021,1,1,0,3,3.0
+19192.0,J. Ramsey,66,Aston Villa,39,Premier League,2023,1,1,0,3,3.0
+286559.0,Carlos Domínguez,541,Real Madrid,140,La Liga,2023,1,1,0,3,3.0
+286475.0,E. Bove,497,AS Roma,135,Serie A,2021,1,1,0,3,3.0
+286474.0,M. Cancellieri,523,Parma,135,Serie A,2024,1,1,0,3,3.0
+288074.0,Alberto Marí,532,Valencia,140,La Liga,2022,1,1,0,3,3.0
+288006.0,R. Højlund,33,Manchester United,39,Premier League,2024,1,1,0,3,3.0
+287927.0,J. Diehl,172,VfB Stuttgart,78,Bundesliga,2024,1,1,0,3,3.0
+7332.0,L. Sučić,548,Real Sociedad,140,La Liga,2024,1,1,0,3,3.0
+19329.0,D. James,63,Leeds,39,Premier League,2021,1,1,0,3,3.0
+19323.0,J. Asoro,112,Metz,61,Ligue 1,2023,1,1,0,3,3.0
+19305.0,R. Yates,65,Nottingham Forest,39,Premier League,2024,1,1,0,3,3.0
+290046.0,A. Makoumbou,490,Cagliari,135,Serie A,2023,1,1,0,3,3.0
+19361.0,S. Benrahma,80,Lyon,61,Ligue 1,2024,1,1,0,3,3.0
+19354.0,E. Konsa,66,Aston Villa,39,Premier League,2024,1,1,0,3,3.0
+19352.0,Sergi Canós,55,Brentford,39,Premier League,2021,1,1,0,3,3.0
+19461.0,L. Nmecha,161,VfL Wolfsburg,78,Bundesliga,2023,1,1,0,3,3.0
+19461.0,L. Nmecha,161,VfL Wolfsburg,78,Bundesliga,2021,1,1,0,3,3.0
+289761.0,G. Scalvini,499,Atalanta,135,Serie A,2021,1,1,0,3,3.0
+289460.0,J. Malatini,162,Werder Bremen,78,Bundesliga,2023,1,1,0,3,3.0
+292172.0,M. Pellegrino,523,Parma,135,Serie A,2024,1,1,0,3,3.0
+291476.0,D. Fofana,182,Union Berlin,78,Bundesliga,2023,1,1,0,3,3.0
+291363.0,G. Earthy,48,West Ham,39,Premier League,2023,1,1,0,3,3.0
+290482.0,Jorge Pascual,533,Villarreal,140,La Liga,2022,1,1,0,3,3.0
+7691.0,M. Berisha,170,FC Augsburg,78,Bundesliga,2022,1,1,0,3,3.0
+269531.0,N. Collins,169,Eintracht Frankfurt,78,Bundesliga,2024,1,1,0,3,3.0
+20870.0,R. Dugimont,108,Auxerre,61,Ligue 1,2021,1,1,0,3,3.0
+20776.0,J. Gastien,99,Clermont Foot,61,Ligue 1,2022,1,1,0,3,3.0
+20768.0,F. Ogier,99,Clermont Foot,61,Ligue 1,2023,1,1,0,3,3.0
+21005.0,C. Bayala,98,Ajaccio,61,Ligue 1,2022,1,1,0,3,3.0
+20995.0,Maxence Lacroix,164,FSV Mainz 05,78,Bundesliga,2021,1,1,0,3,3.0
+20995.0,Maxence Lacroix,161,VfL Wolfsburg,78,Bundesliga,2023,1,1,0,3,3.0
+20916.0,Christopher Wooh,95,Strasbourg,61,Ligue 1,2024,1,1,0,3,3.0
+2937.0,D. Rice,48,West Ham,39,Premier League,2022,1,1,0,3,3.0
+2936.0,James Tarkowski,45,Everton,39,Premier League,2024,1,1,0,3,3.0
+20503.0,Lewis O'Brien,65,Nottingham Forest,39,Premier League,2022,1,1,0,3,3.0
+3003.0,M. Kamiński,174,FC Schalke 04,78,Bundesliga,2022,1,1,0,3,3.0
+2996.0,S. Thioub,77,Angers,61,Ligue 1,2022,1,1,0,3,3.0
+2990.0,I. Gueye,45,Everton,39,Premier League,2023,1,1,0,3,3.0
+2973.0,Michael Murillo,81,Marseille,61,Ligue 1,2023,1,1,0,3,3.0
+270139.0,J. O'Brien,80,Lyon,61,Ligue 1,2023,1,1,0,3,3.0
+226.0,D. Dumfries,1579,Monza,135,Serie A,2022,1,1,0,3,3.0
+226.0,D. Dumfries,505,Inter,135,Serie A,2022,1,1,0,3,3.0
+215.0,S. Esposito,511,Empoli,135,Serie A,2024,1,1,0,3,3.0
+213.0,K. Baldé,1579,Monza,135,Serie A,2024,1,1,0,3,3.0
+207.0,I. Perišić,505,Inter,135,Serie A,2021,1,1,0,3,3.0
+21088.0,N. Pallois,81,Marseille,61,Ligue 1,2022,1,1,0,3,3.0
+21102.0,V. Rongier,81,Marseille,61,Ligue 1,2024,1,1,0,3,3.0
+21393.0,S. Guirassy,172,VfB Stuttgart,78,Bundesliga,2022,1,1,0,3,3.0
+21155.0,W. Kanga,159,Hertha Berlin,78,Bundesliga,2022,1,1,0,3,3.0
+21148.0,T. Mangani,77,Angers,61,Ligue 1,2021,1,1,0,3,3.0
+21146.0,A. Fulgini,116,Lens,61,Ligue 1,2024,1,1,0,3,3.0
+21497.0,L. Blas,94,Rennes,61,Ligue 1,2023,1,1,0,3,3.0
+21451.0,R. Ripart,110,Estac Troyes,61,Ligue 1,2021,1,1,0,3,3.0
+21441.0,Faitout Maouassa,82,Montpellier,61,Ligue 1,2022,1,1,0,3,3.0
+21434.0,T. Sainte-Luce,82,Montpellier,61,Ligue 1,2024,1,1,0,3,3.0
+238391.0,Jeffinho,80,Lyon,61,Ligue 1,2023,1,1,0,3,3.0
+194.0,S. de Vrij,505,Inter,135,Serie A,2024,1,1,0,3,3.0
+237103.0,Lázaro,723,Almeria,140,La Liga,2022,1,1,0,3,3.0
+269.0,C. Nkunku,49,Chelsea,39,Premier League,2023,1,1,0,3,3.0
+267.0,J. Draxler,85,Paris Saint Germain,61,Ligue 1,2021,1,1,0,3,3.0
+263530.0,Pau Víctor,529,Barcelona,140,La Liga,2024,1,1,0,3,3.0
+263482.0,Nuno Mendes,85,Paris Saint Germain,61,Ligue 1,2023,1,1,0,3,3.0
+263481.0,L. Colombo,1579,Monza,135,Serie A,2023,1,1,0,3,3.0
+268341.0,F. Gatti,496,Juventus,135,Serie A,2023,1,1,0,3,3.0
+268341.0,F. Gatti,488,Sassuolo,135,Serie A,2023,1,1,0,3,3.0
+266481.0,F. Bianchi,495,Genoa,135,Serie A,2021,1,1,0,3,3.0
+264470.0,Raúl Moro,720,Valladolid,140,La Liga,2024,1,1,0,3,3.0
+200.0,Gabriele Zappa,490,Cagliari,135,Serie A,2024,1,1,0,3,3.0
+237232.0,H. Ojediran,116,Lens,61,Ligue 1,2024,1,1,0,3,3.0
+20665.0,J. Bellegarde,95,Strasbourg,61,Ligue 1,2023,1,1,0,3,3.0
+20648.0,Ibrahim Sissoko,1063,Saint Etienne,61,Ligue 1,2024,1,1,0,3,3.0
+20638.0,E. Le Fée,97,Lorient,61,Ligue 1,2022,1,1,0,3,3.0
+20766.0,Julien Laporte,97,Lorient,61,Ligue 1,2021,1,1,0,3,3.0
+20696.0,P. Gueye,81,Marseille,61,Ligue 1,2023,1,1,0,3,3.0
+281408.0,Vítinha,81,Marseille,61,Ligue 1,2023,1,1,0,3,3.0
+280688.0,Theo Corbeanu,715,Granada CF,140,La Liga,2023,1,1,0,3,3.0
+280687.0,Hugo Bueno,40,Liverpool,39,Premier League,2023,1,1,0,3,3.0
+280055.0,L. Kerber,180,1. FC Heidenheim,78,Bundesliga,2024,1,1,0,3,3.0
+279822.0,E. Boyomo,727,Osasuna,140,La Liga,2024,1,1,0,3,3.0
+274312.0,M. Cho,77,Angers,61,Ligue 1,2021,1,1,0,3,3.0
+283026.0,M. Biereth,91,Monaco,61,Ligue 1,2024,1,1,0,3,3.0
+282770.0,Rodrigo Gomes,39,Wolves,39,Premier League,2024,1,1,0,3,3.0
+282549.0,J. Mwanga,95,Strasbourg,61,Ligue 1,2023,1,1,0,3,3.0
+166.0,J. Foyth,533,Villarreal,140,La Liga,2022,1,1,0,3,3.0
+164.0,B. Davies,47,Tottenham,39,Premier League,2023,1,1,0,3,3.0
+284072.0,B. Dieng,97,Lorient,61,Ligue 1,2022,1,1,0,3,3.0
+171.0,K. Walker-Peters,41,Southampton,39,Premier League,2022,1,1,0,3,3.0
+169.0,K. Trippier,34,Newcastle,39,Premier League,2021,1,1,0,3,3.0
+168.0,D. Sánchez,47,Tottenham,39,Premier League,2021,1,1,0,3,3.0
+20520.0,I. Balliu,724,Cadiz,140,La Liga,2022,1,1,0,3,3.0
+20519.0,Alexandre Oukidja,79,Lille,61,Ligue 1,2021,1,1,0,3,3.0
+283058.0,N. Jackson,49,Chelsea,39,Premier League,2024,1,1,0,3,3.0
+274300.0,M. Akliouche,91,Monaco,61,Ligue 1,2023,1,1,0,3,3.0
+270510.0,M. Tel,47,Tottenham,39,Premier League,2024,1,1,0,3,3.0
+270508.0,L. Ugochukwu,94,Rennes,61,Ligue 1,2021,1,1,0,3,3.0
+270508.0,L. Ugochukwu,41,Southampton,39,Premier League,2024,1,1,0,3,3.0
+276670.0,F. Chaïbi,96,Toulouse,61,Ligue 1,2022,1,1,0,3,3.0
+275671.0,E. Tchato,82,Montpellier,61,Ligue 1,2022,1,1,0,3,3.0
+275394.0,A. Hainaut,523,Parma,135,Serie A,2024,1,1,0,3,3.0
+278370.0,D. Gómez,51,Brighton,39,Premier League,2024,1,1,0,3,3.0
+278190.0,A. Álvarez,488,Sassuolo,135,Serie A,2022,1,1,0,3,3.0
+278095.0,J. Rowe,81,Marseille,61,Ligue 1,2024,1,1,0,3,3.0
+20674.0,S. Banza,116,Lens,61,Ligue 1,2021,1,1,0,3,3.0
+277003.0,N. El Aynaoui,116,Lens,61,Ligue 1,2024,1,1,0,3,3.0
+277003.0,N. El Aynaoui,116,Lens,61,Ligue 1,2023,1,1,0,3,3.0
+3395.0,S. Mounié,106,Stade Brestois 29,61,Ligue 1,2022,1,1,0,3,3.0
+3384.0,J. Dossou,99,Clermont Foot,61,Ligue 1,2022,1,1,0,3,3.0
+3384.0,J. Dossou,99,Clermont Foot,61,Ligue 1,2021,1,1,0,3,3.0
+3379.0,Cédric Hountondji,95,Strasbourg,61,Ligue 1,2021,1,1,0,3,3.0
+3336.0,Falaye Sacko,81,Marseille,61,Ligue 1,2023,1,1,0,3,3.0
+20627.0,Houboulang Mendes,81,Marseille,61,Ligue 1,2021,1,1,0,3,3.0
+20600.0,Romain Perraud,41,Southampton,39,Premier League,2022,1,1,0,3,3.0
+3395.0,S. Mounié,170,FC Augsburg,78,Bundesliga,2024,1,1,0,3,3.0
+3395.0,S. Mounié,106,Stade Brestois 29,61,Ligue 1,2023,1,1,0,3,3.0
+277191.0,A. Sima,97,Lorient,61,Ligue 1,2022,1,1,0,3,3.0
+334035.0,S. Amo-Ameyaw,95,Strasbourg,61,Ligue 1,2024,1,1,0,3,3.0
+333672.0,César Tárrega,532,Valencia,140,La Liga,2024,1,1,0,3,3.0
+81.0,K. Diatta,91,Monaco,61,Ligue 1,2022,1,1,0,3,3.0
+339883.0,K. Yıldız,496,Juventus,135,Serie A,2023,1,1,0,3,3.0
+339874.0,O. Højlund,169,Eintracht Frankfurt,78,Bundesliga,2024,1,1,0,3,3.0
+337426.0,A. Boakye,1063,Saint Etienne,61,Ligue 1,2024,1,1,0,3,3.0
+336657.0,W. Zaïre-Emery,85,Paris Saint Germain,61,Ligue 1,2022,1,1,0,3,3.0
+336594.0,Pablo Barrios,530,Atletico Madrid,140,La Liga,2024,1,1,0,3,3.0
+95.0,B. Badiashile,49,Chelsea,39,Premier League,2022,1,1,0,3,3.0
+85.0,C. Ngonge,492,Napoli,135,Serie A,2023,1,1,0,3,3.0
+19265.0,A. Webster,51,Brighton,39,Premier League,2021,1,1,0,3,3.0
+83.0,A. Danjuma,47,Tottenham,39,Premier League,2022,1,1,0,3,3.0
+18397.0,J. Taylor,57,Ipswich,39,Premier League,2024,1,1,0,3,3.0
+17661.0,J. Branthwaite,45,Everton,39,Premier League,2023,1,1,0,3,3.0
+17597.0,Dara O'Shea,48,West Ham,39,Premier League,2023,1,1,0,3,3.0
+15972.0,A. Albers,186,FC St. Pauli,78,Bundesliga,2024,1,1,0,3,3.0
+15911.0,M. Kudus,48,West Ham,39,Premier League,2024,1,1,0,3,3.0
+18802.0,Étienne Capoue,533,Villarreal,140,La Liga,2021,1,1,0,3,3.0
+18786.0,W. Ndidi,42,Arsenal,39,Premier League,2024,1,1,0,3,3.0
+18592.0,I. Ndiaye,45,Everton,39,Premier League,2024,1,1,0,3,3.0
+18819.0,M. Antonio,48,West Ham,39,Premier League,2023,1,1,0,3,3.0
+83.0,A. Danjuma,547,Girona,140,La Liga,2024,1,1,0,3,3.0
+8966.0,T. Teuma,93,Reims,61,Ligue 1,2024,1,1,0,3,3.0
+18872.0,Lewis Cook,35,Bournemouth,39,Premier League,2024,1,1,0,3,3.0
+18861.0,N. Aké,50,Manchester City,39,Premier League,2023,1,1,0,3,3.0
+18861.0,N. Aké,50,Manchester City,39,Premier League,2021,1,1,0,3,3.0
+18895.0,Florian Lejeune,728,Rayo Vallecano,140,La Liga,2022,1,1,0,3,3.0
+18895.0,Florian Lejeune,548,Real Sociedad,140,La Liga,2022,1,1,0,3,3.0
+18895.0,Florian Lejeune,529,Barcelona,140,La Liga,2023,1,1,0,3,3.0
+18884.0,S. Surridge,65,Nottingham Forest,39,Premier League,2022,1,1,0,3,3.0
+18881.0,J. King,96,Toulouse,61,Ligue 1,2024,1,1,0,3,3.0
+18874.0,D. Gosling,38,Watford,39,Premier League,2021,1,1,0,3,3.0
+329720.0,Hugo Álvarez,538,Celta Vigo,140,La Liga,2024,1,1,0,3,3.0
+10316.0,Caio Henrique,83,Nantes,61,Ligue 1,2022,1,1,0,3,3.0
+10238.0,Carlos Augusto,1579,Monza,135,Serie A,2022,1,1,0,3,3.0
+15592.0,J. Stage,162,Werder Bremen,78,Bundesliga,2022,1,1,0,3,3.0
+15286.0,Mousa Al-Taamari,82,Montpellier,61,Ligue 1,2023,1,1,0,3,3.0
+14405.0,Myrto Uzuni,715,Granada CF,140,La Liga,2021,1,1,0,3,3.0
+14395.0,K. Jakić,170,FC Augsburg,78,Bundesliga,2023,1,1,0,3,3.0
+14395.0,K. Jakić,169,Eintracht Frankfurt,78,Bundesliga,2022,1,1,0,3,3.0
+14344.0,A. Palaversa,110,Estac Troyes,61,Ligue 1,2022,1,1,0,3,3.0
+333118.0,L. Mincarelli,82,Montpellier,61,Ligue 1,2024,1,1,0,3,3.0
+331678.0,H. Meister,94,Rennes,61,Ligue 1,2024,1,1,0,3,3.0
+330599.0,Iker Bravo,494,Udinese,135,Serie A,2024,1,1,0,3,3.0
+10316.0,Caio Henrique,91,Monaco,61,Ligue 1,2021,1,1,0,3,3.0
+375000.0,I. Salah,106,Stade Brestois 29,61,Ligue 1,2024,1,1,0,3,3.0
+369885.0,J. Sebas,95,Strasbourg,61,Ligue 1,2023,1,1,0,3,3.0
+894.0,Ashley Young,51,Brighton,39,Premier League,2023,1,1,0,3,3.0
+892.0,C. Smalling,497,AS Roma,135,Serie A,2021,1,1,0,3,3.0
+47547.0,Álex Moreno,66,Aston Villa,39,Premier League,2023,1,1,0,3,3.0
+47554.0,Adrián Embarba,723,Almeria,140,La Liga,2023,1,1,0,3,3.0
+47554.0,Adrián Embarba,723,Almeria,140,La Liga,2022,1,1,0,3,3.0
+47551.0,Raúl de Tomás,728,Rayo Vallecano,140,La Liga,2022,1,1,0,3,3.0
+47988.0,C. Starfelt,538,Celta Vigo,140,La Liga,2024,1,1,0,3,3.0
+446249.0,I. Mbaye,85,Paris Saint Germain,61,Ligue 1,2024,1,1,0,3,3.0
+18805.0,A. Doucouré,45,Everton,39,Premier League,2024,1,1,0,3,3.0
+47574.0,Moi Gómez,727,Osasuna,140,La Liga,2022,1,1,0,3,3.0
+47574.0,Moi Gómez,538,Celta Vigo,140,La Liga,2024,1,1,0,3,3.0
+927.0,Lee Kang-In,797,Elche,140,La Liga,2021,1,1,0,3,3.0
+925.0,Gonçalo Guedes,39,Wolves,39,Premier League,2024,1,1,0,3,3.0
+924.0,F. Coquelin,533,Villarreal,140,La Liga,2022,1,1,0,3,3.0
+355167.0,M. Finkgräfe,192,1.FC Köln,78,Bundesliga,2023,1,1,0,3,3.0
+18777.0,M. Albrighton,46,Leicester,39,Premier League,2021,1,1,0,3,3.0
+47985.0,E. Holm,499,Atalanta,135,Serie A,2023,1,1,0,3,3.0
+17.0,C. Pulišić,49,Chelsea,39,Premier League,2021,1,1,0,3,3.0
+438752.0,P. Diong,95,Strasbourg,61,Ligue 1,2024,1,1,0,3,3.0
+14.0,Mahmoud Dahoud,172,VfB Stuttgart,78,Bundesliga,2023,1,1,0,3,3.0
+47969.0,G. Gudmundsson,79,Lille,61,Ligue 1,2023,1,1,0,3,3.0
+18802.0,Étienne Capoue,533,Villarreal,140,La Liga,2022,1,1,0,3,3.0
+18847.0,J. Ward,52,Crystal Palace,39,Premier League,2022,1,1,0,3,3.0
+18843.0,J. Schlupp,52,Crystal Palace,39,Premier League,2022,1,1,0,3,3.0
+18843.0,J. Schlupp,52,Crystal Palace,39,Premier League,2021,1,1,0,3,3.0
+18835.0,Vicente Guaita,541,Real Madrid,140,La Liga,2023,1,1,0,3,3.0
+18758.0,S. Coleman,35,Bournemouth,39,Premier League,2023,1,1,0,3,3.0
+18753.0,Adama Traoré,39,Wolves,39,Premier League,2022,1,1,0,3,3.0
+18753.0,Adama Traoré,39,Wolves,39,Premier League,2021,1,1,0,3,3.0
+18744.0,M. Kilman,39,Wolves,39,Premier League,2023,1,1,0,3,3.0
+18769.0,T. Walcott,41,Southampton,39,Premier League,2022,1,1,0,3,3.0
+377122.0,Endrick,541,Real Madrid,140,La Liga,2024,1,1,0,3,3.0
+18766.0,Dominic Calvert-Lewin,45,Everton,39,Premier League,2023,1,1,0,3,3.0
+18765.0,André Gomes,79,Lille,61,Ligue 1,2022,1,1,0,3,3.0
+18765.0,André Gomes,45,Everton,39,Premier League,2023,1,1,0,3,3.0
+15797.0,J. Cajuste,57,Ipswich,39,Premier League,2024,1,1,0,3,3.0
+15793.0,R. Nicolaisen,96,Toulouse,61,Ligue 1,2023,1,1,0,3,3.0
+15783.0,E. Sabbi,111,Le Havre,61,Ligue 1,2023,1,1,0,3,3.0
+31.0,J. Giménez,530,Atletico Madrid,140,La Liga,2022,1,1,0,3,3.0
+358166.0,A. Ouattara,95,Strasbourg,61,Ligue 1,2024,1,1,0,3,3.0
+357996.0,M. Cissé,499,Atalanta,135,Serie A,2021,1,1,0,3,3.0
+356041.0,C. Baleba,51,Brighton,39,Premier League,2024,1,1,0,3,3.0
+378284.0,E. Eyong,533,Villarreal,140,La Liga,2024,1,1,0,3,3.0
+18769.0,T. Walcott,34,Newcastle,39,Premier League,2022,1,1,0,3,3.0
+306727.0,J. Solís,547,Girona,140,La Liga,2024,1,1,0,3,3.0
+305834.0,Andrey Santos,95,Strasbourg,61,Ligue 1,2024,1,1,0,3,3.0
+312650.0,Marko Milovanović,723,Almeria,140,La Liga,2023,1,1,0,3,3.0
+312468.0,Á. Padilla,536,Sevilla,140,La Liga,2024,1,1,0,3,3.0
+311344.0,A. Véliz,540,Espanyol,140,La Liga,2024,1,1,0,3,3.0
+311344.0,A. Véliz,47,Tottenham,39,Premier League,2023,1,1,0,3,3.0
+311334.0,F. Buonanotte,46,Leicester,39,Premier League,2024,1,1,0,3,3.0
+311157.0,Matheus França,52,Crystal Palace,39,Premier League,2024,1,1,0,3,3.0
+123.0,P. Pellegri,503,Torino,135,Serie A,2022,1,1,0,3,3.0
+121.0,S. Jovetić,159,Hertha Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+9971.0,Antony,33,Manchester United,39,Premier League,2023,1,1,0,3,3.0
+315237.0,W. Osula,34,Newcastle,39,Premier League,2024,1,1,0,3,3.0
+137.0,Sergi Roberto,529,Barcelona,140,La Liga,2022,1,1,0,3,3.0
+137.0,Sergi Roberto,529,Barcelona,140,La Liga,2021,1,1,0,3,3.0
+133.0,Clément Lenglet,530,Atletico Madrid,140,La Liga,2024,1,1,0,3,3.0
+123.0,P. Pellegri,503,Torino,135,Serie A,2023,1,1,0,3,3.0
+10233.0,Bruno Méndez,715,Granada CF,140,La Liga,2023,1,1,0,3,3.0
+10169.0,Vinicius Souza,540,Espanyol,140,La Liga,2022,1,1,0,3,3.0
+10077.0,Luis Henrique,81,Marseille,61,Ligue 1,2023,1,1,0,3,3.0
+10009.0,Rodrygo,541,Real Madrid,140,La Liga,2023,1,1,0,3,3.0
+19004.0,B. De Cordova-Reid,46,Leicester,39,Premier League,2024,1,1,0,3,3.0
+315699.0,Javi Guerra,532,Valencia,140,La Liga,2022,1,1,0,3,3.0
+19235.0,D. Spence,47,Tottenham,39,Premier League,2024,1,1,0,3,3.0
+6629.0,A. Gaich,504,Verona,135,Serie A,2022,1,1,0,3,3.0
+19294.0,J. Robinson,1359,Luton,39,Premier League,2023,1,1,0,3,3.0
+19163.0,J. Murphy,34,Newcastle,39,Premier League,2022,1,1,0,3,3.0
+19147.0,C. Dawson,48,West Ham,39,Premier League,2021,1,1,0,3,3.0
+19191.0,J. McGinn,66,Aston Villa,39,Premier League,2021,1,1,0,3,3.0
+19187.0,J. Grealish,50,Manchester City,39,Premier League,2023,1,1,0,3,3.0
+19185.0,K. Davis,494,Udinese,135,Serie A,2023,1,1,0,3,3.0
+19179.0,T. Mings,66,Aston Villa,39,Premier League,2021,1,1,0,3,3.0
+19179.0,T. Mings,36,Fulham,39,Premier League,2022,1,1,0,3,3.0
+307835.0,Lucas Beraldo,85,Paris Saint Germain,61,Ligue 1,2024,1,1,0,3,3.0
+8500.0,W. Endō,40,Liverpool,39,Premier League,2023,1,1,0,3,3.0
+8478.0,A. Souquet,82,Montpellier,61,Ligue 1,2021,1,1,0,3,3.0
+8451.0,Aurélio Buta,169,Eintracht Frankfurt,78,Bundesliga,2023,1,1,0,3,3.0
+19191.0,J. McGinn,66,Aston Villa,39,Premier League,2024,1,1,0,3,3.0
+8598.0,T. Awoniyi,182,Union Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+8598.0,T. Awoniyi,65,Nottingham Forest,39,Premier League,2024,1,1,0,3,3.0
+8587.0,S. Amallah,720,Valladolid,140,La Liga,2024,1,1,0,3,3.0
+8500.0,W. Endō,172,VfB Stuttgart,78,Bundesliga,2021,1,1,0,3,3.0
+311067.0,S. Castro,504,Verona,135,Serie A,2024,1,1,0,3,3.0
+310187.0,Stefan Bajčetić,40,Liverpool,39,Premier League,2022,1,1,0,3,3.0
+308678.0,Dário Essugo,534,Las Palmas,140,La Liga,2024,1,1,0,3,3.0
+19177.0,K. Hause,66,Aston Villa,39,Premier League,2021,1,1,0,3,3.0
+323936.0,M. Soulé,496,Juventus,135,Serie A,2022,1,1,0,3,3.0
+326088.0,K. Fayad,82,Montpellier,61,Ligue 1,2023,1,1,0,3,3.0
+326088.0,K. Fayad,80,Lyon,61,Ligue 1,2024,1,1,0,3,3.0
+18906.0,Ayoze Pérez,543,Real Betis,140,La Liga,2023,1,1,0,3,3.0
+18903.0,M. Ritchie,34,Newcastle,39,Premier League,2023,1,1,0,3,3.0
+15745.0,M. Roerslev,55,Brentford,39,Premier League,2021,1,1,0,3,3.0
+15673.0,Y. Ramadani,867,Lecce,135,Serie A,2023,1,1,0,3,3.0
+15632.0,Mads Juel Andersen,1359,Luton,39,Premier League,2023,1,1,0,3,3.0
+18949.0,Oriol Romeu,41,Southampton,39,Premier League,2021,1,1,0,3,3.0
+18947.0,M. Lemina,84,Nice,61,Ligue 1,2021,1,1,0,3,3.0
+19004.0,B. De Cordova-Reid,36,Fulham,39,Premier League,2022,1,1,0,3,3.0
+18946.0,M. Elyounoussi,41,Southampton,39,Premier League,2021,1,1,0,3,3.0
+18931.0,C. Wood,65,Nottingham Forest,39,Premier League,2022,1,1,0,3,3.0
+18922.0,J. Cork,44,Burnley,39,Premier League,2021,1,1,0,3,3.0
+8793.0,T. Henry,504,Verona,135,Serie A,2023,1,1,0,3,3.0
+18956.0,S. Long,41,Southampton,39,Premier League,2021,1,1,0,3,3.0
+18955.0,D. Ings,66,Aston Villa,39,Premier League,2022,1,1,0,3,3.0
+18955.0,D. Ings,48,West Ham,39,Premier League,2024,1,1,0,3,3.0
+18955.0,D. Ings,48,West Ham,39,Premier League,2023,1,1,0,3,3.0
+18949.0,Oriol Romeu,547,Girona,140,La Liga,2022,1,1,0,3,3.0
+10008.0,Kaio Jorge,512,Frosinone,135,Serie A,2023,1,1,0,3,3.0
+9971.0,Antony,543,Real Betis,140,La Liga,2024,1,1,0,3,3.0
+18947.0,M. Lemina,39,Wolves,39,Premier League,2023,1,1,0,3,3.0
+18981.0,J. Locadia,176,VfL Bochum,78,Bundesliga,2021,1,1,0,3,3.0
+18968.0,Y. Bissouma,51,Brighton,39,Premier League,2021,1,1,0,3,3.0
+10238.0,Carlos Augusto,505,Inter,135,Serie A,2024,1,1,0,3,3.0
+19071.0,E. Buendía,168,Bayer Leverkusen,78,Bundesliga,2024,1,1,0,3,3.0
+19068.0,Felix Passlack,165,Borussia Dortmund,78,Bundesliga,2021,1,1,0,3,3.0
+19066.0,Grant Hanley,71,Norwich,39,Premier League,2021,1,1,0,3,3.0
+19030.0,M. O'Riley,36,Fulham,39,Premier League,2024,1,1,0,3,3.0
+19126.0,S. Dallas,63,Leeds,39,Premier League,2021,1,1,0,3,3.0
+19105.0,Oliver Norwood,62,Sheffield Utd,39,Premier League,2023,1,1,0,3,3.0
+19088.0,Dean Henderson,48,West Ham,39,Premier League,2023,1,1,0,3,3.0
+323936.0,M. Soulé,512,Frosinone,135,Serie A,2023,1,1,0,3,3.0
+147.0,Philippe Coutinho,66,Aston Villa,39,Premier League,2021,1,1,0,3,3.0
+146.0,Álex Collado,715,Granada CF,140,La Liga,2021,1,1,0,3,3.0
+143.0,Carles Aleñá,546,Getafe,140,La Liga,2021,1,1,0,3,3.0
+323449.0,A. Al Dakhil,44,Burnley,39,Premier League,2023,1,1,0,3,3.0
+322630.0,G. Fabbian,500,Bologna,135,Serie A,2024,1,1,0,3,3.0
+322595.0,L. Coulibaly,108,Auxerre,61,Ligue 1,2024,1,1,0,3,3.0
+322508.0,Y. Kabadayı,170,FC Augsburg,78,Bundesliga,2024,1,1,0,3,3.0
+321744.0,A. Obert,490,Cagliari,135,Serie A,2024,1,1,0,3,3.0
+316517.0,A. Matturro,494,Udinese,135,Serie A,2023,1,1,0,3,3.0
+326073.0,R. Labeau-Lascary,116,Lens,61,Ligue 1,2024,1,1,0,3,3.0
+324030.0,J. Niemiec,158,Fortuna Dusseldorf,78,Bundesliga,2023,1,1,0,3,3.0
+19077.0,K. McLean,71,Norwich,39,Premier League,2021,1,1,0,3,3.0
+25408.0,M. Arnold,161,VfL Wolfsburg,78,Bundesliga,2021,1,1,0,3,3.0
+25400.0,Y. Gerhardt,161,VfL Wolfsburg,78,Bundesliga,2022,1,1,0,3,3.0
+25391.0,N. Füllkrug,48,West Ham,39,Premier League,2024,1,1,0,3,3.0
+25389.0,I. Bebou,167,1899 Hoffenheim,78,Bundesliga,2022,1,1,0,3,3.0
+25387.0,Walace,494,Udinese,135,Serie A,2021,1,1,0,3,3.0
+2412.0,Felipe Anderson,487,Lazio,135,Serie A,2022,1,1,0,3,3.0
+2412.0,Felipe Anderson,487,Lazio,135,Serie A,2021,1,1,0,3,3.0
+2385.0,K. Świderski,504,Verona,135,Serie A,2023,1,1,0,3,3.0
+25410.0,J. Guilavogui,167,1899 Hoffenheim,78,Bundesliga,2022,1,1,0,3,3.0
+2459.0,D. Machís,724,Cadiz,140,La Liga,2023,1,1,0,3,3.0
+21104.0,R. Kolo Muani,496,Juventus,135,Serie A,2024,1,1,0,3,3.0
+2449.0,Y. Herrera,540,Espanyol,140,La Liga,2021,1,1,0,3,3.0
+2424.0,M. Trauco,1063,Saint Etienne,61,Ligue 1,2021,1,1,0,3,3.0
+2418.0,L. Abram,542,Alaves,140,La Liga,2021,1,1,0,3,3.0
+174565.0,H. Ekitiké,169,Eintracht Frankfurt,78,Bundesliga,2024,1,1,0,3,3.0
+163189.0,M. Thiaw,495,Genoa,135,Serie A,2023,1,1,0,3,3.0
+381.0,Danilo Pereira,85,Paris Saint Germain,61,Ligue 1,2022,1,1,0,3,3.0
+174703.0,T. Le Bris,97,Lorient,61,Ligue 1,2022,1,1,0,3,3.0
+174660.0,L. Rao-Lisoa,77,Angers,61,Ligue 1,2022,1,1,0,3,3.0
+174607.0,David Pereira da Costa,116,Lens,61,Ligue 1,2023,1,1,0,3,3.0
+174607.0,David Pereira da Costa,116,Lens,61,Ligue 1,2022,1,1,0,3,3.0
+2449.0,Y. Herrera,547,Girona,140,La Liga,2023,1,1,0,3,3.0
+2285.0,A. Rüdiger,541,Real Madrid,140,La Liga,2023,1,1,0,3,3.0
+2285.0,A. Rüdiger,541,Real Madrid,140,La Liga,2022,1,1,0,3,3.0
+2285.0,A. Rüdiger,49,Chelsea,39,Premier League,2021,1,1,0,3,3.0
+25639.0,L. Stindl,163,Borussia Mönchengladbach,78,Bundesliga,2021,1,1,0,3,3.0
+25638.0,F. Neuhaus,163,Borussia Mönchengladbach,78,Bundesliga,2023,1,1,0,3,3.0
+163004.0,E. Lepaul,77,Angers,61,Ligue 1,2024,1,1,0,3,3.0
+162952.0,Mario Gila Fuentes,496,Juventus,135,Serie A,2024,1,1,0,3,3.0
+162907.0,A. Zanoli,498,Sampdoria,135,Serie A,2022,1,1,0,3,3.0
+162907.0,A. Zanoli,495,Genoa,135,Serie A,2024,1,1,0,3,3.0
+163039.0,C. Matsima,157,Bayern München,78,Bundesliga,2024,1,1,0,3,3.0
+25410.0,J. Guilavogui,161,VfL Wolfsburg,78,Bundesliga,2022,1,1,0,3,3.0
+332.0,D. Mertens,492,Napoli,135,Serie A,2021,1,1,0,3,3.0
+328.0,Fabián Ruiz,85,Paris Saint Germain,61,Ligue 1,2022,1,1,0,3,3.0
+327.0,A. Ounas,79,Lille,61,Ligue 1,2023,1,1,0,3,3.0
+325.0,G. Gaetano,492,Napoli,135,Serie A,2023,1,1,0,3,3.0
+371.0,Felipe,530,Atletico Madrid,140,La Liga,2021,1,1,0,3,3.0
+334.0,S. Verdi,514,Salernitana,135,Serie A,2021,1,1,0,3,3.0
+334.0,S. Verdi,503,Torino,135,Serie A,2021,1,1,0,3,3.0
+25385.0,N. Sarenren Bazee,170,FC Augsburg,78,Bundesliga,2021,1,1,0,3,3.0
+25380.0,L. Maina,192,1.FC Köln,78,Bundesliga,2022,1,1,0,3,3.0
+25375.0,T. Asano,176,VfL Bochum,78,Bundesliga,2023,1,1,0,3,3.0
+25368.0,Waldemar Anton,165,Borussia Dortmund,78,Bundesliga,2024,1,1,0,3,3.0
+163032.0,F. Rieder,94,Rennes,61,Ligue 1,2023,1,1,0,3,3.0
+181259.0,Abel Bretones,727,Osasuna,140,La Liga,2024,1,1,0,3,3.0
+180731.0,Lorenz Assignon,94,Rennes,61,Ligue 1,2024,1,1,0,3,3.0
+180586.0,I. Monterisi,512,Frosinone,135,Serie A,2023,1,1,0,3,3.0
+180496.0,Georges Mikautadze,112,Metz,61,Ligue 1,2023,1,1,0,3,3.0
+289.0,A. Robertson,48,West Ham,39,Premier League,2024,1,1,0,3,3.0
+288.0,Alberto Moreno,533,Villarreal,140,La Liga,2021,1,1,0,3,3.0
+181421.0,A. Ezzalzouli,543,Real Betis,140,La Liga,2024,1,1,0,3,3.0
+300.0,G. Wijnaldum,497,AS Roma,135,Serie A,2022,1,1,0,3,3.0
+300.0,G. Wijnaldum,85,Paris Saint Germain,61,Ligue 1,2021,1,1,0,3,3.0
+294.0,N. Keïta,40,Liverpool,39,Premier League,2021,1,1,0,3,3.0
+177665.0,A. Stach,167,1899 Hoffenheim,78,Bundesliga,2023,1,1,0,3,3.0
+25066.0,M. Leitsch,164,FSV Mainz 05,78,Bundesliga,2024,1,1,0,3,3.0
+25026.0,R. Massimo,172,VfB Stuttgart,78,Bundesliga,2021,1,1,0,3,3.0
+25151.0,Maximilian Wittek,176,VfL Bochum,78,Bundesliga,2023,1,1,0,3,3.0
+25147.0,P. Jaeckel,182,Union Berlin,78,Bundesliga,2022,1,1,0,3,3.0
+25144.0,M. Bauer,159,Hertha Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+25084.0,S. Zoller,176,VfL Bochum,78,Bundesliga,2021,1,1,0,3,3.0
+25081.0,M. Pantović,182,Union Berlin,78,Bundesliga,2023,1,1,0,3,3.0
+25081.0,M. Pantović,182,Union Berlin,78,Bundesliga,2022,1,1,0,3,3.0
+2484.0,Y. Mina,45,Everton,39,Premier League,2022,1,1,0,3,3.0
+2476.0,G. Rodríguez,529,Barcelona,140,La Liga,2022,1,1,0,3,3.0
+2493.0,L. Muriel,499,Atalanta,135,Serie A,2022,1,1,0,3,3.0
+25074.0,A. Losilla,176,VfL Bochum,78,Bundesliga,2021,1,1,0,3,3.0
+174927.0,Arouna Sangante,111,Le Havre,61,Ligue 1,2024,1,1,0,3,3.0
+178293.0,T. Oberdorf,158,Fortuna Dusseldorf,78,Bundesliga,2023,1,1,0,3,3.0
+178146.0,C. Boukhalfa,186,FC St. Pauli,78,Bundesliga,2024,1,1,0,3,3.0
+178106.0,M. Pieringer,180,1. FC Heidenheim,78,Bundesliga,2024,1,1,0,3,3.0
+178093.0,Y. Keitel,160,SC Freiburg,78,Bundesliga,2023,1,1,0,3,3.0
+178077.0,K. Schade,160,SC Freiburg,78,Bundesliga,2022,1,1,0,3,3.0
+25242.0,M. Bülter,167,1899 Hoffenheim,78,Bundesliga,2024,1,1,0,3,3.0
+25192.0,K. Behrens,161,VfL Wolfsburg,78,Bundesliga,2024,1,1,0,3,3.0
+2598.0,R. Doan,160,SC Freiburg,78,Bundesliga,2023,1,1,0,3,3.0
+2597.0,T. Tomiyasu,42,Arsenal,39,Premier League,2023,1,1,0,3,3.0
+181421.0,A. Ezzalzouli,543,Real Betis,140,La Liga,2023,1,1,0,3,3.0
+25299.0,F. Jensen,170,FC Augsburg,78,Bundesliga,2022,1,1,0,3,3.0
+25287.0,K. Danso,116,Lens,61,Ligue 1,2023,1,1,0,3,3.0
+25329.0,M. Kruse,182,Union Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+25326.0,J. Eggestein,186,FC St. Pauli,78,Bundesliga,2024,1,1,0,3,3.0
+25314.0,Marco Friedl,192,1.FC Köln,78,Bundesliga,2022,1,1,0,3,3.0
+25362.0,D. Selke,159,Hertha Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+25349.0,O. Duda,192,1.FC Köln,78,Bundesliga,2021,1,1,0,3,3.0
+179843.0,Lucas Gourna-Douath,1063,Saint Etienne,61,Ligue 1,2021,1,1,0,3,3.0
+179401.0,S. Delaye,82,Montpellier,61,Ligue 1,2022,1,1,0,3,3.0
+178769.0,Philipp Treu,160,SC Freiburg,78,Bundesliga,2024,1,1,0,3,3.0
+178709.0,Y. Engelhardt,158,Fortuna Dusseldorf,78,Bundesliga,2023,1,1,0,3,3.0
+25300.0,Rani Khedira,182,Union Berlin,78,Bundesliga,2022,1,1,0,3,3.0
+161622.0,M. Abline,83,Nantes,61,Ligue 1,2024,1,1,0,3,3.0
+161933.0,Nico González,529,Barcelona,140,La Liga,2021,1,1,0,3,3.0
+161933.0,Nico González,50,Manchester City,39,Premier League,2024,1,1,0,3,3.0
+161919.0,Y. Moukoko,165,Borussia Dortmund,78,Bundesliga,2021,1,1,0,3,3.0
+161907.0,Malo Gusto,81,Marseille,61,Ligue 1,2022,1,1,0,3,3.0
+162032.0,Miguel Gutiérrez,547,Girona,140,La Liga,2022,1,1,0,3,3.0
+162028.0,Juanmi Latasa,720,Valladolid,140,La Liga,2024,1,1,0,3,3.0
+161948.0,L. Delap,57,Ipswich,39,Premier League,2024,1,1,0,3,3.0
+26240.0,Philipp Lienhart,160,SC Freiburg,78,Bundesliga,2021,1,1,0,3,3.0
+26239.0,L. Kübler,160,SC Freiburg,78,Bundesliga,2024,1,1,0,3,3.0
+25458.0,D. Lukébakio,161,VfL Wolfsburg,78,Bundesliga,2021,1,1,0,3,3.0
+26227.0,M. Broschinski,176,VfL Bochum,78,Bundesliga,2022,1,1,0,3,3.0
+25927.0,J. Mateta,52,Crystal Palace,39,Premier League,2022,1,1,0,3,3.0
+25926.0,J. Burkardt,164,FSV Mainz 05,78,Bundesliga,2023,1,1,0,3,3.0
+26248.0,V. Grifo,160,SC Freiburg,78,Bundesliga,2021,1,1,0,3,3.0
+26243.0,Nico Schlotterbeck,160,SC Freiburg,78,Bundesliga,2021,1,1,0,3,3.0
+26242.0,Keven Schlotterbeck,180,1. FC Heidenheim,78,Bundesliga,2023,1,1,0,3,3.0
+26242.0,Keven Schlotterbeck,176,VfL Bochum,78,Bundesliga,2022,1,1,0,3,3.0
+26242.0,Keven Schlotterbeck,170,FC Augsburg,78,Bundesliga,2024,1,1,0,3,3.0
+26240.0,Philipp Lienhart,160,SC Freiburg,78,Bundesliga,2022,1,1,0,3,3.0
+26287.0,P. Hofmann,176,VfL Bochum,78,Bundesliga,2022,1,1,0,3,3.0
+26238.0,Robin Koch,169,Eintracht Frankfurt,78,Bundesliga,2023,1,1,0,3,3.0
+153430.0,A. Elanga,33,Manchester United,39,Premier League,2021,1,1,0,3,3.0
+153425.0,L. Dobbin,45,Everton,39,Premier League,2023,1,1,0,3,3.0
+2216.0,M. Niang,108,Auxerre,61,Ligue 1,2022,1,1,0,3,3.0
+2216.0,M. Niang,78,Bordeaux,61,Ligue 1,2021,1,1,0,3,3.0
+2214.0,Romain Del Castillo,106,Stade Brestois 29,61,Ligue 1,2022,1,1,0,3,3.0
+2208.0,Clément Grenier,798,Mallorca,140,La Liga,2021,1,1,0,3,3.0
+2204.0,Benjamin André,79,Lille,61,Ligue 1,2023,1,1,0,3,3.0
+26302.0,Pablo Maffeo,798,Mallorca,140,La Liga,2023,1,1,0,3,3.0
+26301.0,Marc-Oliver Kempf,172,VfB Stuttgart,78,Bundesliga,2021,1,1,0,3,3.0
+2278.0,Marcos Alonso,538,Celta Vigo,140,La Liga,2024,1,1,0,3,3.0
+161622.0,M. Abline,94,Rennes,61,Ligue 1,2022,1,1,0,3,3.0
+26475.0,D. Undav,51,Brighton,39,Premier League,2022,1,1,0,3,3.0
+26343.0,S. Tigges,192,1.FC Köln,78,Bundesliga,2022,1,1,0,3,3.0
+26319.0,F. Agu,168,Bayer Leverkusen,78,Bundesliga,2024,1,1,0,3,3.0
+26306.0,G. Castro,188,Arminia Bielefeld,78,Bundesliga,2021,1,1,0,3,3.0
+30396.0,C. Biraghi,500,Bologna,135,Serie A,2024,1,1,0,3,3.0
+30396.0,C. Biraghi,487,Lazio,135,Serie A,2021,1,1,0,3,3.0
+26828.0,G. Kyriakopoulos,505,Inter,135,Serie A,2024,1,1,0,3,3.0
+161621.0,L. Tchaouna,487,Lazio,135,Serie A,2024,1,1,0,3,3.0
+158697.0,J. McAtee,50,Manchester City,39,Premier League,2024,1,1,0,3,3.0
+158694.0,T. Livramento,34,Newcastle,39,Premier League,2023,1,1,0,3,3.0
+161800.0,C. Tzolis,158,Fortuna Dusseldorf,78,Bundesliga,2023,1,1,0,3,3.0
+2219.0,J. Siebatcheu,182,Union Berlin,78,Bundesliga,2022,1,1,0,3,3.0
+25917.0,Ridle Baku,161,VfL Wolfsburg,78,Bundesliga,2024,1,1,0,3,3.0
+162067.0,T. Pembélé,111,Le Havre,61,Ligue 1,2024,1,1,0,3,3.0
+162175.0,Jesús Vázquez,532,Valencia,140,La Liga,2023,1,1,0,3,3.0
+162173.0,S. Iling-Junior,500,Bologna,135,Serie A,2024,1,1,0,3,3.0
+162170.0,Hugo Novoa,173,RB Leipzig,78,Bundesliga,2022,1,1,0,3,3.0
+162170.0,Hugo Novoa,173,RB Leipzig,78,Bundesliga,2021,1,1,0,3,3.0
+162141.0,Koni De Winter,495,Genoa,135,Serie A,2024,1,1,0,3,3.0
+162266.0,L. da Cunha,99,Clermont Foot,61,Ligue 1,2021,1,1,0,3,3.0
+162771.0,J. Ngankam,159,Hertha Berlin,78,Bundesliga,2022,1,1,0,3,3.0
+162720.0,M. Geschwill,186,FC St. Pauli,78,Bundesliga,2024,1,1,0,3,3.0
+26257.0,F. Niederlechner,170,FC Augsburg,78,Bundesliga,2021,1,1,0,3,3.0
+162712.0,Óscar Mingueza,538,Celta Vigo,140,La Liga,2023,1,1,0,3,3.0
+162707.0,E. Wahi,82,Montpellier,61,Ligue 1,2021,1,1,0,3,3.0
+162587.0,Adria Miquel Bosch Sanchis,548,Real Sociedad,140,La Liga,2023,1,1,0,3,3.0
+2473.0,M. Lanzini,48,West Ham,39,Premier League,2022,1,1,0,3,3.0
+2472.0,R. De Paul,530,Atletico Madrid,140,La Liga,2023,1,1,0,3,3.0
+2469.0,Germán Pezzella,543,Real Betis,140,La Liga,2023,1,1,0,3,3.0
+2467.0,Lisandro Martínez,47,Tottenham,39,Premier League,2023,1,1,0,3,3.0
+25448.0,K. Ayhan,488,Sassuolo,135,Serie A,2021,1,1,0,3,3.0
+25416.0,Wout Weghorst,161,VfL Wolfsburg,78,Bundesliga,2021,1,1,0,3,3.0
+25413.0,E. Rexhbeçaj,170,FC Augsburg,78,Bundesliga,2023,1,1,0,3,3.0
+25466.0,K. Karaman,174,FC Schalke 04,78,Bundesliga,2022,1,1,0,3,3.0
+162714.0,A. Onana,45,Everton,39,Premier League,2023,1,1,0,3,3.0
+26255.0,L. Höler,160,SC Freiburg,78,Bundesliga,2023,1,1,0,3,3.0
+26255.0,L. Höler,160,SC Freiburg,78,Bundesliga,2021,1,1,0,3,3.0
+26249.0,J. Haberer,182,Union Berlin,78,Bundesliga,2023,1,1,0,3,3.0
+9.0,A. Hakimi,85,Paris Saint Germain,61,Ligue 1,2023,1,1,0,3,3.0
+2194.0,R. Bensebaini,163,Borussia Mönchengladbach,78,Bundesliga,2022,1,1,0,3,3.0
+2194.0,R. Bensebaini,163,Borussia Mönchengladbach,78,Bundesliga,2021,1,1,0,3,3.0
+2294.0,Willian,36,Fulham,39,Premier League,2022,1,1,0,3,3.0
+2292.0,Ruben Loftus-Cheek,489,AC Milan,135,Serie A,2023,1,1,0,3,3.0
+2289.0,Jorginho,49,Chelsea,39,Premier League,2022,1,1,0,3,3.0
+2287.0,R. Barkley,49,Chelsea,39,Premier League,2021,1,1,0,3,3.0
+25918.0,Leandro Barreiro,164,FSV Mainz 05,78,Bundesliga,2023,1,1,0,3,3.0
+25644.0,P. Herrmann,163,Borussia Mönchengladbach,78,Bundesliga,2022,1,1,0,3,3.0
+2298.0,C. Hudson-Odoi,65,Nottingham Forest,39,Premier League,2024,1,1,0,3,3.0
+2298.0,C. Hudson-Odoi,65,Nottingham Forest,39,Premier League,2023,1,1,0,3,3.0
+2295.0,O. Giroud,489,AC Milan,135,Serie A,2022,1,1,0,3,3.0
+25917.0,Ridle Baku,161,VfL Wolfsburg,78,Bundesliga,2021,1,1,0,3,3.0
+25916.0,M. Niakhaté,164,FSV Mainz 05,78,Bundesliga,2021,1,1,0,3,3.0
+25907.0,S. Bell,164,FSV Mainz 05,78,Bundesliga,2021,1,1,0,3,3.0
+25903.0,Finn Gilbert Dahmen,169,Eintracht Frankfurt,78,Bundesliga,2023,1,1,0,3,3.0
+25646.0,A. Pléa,163,Borussia Mönchengladbach,78,Bundesliga,2023,1,1,0,3,3.0
+25926.0,J. Burkardt,164,FSV Mainz 05,78,Bundesliga,2021,1,1,0,3,3.0
+25919.0,G. Holtmann,176,VfL Bochum,78,Bundesliga,2024,1,1,0,3,3.0
+2286.0,D. Zappacosta,499,Atalanta,135,Serie A,2024,1,1,0,3,3.0
+195717.0,Yerson Mosquera,533,Villarreal,140,La Liga,2023,1,1,0,3,3.0
+195106.0,Rodrigo Muniz,36,Fulham,39,Premier League,2023,1,1,0,3,3.0
+199310.0,A. Ben Slimane,1359,Luton,39,Premier League,2023,1,1,0,3,3.0
+199143.0,Y. Suzuki,95,Strasbourg,61,Ligue 1,2022,1,1,0,3,3.0
+199089.0,Lorenzo Lucca,494,Udinese,135,Serie A,2024,1,1,0,3,3.0
+202017.0,W. Faghir,172,VfB Stuttgart,78,Bundesliga,2021,1,1,0,3,3.0
+201351.0,A. Kelati,191,Holstein Kiel,78,Bundesliga,2024,1,1,0,3,3.0
+21636.0,F. Guilbert,95,Strasbourg,61,Ligue 1,2023,1,1,0,3,3.0
+21635.0,J. Gradit,116,Lens,61,Ligue 1,2023,1,1,0,3,3.0
+21635.0,J. Gradit,116,Lens,61,Ligue 1,2022,1,1,0,3,3.0
+2490.0,J. Lerma,50,Manchester City,39,Premier League,2022,1,1,0,3,3.0
+21618.0,J. Allevinah,99,Clermont Foot,61,Ligue 1,2022,1,1,0,3,3.0
+2933.0,B. Chilwell,49,Chelsea,39,Premier League,2021,1,1,0,3,3.0
+2927.0,Michy Batshuayi,169,Eintracht Frankfurt,78,Bundesliga,2024,1,1,0,3,3.0
+22002.0,G. Konan,93,Reims,61,Ligue 1,2021,1,1,0,3,3.0
+21998.0,A. Disasi,49,Chelsea,39,Premier League,2023,1,1,0,3,3.0
+21997.0,Logan Costa,80,Lyon,61,Ligue 1,2022,1,1,0,3,3.0
+21715.0,W. Saïd,116,Lens,61,Ligue 1,2024,1,1,0,3,3.0
+21715.0,W. Saïd,116,Lens,61,Ligue 1,2022,1,1,0,3,3.0
+21715.0,W. Saïd,116,Lens,61,Ligue 1,2021,1,1,0,3,3.0
+22016.0,R. Oudin,867,Lecce,135,Serie A,2023,1,1,0,3,3.0
+21618.0,J. Allevinah,99,Clermont Foot,61,Ligue 1,2023,1,1,0,3,3.0
+2803.0,N. Elvedi,163,Borussia Mönchengladbach,78,Bundesliga,2022,1,1,0,3,3.0
+22093.0,R. Cabella,79,Lille,61,Ligue 1,2023,1,1,0,3,3.0
+2858.0,A. Ekdal,498,Sampdoria,135,Serie A,2021,1,1,0,3,3.0
+2824.0,Nemanja Maksimović,546,Getafe,140,La Liga,2023,1,1,0,3,3.0
+2823.0,S. Lukić,503,Torino,135,Serie A,2022,1,1,0,3,3.0
+22151.0,C. Jean,116,Lens,61,Ligue 1,2021,1,1,0,3,3.0
+22147.0,M. Koné,497,AS Roma,135,Serie A,2024,1,1,0,3,3.0
+22138.0,Christopher Jullien,82,Montpellier,61,Ligue 1,2023,1,1,0,3,3.0
+22102.0,Wahbi Khazri,82,Montpellier,61,Ligue 1,2022,1,1,0,3,3.0
+22225.0,Reinildo,530,Atletico Madrid,140,La Liga,2023,1,1,0,3,3.0
+195993.0,C. Alcaraz,45,Everton,39,Premier League,2024,1,1,0,3,3.0
+22179.0,M. Maolida,159,Hertha Berlin,78,Bundesliga,2021,1,1,0,3,3.0
+22173.0,A. Saint-Maximin,34,Newcastle,39,Premier League,2021,1,1,0,3,3.0
+22170.0,P. Lees-Melou,106,Stade Brestois 29,61,Ligue 1,2023,1,1,0,3,3.0
+195103.0,João Gomes,39,Wolves,39,Premier League,2022,1,1,0,3,3.0
+194750.0,E. Touré,723,Almeria,140,La Liga,2022,1,1,0,3,3.0
+194750.0,E. Touré,499,Atalanta,135,Serie A,2023,1,1,0,3,3.0
+194750.0,E. Touré,172,VfB Stuttgart,78,Bundesliga,2024,1,1,0,3,3.0
+193870.0,J. Antiste,488,Sassuolo,135,Serie A,2022,1,1,0,3,3.0
+193720.0,S. Alvero,162,Werder Bremen,78,Bundesliga,2023,1,1,0,3,3.0
+193720.0,S. Alvero,80,Lyon,61,Ligue 1,2023,1,1,0,3,3.0
+197196.0,Ramón Martínez,536,Sevilla,140,La Liga,2024,1,1,0,3,3.0
+22224.0,Gabriel Magalhães,42,Arsenal,39,Premier League,2022,1,1,0,3,3.0
+2897.0,Kim Min-Jae,492,Napoli,135,Serie A,2022,1,1,0,3,3.0
+2925.0,D. Praet,46,Leicester,39,Premier League,2022,1,1,0,3,3.0
+2924.0,A. Januzaj,548,Real Sociedad,140,La Liga,2021,1,1,0,3,3.0
+2923.0,Yannick Carrasco,530,Atletico Madrid,140,La Liga,2022,1,1,0,3,3.0
+203007.0,R. Reitz,163,Borussia Mönchengladbach,78,Bundesliga,2023,1,1,0,3,3.0
+236955.0,A. Sarr,80,Lyon,61,Ligue 1,2022,1,1,0,3,3.0
+204043.0,A. Theate,500,Bologna,135,Serie A,2021,1,1,0,3,3.0
+204039.0,D. Udogie,494,Udinese,135,Serie A,2022,1,1,0,3,3.0
+204039.0,D. Udogie,494,Udinese,135,Serie A,2021,1,1,0,3,3.0
+243.0,Z. Aboukhlal,96,Toulouse,61,Ligue 1,2023,1,1,0,3,3.0
+22016.0,R. Oudin,867,Lecce,135,Serie A,2022,1,1,0,3,3.0
+237.0,G. Pereiro,490,Cagliari,135,Serie A,2021,1,1,0,3,3.0
+227.0,Angeliño,497,AS Roma,135,Serie A,2024,1,1,0,3,3.0
+227.0,Angeliño,173,RB Leipzig,78,Bundesliga,2021,1,1,0,3,3.0
+261.0,T. Kehrer,85,Paris Saint Germain,61,Ligue 1,2021,1,1,0,3,3.0
+259.0,Thiago Silva,49,Chelsea,39,Premier League,2023,1,1,0,3,3.0
+249.0,D. Malen,165,Borussia Dortmund,78,Bundesliga,2022,1,1,0,3,3.0
+3080.0,M. Munetsi,93,Reims,61,Ligue 1,2022,1,1,0,3,3.0
+3080.0,M. Munetsi,93,Reims,61,Ligue 1,2021,1,1,0,3,3.0
+3034.0,M. Elia,83,Nantes,61,Ligue 1,2024,1,1,0,3,3.0
+3014.0,S. Żurkowski,511,Empoli,135,Serie A,2021,1,1,0,3,3.0
+21138.0,R. Aït-Nouri,39,Wolves,39,Premier League,2022,1,1,0,3,3.0
+240.0,Pablo Rosario,84,Nice,61,Ligue 1,2024,1,1,0,3,3.0
+22009.0,N. Mbemba,111,Le Havre,61,Ligue 1,2023,1,1,0,3,3.0
+22005.0,X. Chavalerin,110,Estac Troyes,61,Ligue 1,2021,1,1,0,3,3.0
+2803.0,N. Elvedi,163,Borussia Mönchengladbach,78,Bundesliga,2021,1,1,0,3,3.0
+2799.0,A. Guðmundsson,502,Fiorentina,135,Serie A,2024,1,1,0,3,3.0
+2799.0,A. Guðmundsson,495,Genoa,135,Serie A,2021,1,1,0,3,3.0
+22087.0,M. Nadé,1063,Saint Etienne,61,Ligue 1,2021,1,1,0,3,3.0
+22086.0,T. Kolodziejczak,1063,Saint Etienne,61,Ligue 1,2021,1,1,0,3,3.0
+21582.0,F. Mollet,174,FC Schalke 04,78,Bundesliga,2022,1,1,0,3,3.0
+21582.0,F. Mollet,83,Nantes,61,Ligue 1,2023,1,1,0,3,3.0
+21582.0,F. Mollet,82,Montpellier,61,Ligue 1,2021,1,1,0,3,3.0
+2906.0,Lee Jae-Sung,164,FSV Mainz 05,78,Bundesliga,2022,1,1,0,3,3.0
+2887.0,R. Jiménez,36,Fulham,39,Premier League,2024,1,1,0,3,3.0
+2869.0,E. Álvarez,48,West Ham,39,Premier League,2023,1,1,0,3,3.0
+2864.0,A. Isak,548,Real Sociedad,140,La Liga,2021,1,1,0,3,3.0
+21592.0,G. Laborde,94,Rennes,61,Ligue 1,2022,1,1,0,3,3.0
+21591.0,A. Delort,82,Montpellier,61,Ligue 1,2021,1,1,0,3,3.0
+21587.0,Ellyes Skhiri,192,1.FC Köln,78,Bundesliga,2022,1,1,0,3,3.0
+21585.0,J. Sambia,514,Salernitana,135,Serie A,2023,1,1,0,3,3.0
+2917.0,M. Eggestein,160,SC Freiburg,78,Bundesliga,2024,1,1,0,3,3.0
+2916.0,N. Stark,162,Werder Bremen,78,Bundesliga,2023,1,1,0,3,3.0
+2915.0,M. Ginter,180,1. FC Heidenheim,78,Bundesliga,2023,1,1,0,3,3.0
+2915.0,M. Ginter,160,SC Freiburg,78,Bundesliga,2022,1,1,0,3,3.0
+21575.0,C. Vidal,98,Ajaccio,61,Ligue 1,2022,1,1,0,3,3.0
+24904.0,N. Dorsch,180,1. FC Heidenheim,78,Bundesliga,2024,1,1,0,3,3.0
+24904.0,N. Dorsch,170,FC Augsburg,78,Bundesliga,2021,1,1,0,3,3.0
+181908.0,J. Thielmann,192,1.FC Köln,78,Bundesliga,2023,1,1,0,3,3.0
+181812.0,J. Musiala,157,Bayern München,78,Bundesliga,2023,1,1,0,3,3.0
+181734.0,Pep Chavarría,728,Rayo Vallecano,140,La Liga,2023,1,1,0,3,3.0
+305.0,D. Origi,489,AC Milan,135,Serie A,2022,1,1,0,3,3.0
+182560.0,Oier Zarraga,531,Athletic Club,140,La Liga,2021,1,1,0,3,3.0
+182560.0,Oier Zarraga,494,Udinese,135,Serie A,2023,1,1,0,3,3.0
+182434.0,D. Beljo,170,FC Augsburg,78,Bundesliga,2023,1,1,0,3,3.0
+182201.0,T. Mitchell,52,Crystal Palace,39,Premier League,2023,1,1,0,3,3.0
+2806.0,Fabian Schär,34,Newcastle,39,Premier League,2024,1,1,0,3,3.0
+275.0,E. Choupo-Moting,157,Bayern München,78,Bundesliga,2022,1,1,0,3,3.0
+270.0,S. Nsoki,167,1899 Hoffenheim,78,Bundesliga,2022,1,1,0,3,3.0
+23120.0,Q. Boisgard,97,Lorient,61,Ligue 1,2022,1,1,0,3,3.0
+22842.0,J. Krasso,1063,Saint Etienne,61,Ligue 1,2021,1,1,0,3,3.0
+22265.0,Nuno da Costa,108,Auxerre,61,Ligue 1,2022,1,1,0,3,3.0
+22264.0,Ludovic Ajorque,164,FSV Mainz 05,78,Bundesliga,2023,1,1,0,3,3.0
+2773.0,W. Troost-Ekong,514,Salernitana,135,Serie A,2022,1,1,0,3,3.0
+24743.0,Z. Davitashvili,1063,Saint Etienne,61,Ligue 1,2024,1,1,0,3,3.0
+24228.0,B. Lasme,188,Arminia Bielefeld,78,Bundesliga,2021,1,1,0,3,3.0
+24207.0,S. Diarra,97,Lorient,61,Ligue 1,2022,1,1,0,3,3.0
+24147.0,M. Camara,1063,Saint Etienne,61,Ligue 1,2021,1,1,0,3,3.0
+182621.0,Iker Muñoz,727,Osasuna,140,La Liga,2023,1,1,0,3,3.0
+2490.0,J. Lerma,35,Bournemouth,39,Premier League,2022,1,1,0,3,3.0
+2489.0,L. Díaz,40,Liverpool,39,Premier League,2024,1,1,0,3,3.0
+2489.0,L. Díaz,40,Liverpool,39,Premier League,2022,1,1,0,3,3.0
+2717.0,A. Tuhami,720,Valladolid,140,La Liga,2022,1,1,0,3,3.0
+2716.0,R. Saïss,39,Wolves,39,Premier League,2021,1,1,0,3,3.0
+2711.0,M. Bourabia,515,Spezia,135,Serie A,2021,1,1,0,3,3.0
+2704.0,Y. Abdelhamid,93,Reims,61,Ligue 1,2023,1,1,0,3,3.0
+2704.0,Y. Abdelhamid,93,Reims,61,Ligue 1,2021,1,1,0,3,3.0
+2699.0,S. Ghoddos,55,Brentford,39,Premier League,2023,1,1,0,3,3.0
+2699.0,S. Ghoddos,55,Brentford,39,Premier League,2021,1,1,0,3,3.0
+24910.0,T. Skarke,181,SV Darmstadt 98,78,Bundesliga,2023,1,1,0,3,3.0
+24826.0,S. Michel,170,FC Augsburg,78,Bundesliga,2023,1,1,0,3,3.0
+24811.0,Anthony Modeste,165,Borussia Dortmund,78,Bundesliga,2022,1,1,0,3,3.0
+24899.0,Patrick Mainka,180,1. FC Heidenheim,78,Bundesliga,2024,1,1,0,3,3.0
+24888.0,Hwang Hee-Chan,39,Wolves,39,Premier League,2024,1,1,0,3,3.0
+24888.0,Hwang Hee-Chan,39,Wolves,39,Premier League,2021,1,1,0,3,3.0
+24887.0,F. Arp,191,Holstein Kiel,78,Bundesliga,2024,1,1,0,3,3.0
+24868.0,J. Vagnoman,172,VfB Stuttgart,78,Bundesliga,2024,1,1,0,3,3.0
+24868.0,J. Vagnoman,172,VfB Stuttgart,78,Bundesliga,2023,1,1,0,3,3.0
+24993.0,S. Adamyan,192,1.FC Köln,78,Bundesliga,2022,1,1,0,3,3.0
+24993.0,S. Adamyan,167,1899 Hoffenheim,78,Bundesliga,2021,1,1,0,3,3.0
+24974.0,A. Seydel,181,SV Darmstadt 98,78,Bundesliga,2023,1,1,0,3,3.0
+24861.0,S. Polter,176,VfL Bochum,78,Bundesliga,2021,1,1,0,3,3.0
+2771.0,O. Aina,65,Nottingham Forest,39,Premier League,2024,1,1,0,3,3.0
+2763.0,M. Pašalić,499,Atalanta,135,Serie A,2022,1,1,0,3,3.0
+2735.0,Pierre-Emile Højbjerg,81,Marseille,61,Ligue 1,2024,1,1,0,3,3.0
+2734.0,P. Billing,492,Napoli,135,Serie A,2024,1,1,0,3,3.0
+183849.0,Aitor Paredes,531,Athletic Club,140,La Liga,2024,1,1,0,3,3.0
+183849.0,Aitor Paredes,531,Athletic Club,140,La Liga,2023,1,1,0,3,3.0
+286.0,J. Matip,47,Tottenham,39,Premier League,2023,1,1,0,3,3.0
+185202.0,Juan Cruz,543,Real Betis,140,La Liga,2022,1,1,0,3,3.0
+184481.0,Diego García,537,Leganes,140,La Liga,2024,1,1,0,3,3.0
+184420.0,Carlos Romero,540,Espanyol,140,La Liga,2024,1,1,0,3,3.0
+2669.0,Hermoso,530,Atletico Madrid,140,La Liga,2022,1,1,0,3,3.0
+190686.0,S. Mara,78,Bordeaux,61,Ligue 1,2021,1,1,0,3,3.0
+190489.0,Álvaro Djaló,531,Athletic Club,140,La Liga,2024,1,1,0,3,3.0
+190485.0,Samuel Costa,798,Mallorca,140,La Liga,2023,1,1,0,3,3.0
+193617.0,T. Louchet,84,Nice,61,Ligue 1,2024,1,1,0,3,3.0
+193270.0,A. Carboni,1579,Monza,135,Serie A,2023,1,1,0,3,3.0
+192434.0,Miguel Rodríguez,538,Celta Vigo,140,La Liga,2022,1,1,0,3,3.0
+191979.0,J. Ondrejka,523,Parma,135,Serie A,2024,1,1,0,3,3.0
+190831.0,S. Doucouré,97,Lorient,61,Ligue 1,2023,1,1,0,3,3.0
+2821.0,M. Veljković,162,Werder Bremen,78,Bundesliga,2023,1,1,0,3,3.0
+2817.0,N. Milenković,489,AC Milan,135,Serie A,2022,1,1,0,3,3.0
+2817.0,N. Milenković,65,Nottingham Forest,39,Premier League,2024,1,1,0,3,3.0
+184277.0,Fer Niño,798,Mallorca,140,La Liga,2021,1,1,0,3,3.0
+2668.0,Mostafa Mohamed,83,Nantes,61,Ligue 1,2023,1,1,0,3,3.0
+24798.0,C. Führich,172,VfB Stuttgart,78,Bundesliga,2021,1,1,0,3,3.0
+24794.0,Benno Schmitz,165,Borussia Dortmund,78,Bundesliga,2022,1,1,0,3,3.0
+24789.0,Rafael Czichos,160,SC Freiburg,78,Bundesliga,2021,1,1,0,3,3.0
+2678.0,Diogo Jota,40,Liverpool,39,Premier League,2022,1,1,0,3,3.0
+2676.0,Rúben Neves,39,Wolves,39,Premier League,2022,1,1,0,3,3.0
+2672.0,Iker Muniain,531,Athletic Club,140,La Liga,2023,1,1,0,3,3.0
+2671.0,Jaime Mata,546,Getafe,140,La Liga,2023,1,1,0,3,3.0
+2671.0,Jaime Mata,546,Getafe,140,La Liga,2021,1,1,0,3,3.0
+22244.0,A. Caci,164,FSV Mainz 05,78,Bundesliga,2022,1,1,0,3,3.0
+22264.0,Ludovic Ajorque,164,FSV Mainz 05,78,Bundesliga,2022,1,1,0,3,3.0
+22229.0,J. Ikoné,502,Fiorentina,135,Serie A,2022,1,1,0,3,3.0
+22229.0,J. Ikoné,79,Lille,61,Ligue 1,2021,1,1,0,3,3.0
+22228.0,Xeka,79,Lille,61,Ligue 1,2021,1,1,0,3,3.0
+22261.0,A. Thomasson,116,Lens,61,Ligue 1,2022,1,1,0,3,3.0
+22254.0,Y. Fofana,91,Monaco,61,Ligue 1,2023,1,1,0,3,3.0
+22244.0,A. Caci,164,FSV Mainz 05,78,Bundesliga,2024,1,1,0,3,3.0
+2731.0,M. Jørgensen,65,Nottingham Forest,39,Premier League,2022,1,1,0,3,3.0
+2729.0,Joachim Andersen,51,Brighton,39,Premier League,2021,1,1,0,3,3.0
+2726.0,K. Zouma,48,West Ham,39,Premier League,2023,1,1,0,3,3.0
+2724.0,L. Digne,45,Everton,39,Premier League,2022,1,1,0,3,3.0
+2717.0,A. Tuhami,720,Valladolid,140,La Liga,2024,1,1,0,3,3.0
+22229.0,J. Ikoné,502,Fiorentina,135,Serie A,2023,1,1,0,3,3.0
+8.0,Raphaël Guerreiro,165,Borussia Dortmund,78,Bundesliga,2021,1,0,1,2,2.0
+26.0,M. Wolf,165,Borussia Dortmund,78,Bundesliga,2023,1,0,1,2,2.0
+31.0,J. Giménez,530,Atletico Madrid,140,La Liga,2024,1,0,1,2,2.0
+382452.0,Patrick Dorgu,867,Lecce,135,Serie A,2024,1,0,1,2,2.0
+382945.0,K. Zeroli,1579,Monza,135,Serie A,2024,1,0,1,2,2.0
+383002.0,I. Konate,511,Empoli,135,Serie A,2024,1,0,1,2,2.0
+383665.0,T. Gomis,173,RB Leipzig,78,Bundesliga,2024,1,0,1,2,2.0
+384135.0,Javi Rodríguez,538,Celta Vigo,140,La Liga,2024,1,0,1,2,2.0
+389322.0,N. Sangui,93,Reims,61,Ligue 1,2024,1,0,1,2,2.0
+403498.0,Sergio Rodelas,715,Granada CF,140,La Liga,2023,1,0,1,2,2.0
+403554.0,Christantus Uche,546,Getafe,140,La Liga,2024,1,0,1,2,2.0
+403889.0,P. Diallo,112,Metz,61,Ligue 1,2024,1,0,1,2,2.0
+405073.0,Jon Martín,548,Real Sociedad,140,La Liga,2024,1,0,1,2,2.0
+409216.0,S. Mayulu,85,Paris Saint Germain,61,Ligue 1,2024,1,0,1,2,2.0
+18742.0,M. Doherty,47,Tottenham,39,Premier League,2021,1,0,1,2,2.0
+50.0,Koke,530,Atletico Madrid,140,La Liga,2021,1,0,1,2,2.0
+68.0,Clinton Mata,80,Lyon,61,Ligue 1,2023,1,0,1,2,2.0
+74.0,S. Amrabat,502,Fiorentina,135,Serie A,2022,1,0,1,2,2.0
+351923.0,Ó. Cortés,116,Lens,61,Ligue 1,2023,1,0,1,2,2.0
+18806.0,W. Hughes,52,Crystal Palace,39,Premier League,2023,1,0,1,2,2.0
+18830.0,M. Arnautović,505,Inter,135,Serie A,2024,1,0,1,2,2.0
+18846.0,A. Wan-Bissaka,33,Manchester United,39,Premier League,2023,1,0,1,2,2.0
+18751.0,Ivan Cavaleiro,79,Lille,61,Ligue 1,2023,1,0,1,2,2.0
+18753.0,Adama Traoré,529,Barcelona,140,La Liga,2021,1,0,1,2,2.0
+18760.0,Jonjoe Kenny,45,Everton,39,Premier League,2021,1,0,1,2,2.0
+18764.0,M. Schneiderlin,84,Nice,61,Ligue 1,2021,1,0,1,2,2.0
+18765.0,André Gomes,45,Everton,39,Premier League,2021,1,0,1,2,2.0
+16367.0,W. Pacho,169,Eintracht Frankfurt,78,Bundesliga,2023,1,0,1,2,2.0
+17597.0,Dara O'Shea,57,Ipswich,39,Premier League,2024,1,0,1,2,2.0
+18791.0,B. Foster,38,Watford,39,Premier League,2021,1,0,1,2,2.0
+18794.0,Kiko Femenía,38,Watford,39,Premier League,2021,1,0,1,2,2.0
+18799.0,A. Masina,38,Watford,39,Premier League,2021,1,0,1,2,2.0
+18802.0,Étienne Capoue,533,Villarreal,140,La Liga,2023,1,0,1,2,2.0
+18805.0,A. Doucouré,45,Everton,39,Premier League,2022,1,0,1,2,2.0
+18806.0,W. Hughes,52,Crystal Palace,39,Premier League,2022,1,0,1,2,2.0
+334914.0,S. Kumbedi,80,Lyon,61,Ligue 1,2022,1,0,1,2,2.0
+335056.0,Diego Moreira,95,Strasbourg,61,Ligue 1,2024,1,0,1,2,2.0
+335816.0,C. Ikwuemesi,514,Salernitana,135,Serie A,2023,1,0,1,2,2.0
+336594.0,Pablo Barrios,530,Atletico Madrid,140,La Liga,2023,1,0,1,2,2.0
+336711.0,Gonzalo García,541,Real Madrid,140,La Liga,2024,1,0,1,2,2.0
+85.0,C. Ngonge,504,Verona,135,Serie A,2022,1,0,1,2,2.0
+99.0,R. Pierre-Gabriel,106,Stade Brestois 29,61,Ligue 1,2021,1,0,1,2,2.0
+15908.0,M. Damsgaard,55,Brentford,39,Premier League,2024,1,0,1,2,2.0
+14327.0,D. Bradarić,514,Salernitana,135,Serie A,2022,1,0,1,2,2.0
+328105.0,L. Miley,34,Newcastle,39,Premier League,2023,1,0,1,2,2.0
+328225.0,B. Gruda,164,FSV Mainz 05,78,Bundesliga,2023,1,0,1,2,2.0
+330717.0,N. Kandil,95,Strasbourg,61,Ligue 1,2021,1,0,1,2,2.0
+333116.0,R. Belahyane,504,Verona,135,Serie A,2024,1,0,1,2,2.0
+333137.0,K. Ouattara,91,Monaco,61,Ligue 1,2024,1,0,1,2,2.0
+334574.0,Ángel Ortiz,543,Real Betis,140,La Liga,2024,1,0,1,2,2.0
+334879.0,B. Bouanani,84,Nice,61,Ligue 1,2022,1,0,1,2,2.0
+47471.0,Roger Martí,724,Cadiz,140,La Liga,2023,1,0,1,2,2.0
+47480.0,Mohammed Salisu,41,Southampton,39,Premier League,2022,1,0,1,2,2.0
+909.0,M. Rashford,66,Aston Villa,39,Premier League,2024,1,0,1,2,2.0
+915.0,Gabriel Paulista,532,Valencia,140,La Liga,2021,1,0,1,2,2.0
+916.0,M. Diakhaby,532,Valencia,140,La Liga,2021,1,0,1,2,2.0
+1095.0,X. Schlager,173,RB Leipzig,78,Bundesliga,2022,1,0,1,2,2.0
+47354.0,Martín Aguirregabiria,542,Alaves,140,La Liga,2021,1,0,1,2,2.0
+47380.0,Marc Cucurella,51,Brighton,39,Premier League,2021,1,0,1,2,2.0
+962.0,J. Nsame,517,Venezia,135,Serie A,2021,1,0,1,2,2.0
+972.0,J. Tah,168,Bayer Leverkusen,78,Bundesliga,2023,1,0,1,2,2.0
+47432.0,Hugo Mallo,538,Celta Vigo,140,La Liga,2021,1,0,1,2,2.0
+47432.0,Hugo Mallo,538,Celta Vigo,140,La Liga,2022,1,0,1,2,2.0
+47438.0,M. Jensen,55,Brentford,39,Premier League,2024,1,0,1,2,2.0
+47440.0,Brais Méndez,548,Real Sociedad,140,La Liga,2022,1,0,1,2,2.0
+47464.0,José Campaña,534,Las Palmas,140,La Liga,2024,1,0,1,2,2.0
+47464.0,José Campaña,539,Levante,140,La Liga,2021,1,0,1,2,2.0
+48481.0,L. Stergiou,172,VfB Stuttgart,78,Bundesliga,2024,1,0,1,2,2.0
+48577.0,N. Bajrami,488,Sassuolo,135,Serie A,2023,1,0,1,2,2.0
+48648.0,D. Ndoye,84,Nice,61,Ligue 1,2021,1,0,1,2,2.0
+48649.0,A. Zeqiri,170,FC Augsburg,78,Bundesliga,2021,1,0,1,2,2.0
+842.0,N. Vlašić,503,Torino,135,Serie A,2023,1,0,1,2,2.0
+860.0,Alex Sandro,496,Juventus,135,Serie A,2021,1,0,1,2,2.0
+862.0,L. Spinazzola,492,Napoli,135,Serie A,2024,1,0,1,2,2.0
+862.0,L. Spinazzola,497,AS Roma,135,Serie A,2022,1,0,1,2,2.0
+887.0,M. Darmian,505,Inter,135,Serie A,2021,1,0,1,2,2.0
+889.0,V. Lindelöf,33,Manchester United,39,Premier League,2021,1,0,1,2,2.0
+889.0,V. Lindelöf,33,Manchester United,39,Premier League,2023,1,0,1,2,2.0
+48119.0,Odilon Kossounou,168,Bayer Leverkusen,78,Bundesliga,2021,1,0,1,2,2.0
+48378.0,S. Widmer,164,FSV Mainz 05,78,Bundesliga,2022,1,0,1,2,2.0
+48378.0,S. Widmer,164,FSV Mainz 05,78,Bundesliga,2023,1,0,1,2,2.0
+48378.0,S. Widmer,164,FSV Mainz 05,78,Bundesliga,2024,1,0,1,2,2.0
+48471.0,R. Vargas,170,FC Augsburg,78,Bundesliga,2021,1,0,1,2,2.0
+47311.0,Mikel Merino,548,Real Sociedad,140,La Liga,2022,1,0,1,2,2.0
+47314.0,Igor Zubeldia,548,Real Sociedad,140,La Liga,2021,1,0,1,2,2.0
+47315.0,Martín Zubimendi,548,Real Sociedad,140,La Liga,2021,1,0,1,2,2.0
+47317.0,Barrenetxea,548,Real Sociedad,140,La Liga,2021,1,0,1,2,2.0
+47320.0,Juanmi,724,Cadiz,140,La Liga,2023,1,0,1,2,2.0
+47321.0,Roberto López,537,Leganes,140,La Liga,2024,1,0,1,2,2.0
+47334.0,David López,547,Girona,140,La Liga,2024,1,0,1,2,2.0
+47341.0,Marc Roca,543,Real Betis,140,La Liga,2023,1,0,1,2,2.0
+769.0,A. Florenzi,489,AC Milan,135,Serie A,2023,1,0,1,2,2.0
+1143.0,M. Halstenberg,173,RB Leipzig,78,Bundesliga,2022,1,0,1,2,2.0
+1146.0,N. Mukiele,85,Paris Saint Germain,61,Ligue 1,2022,1,0,1,2,2.0
+1146.0,N. Mukiele,173,RB Leipzig,78,Bundesliga,2021,1,0,1,2,2.0
+1149.0,Dayot Upamecano,157,Bayern München,78,Bundesliga,2022,1,0,1,2,2.0
+1150.0,T. Adams,35,Bournemouth,39,Premier League,2024,1,0,1,2,2.0
+47309.0,Ander Guevara,542,Alaves,140,La Liga,2024,1,0,1,2,2.0
+47311.0,Mikel Merino,548,Real Sociedad,140,La Liga,2021,1,0,1,2,2.0
+866.0,J. Cuadrado,499,Atalanta,135,Serie A,2024,1,0,1,2,2.0
+866.0,J. Cuadrado,505,Inter,135,Serie A,2023,1,0,1,2,2.0
+867.0,G. Kastanos,514,Salernitana,135,Serie A,2022,1,0,1,2,2.0
+876.0,N. Fagioli,496,Juventus,135,Serie A,2023,1,0,1,2,2.0
+50856.0,V. Castellanos,487,Lazio,135,Serie A,2023,1,0,1,2,2.0
+51494.0,M. Ugarte,85,Paris Saint Germain,61,Ligue 1,2023,1,0,1,2,2.0
+51572.0,M. Viña,488,Sassuolo,135,Serie A,2023,1,0,1,2,2.0
+53525.0,M. Normann,71,Norwich,39,Premier League,2021,1,0,1,2,2.0
+47384.0,Cote,727,Osasuna,140,La Liga,2021,1,0,1,2,2.0
+47388.0,Gonzalo Escalante,520,Cremonese,135,Serie A,2022,1,0,1,2,2.0
+47419.0,José Arnáiz,727,Osasuna,140,La Liga,2023,1,0,1,2,2.0
+927.0,Lee Kang-In,798,Mallorca,140,La Liga,2021,1,0,1,2,2.0
+930.0,Carlos Soler,85,Paris Saint Germain,61,Ligue 1,2023,1,0,1,2,2.0
+931.0,Ferran Torres,529,Barcelona,140,La Liga,2021,1,0,1,2,2.0
+946.0,K. Mbabu,36,Fulham,39,Premier League,2022,1,0,1,2,2.0
+866.0,J. Cuadrado,496,Juventus,135,Serie A,2022,1,0,1,2,2.0
+1117.0,K. Tierney,548,Real Sociedad,140,La Liga,2023,1,0,1,2,2.0
+1125.0,R. Christie,35,Bournemouth,39,Premier League,2023,1,0,1,2,2.0
+1161.0,E. Smith Rowe,42,Arsenal,39,Premier League,2022,1,0,1,2,2.0
+1166.0,T. Werner,47,Tottenham,39,Premier League,2024,1,0,1,2,2.0
+1231.0,V. Coufal,48,West Ham,39,Premier League,2021,1,0,1,2,2.0
+47100.0,Iza Carcelén,724,Cadiz,140,La Liga,2021,1,0,1,2,2.0
+47119.0,Aitor Ruibal,543,Real Betis,140,La Liga,2024,1,0,1,2,2.0
+47170.0,José Carlos Lazo,540,Espanyol,140,La Liga,2022,1,0,1,2,2.0
+47298.0,Aritz Elustondo,548,Real Sociedad,140,La Liga,2023,1,0,1,2,2.0
+47299.0,Andoni Gorosabel,531,Athletic Club,140,La Liga,2024,1,0,1,2,2.0
+47300.0,T. Hernández,489,AC Milan,135,Serie A,2024,1,0,1,2,2.0
+47303.0,Aihen Muñoz,548,Real Sociedad,140,La Liga,2023,1,0,1,2,2.0
+47306.0,Álex Sola,542,Alaves,140,La Liga,2023,1,0,1,2,2.0
+47307.0,Joseba Zaldúa,724,Cadiz,140,La Liga,2022,1,0,1,2,2.0
+1098.0,P. Daka,46,Leicester,39,Premier League,2022,1,0,1,2,2.0
+1109.0,C. Gamboa,176,VfL Bochum,78,Bundesliga,2023,1,0,1,2,2.0
+746.0,Marco Asensio,85,Paris Saint Germain,61,Ligue 1,2023,1,0,1,2,2.0
+747.0,Casemiro,33,Manchester United,39,Premier League,2023,1,0,1,2,2.0
+747.0,Casemiro,541,Real Madrid,140,La Liga,2021,1,0,1,2,2.0
+748.0,Dani Ceballos,541,Real Madrid,140,La Liga,2022,1,0,1,2,2.0
+47275.0,De Marcos,531,Athletic Club,140,La Liga,2022,1,0,1,2,2.0
+47275.0,De Marcos,531,Athletic Club,140,La Liga,2023,1,0,1,2,2.0
+47275.0,De Marcos,531,Athletic Club,140,La Liga,2024,1,0,1,2,2.0
+47282.0,Raúl García,531,Athletic Club,140,La Liga,2021,1,0,1,2,2.0
+976.0,K. Bellarabi,168,Bayer Leverkusen,78,Bundesliga,2021,1,0,1,2,2.0
+983.0,Leon Bailey,66,Aston Villa,39,Premier League,2021,1,0,1,2,2.0
+56473.0,Matteo Gabbia,489,AC Milan,135,Serie A,2023,1,0,1,2,2.0
+56560.0,Y. Maleh,867,Lecce,135,Serie A,2022,1,0,1,2,2.0
+61159.0,Rafael Ratão,96,Toulouse,61,Ligue 1,2022,1,0,1,2,2.0
+63577.0,M. Mudryk,49,Chelsea,39,Premier League,2022,1,0,1,2,2.0
+64309.0,Manu Sánchez,538,Celta Vigo,140,La Liga,2023,1,0,1,2,2.0
+744.0,Brahim Díaz,541,Real Madrid,140,La Liga,2023,1,0,1,2,2.0
+47013.0,Rafa Mir,532,Valencia,140,La Liga,2024,1,0,1,2,2.0
+47041.0,Alberto Perea,724,Cadiz,140,La Liga,2021,1,0,1,2,2.0
+47085.0,Luis Milla,546,Getafe,140,La Liga,2024,1,0,1,2,2.0
+1150.0,T. Adams,173,RB Leipzig,78,Bundesliga,2021,1,0,1,2,2.0
+1152.0,E. Forsberg,173,RB Leipzig,78,Bundesliga,2023,1,0,1,2,2.0
+1155.0,K. Kampl,173,RB Leipzig,78,Bundesliga,2022,1,0,1,2,2.0
+1157.0,K. Laimer,157,Bayern München,78,Bundesliga,2023,1,0,1,2,2.0
+1157.0,K. Laimer,157,Bayern München,78,Bundesliga,2024,1,0,1,2,2.0
+46795.0,Domingos Duarte,546,Getafe,140,La Liga,2022,1,0,1,2,2.0
+46813.0,Abdelkabir Abqar,542,Alaves,140,La Liga,2024,1,0,1,2,2.0
+46824.0,Iván Alejo,724,Cadiz,140,La Liga,2022,1,0,1,2,2.0
+46967.0,Juan Cruz,727,Osasuna,140,La Liga,2023,1,0,1,2,2.0
+46973.0,Josan Ferrández,797,Elche,140,La Liga,2022,1,0,1,2,2.0
+46979.0,Iván Sánchez,720,Valladolid,140,La Liga,2022,1,0,1,2,2.0
+46982.0,Gonzalo Villar,546,Getafe,140,La Liga,2021,1,0,1,2,2.0
+46982.0,Gonzalo Villar,715,Granada CF,140,La Liga,2023,1,0,1,2,2.0
+748.0,Dani Ceballos,541,Real Madrid,140,La Liga,2023,1,0,1,2,2.0
+67953.0,L. Perrin,95,Strasbourg,61,Ligue 1,2023,1,0,1,2,2.0
+68483.0,B. Yıldırım,94,Rennes,61,Ligue 1,2023,1,0,1,2,2.0
+69971.0,T. Moffi,84,Nice,61,Ligue 1,2022,1,0,1,2,2.0
+70078.0,F. Pellistri,33,Manchester United,39,Premier League,2023,1,0,1,2,2.0
+70315.0,Kirian Rodríguez,534,Las Palmas,140,La Liga,2024,1,0,1,2,2.0
+70500.0,Sergi Cardona,534,Las Palmas,140,La Liga,2023,1,0,1,2,2.0
+721.0,N. Schulz,165,Borussia Dortmund,78,Bundesliga,2021,1,0,1,2,2.0
+47195.0,Álvaro Aguado,540,Espanyol,140,La Liga,2024,1,0,1,2,2.0
+47237.0,Luis Javier Suárez,723,Almeria,140,La Liga,2022,1,0,1,2,2.0
+47251.0,D. Foulquier,532,Valencia,140,La Liga,2022,1,0,1,2,2.0
+47254.0,M. Olivera,492,Napoli,135,Serie A,2023,1,0,1,2,2.0
+47254.0,M. Olivera,546,Getafe,140,La Liga,2021,1,0,1,2,2.0
+47257.0,Damián Suárez,546,Getafe,140,La Liga,2021,1,0,1,2,2.0
+47257.0,Damián Suárez,546,Getafe,140,La Liga,2023,1,0,1,2,2.0
+47258.0,M. Arambarri,546,Getafe,140,La Liga,2021,1,0,1,2,2.0
+45826.0,Strahinja Pavlović,489,AC Milan,135,Serie A,2024,1,0,1,2,2.0
+46090.0,Njegoš Petrović,715,Granada CF,140,La Liga,2021,1,0,1,2,2.0
+46657.0,Nacho Vidal,727,Osasuna,140,La Liga,2021,1,0,1,2,2.0
+46667.0,Kike Barja,727,Osasuna,140,La Liga,2024,1,0,1,2,2.0
+46679.0,Quini,715,Granada CF,140,La Liga,2021,1,0,1,2,2.0
+1231.0,V. Coufal,48,West Ham,39,Premier League,2023,1,0,1,2,2.0
+1243.0,Tomáš Souček,48,West Ham,39,Premier League,2021,1,0,1,2,2.0
+1264.0,Y. Sabaly,543,Real Betis,140,La Liga,2023,1,0,1,2,2.0
+84086.0,Robert Navarro,724,Cadiz,140,La Liga,2023,1,0,1,2,2.0
+87267.0,K. Van Den Kerkhof,112,Metz,61,Ligue 1,2023,1,0,1,2,2.0
+1442.0,S. Kolašinac,499,Atalanta,135,Serie A,2024,1,0,1,2,2.0
+41577.0,Nuno Tavares,487,Lazio,135,Serie A,2024,1,0,1,2,2.0
+41725.0,Fábio Vieira,42,Arsenal,39,Premier League,2022,1,0,1,2,2.0
+42006.0,Al Musrati,91,Monaco,61,Ligue 1,2024,1,0,1,2,2.0
+43036.0,D. Man,523,Parma,135,Serie A,2024,1,0,1,2,2.0
+43056.0,V. Mihăilă,523,Parma,135,Serie A,2024,1,0,1,2,2.0
+736.0,Fran García,541,Real Madrid,140,La Liga,2023,1,0,1,2,2.0
+736.0,Fran García,541,Real Madrid,140,La Liga,2024,1,0,1,2,2.0
+739.0,Sergio Reguilón,47,Tottenham,39,Premier League,2021,1,0,1,2,2.0
+741.0,Jesús Vallejo,541,Real Madrid,140,La Liga,2024,1,0,1,2,2.0
+742.0,R. Varane,33,Manchester United,39,Premier League,2021,1,0,1,2,2.0
+743.0,Marcelo,541,Real Madrid,140,La Liga,2021,1,0,1,2,2.0
+70747.0,J. Enciso,57,Ipswich,39,Premier League,2024,1,0,1,2,2.0
+75414.0,N. Fernández Mercau,797,Elche,140,La Liga,2022,1,0,1,2,2.0
+1302.0,J. Wind,161,VfL Wolfsburg,78,Bundesliga,2021,1,0,1,2,2.0
+1321.0,L. Majer,161,VfL Wolfsburg,78,Bundesliga,2024,1,0,1,2,2.0
+46689.0,Antonio Puertas,715,Granada CF,140,La Liga,2023,1,0,1,2,2.0
+46742.0,Dani Rodríguez,798,Mallorca,140,La Liga,2021,1,0,1,2,2.0
+46742.0,Dani Rodríguez,798,Mallorca,140,La Liga,2024,1,0,1,2,2.0
+733.0,Dani Carvajal,541,Real Madrid,140,La Liga,2022,1,0,1,2,2.0
+735.0,Nacho Fernández,541,Real Madrid,140,La Liga,2022,1,0,1,2,2.0
+735.0,Nacho Fernández,541,Real Madrid,140,La Liga,2023,1,0,1,2,2.0
+37242.0,D. Burgzorg,164,FSV Mainz 05,78,Bundesliga,2022,1,0,1,2,2.0
+37439.0,R. Ache,169,Eintracht Frankfurt,78,Bundesliga,2021,1,0,1,2,2.0
+37724.0,C. Summerville,48,West Ham,39,Premier League,2024,1,0,1,2,2.0
+37938.0,S. Becker,548,Real Sociedad,140,La Liga,2024,1,0,1,2,2.0
+38114.0,Ko Itakura,163,Borussia Mönchengladbach,78,Bundesliga,2022,1,0,1,2,2.0
+38798.0,S. Lynen,162,Werder Bremen,78,Bundesliga,2023,1,0,1,2,2.0
+39271.0,O. Solbakken,497,AS Roma,135,Serie A,2022,1,0,1,2,2.0
+39279.0,A. Hanche-Olsen,164,FSV Mainz 05,78,Bundesliga,2022,1,0,1,2,2.0
+41371.0,Fali Candé,517,Venezia,135,Serie A,2024,1,0,1,2,2.0
+1323.0,Dani Olmo,173,RB Leipzig,78,Bundesliga,2023,1,0,1,2,2.0
+1364.0,Jailson,538,Celta Vigo,140,La Liga,2023,1,0,1,2,2.0
+1408.0,S. Bornauw,161,VfL Wolfsburg,78,Bundesliga,2024,1,0,1,2,2.0
+1417.0,Alexis Saelemaekers,497,AS Roma,135,Serie A,2024,1,0,1,2,2.0
+1427.0,A. Sambi Lokonga,536,Sevilla,140,La Liga,2024,1,0,1,2,2.0
+1439.0,Héctor Bellerín,543,Real Betis,140,La Liga,2024,1,0,1,2,2.0
+1442.0,S. Kolašinac,81,Marseille,61,Ligue 1,2021,1,0,1,2,2.0
+92993.0,M. Wieffer,51,Brighton,39,Premier League,2024,1,0,1,2,2.0
+93671.0,Pedro Chirivella,83,Nantes,61,Ligue 1,2022,1,0,1,2,2.0
+93671.0,Pedro Chirivella,83,Nantes,61,Ligue 1,2023,1,0,1,2,2.0
+101814.0,Ronald Araújo,529,Barcelona,140,La Liga,2022,1,0,1,2,2.0
+679.0,Ismaily,79,Lille,61,Ligue 1,2023,1,0,1,2,2.0
+41144.0,Dodô,502,Fiorentina,135,Serie A,2022,1,0,1,2,2.0
+41150.0,Edmond Tapsoba,168,Bayer Leverkusen,78,Bundesliga,2023,1,0,1,2,2.0
+41323.0,Mama Baldé,110,Estac Troyes,61,Ligue 1,2021,1,0,1,2,2.0
+1266.0,T. Bašić,487,Lazio,135,Serie A,2021,1,0,1,2,2.0
+88033.0,C. Groß,162,Werder Bremen,78,Bundesliga,2023,1,0,1,2,2.0
+90594.0,J. Dina Ebimbe,169,Eintracht Frankfurt,78,Bundesliga,2023,1,0,1,2,2.0
+90594.0,J. Dina Ebimbe,169,Eintracht Frankfurt,78,Bundesliga,2024,1,0,1,2,2.0
+90617.0,Lassine Sinayoko,108,Auxerre,61,Ligue 1,2022,1,0,1,2,2.0
+90977.0,T. Becker,191,Holstein Kiel,78,Bundesliga,2024,1,0,1,2,2.0
+91358.0,E. Valeri,523,Parma,135,Serie A,2024,1,0,1,2,2.0
+91422.0,R. Bellanova,503,Torino,135,Serie A,2023,1,0,1,2,2.0
+36989.0,Mitchell Van Bergen,93,Reims,61,Ligue 1,2022,1,0,1,2,2.0
+37236.0,A. Matusiwa,93,Reims,61,Ligue 1,2021,1,0,1,2,2.0
+1579.0,Joaquín,543,Real Betis,140,La Liga,2021,1,0,1,2,2.0
+1579.0,Joaquín,543,Real Betis,140,La Liga,2022,1,0,1,2,2.0
+31532.0,P. Ciurria,1579,Monza,135,Serie A,2022,1,0,1,2,2.0
+31543.0,Antonino Gallo,867,Lecce,135,Serie A,2022,1,0,1,2,2.0
+31543.0,Antonino Gallo,867,Lecce,135,Serie A,2024,1,0,1,2,2.0
+31555.0,N. Haas,511,Empoli,135,Serie A,2022,1,0,1,2,2.0
+1457.0,Henrikh Mkhitaryan,505,Inter,135,Serie A,2024,1,0,1,2,2.0
+1463.0,J. Willock,34,Newcastle,39,Premier League,2022,1,0,1,2,2.0
+1463.0,J. Willock,34,Newcastle,39,Premier League,2024,1,0,1,2,2.0
+1464.0,G. Xhaka,42,Arsenal,39,Premier League,2021,1,0,1,2,2.0
+36888.0,T. Ouwejan,174,FC Schalke 04,78,Bundesliga,2022,1,0,1,2,2.0
+36910.0,C. Stengs,84,Nice,61,Ligue 1,2021,1,0,1,2,2.0
+36929.0,G. Hamer,62,Sheffield Utd,39,Premier League,2023,1,0,1,2,2.0
+36980.0,M. Thorsby,182,Union Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+715.0,C. Baumgartner,167,1899 Hoffenheim,78,Bundesliga,2022,1,0,1,2,2.0
+716.0,L. Bittencourt,162,Werder Bremen,78,Bundesliga,2024,1,0,1,2,2.0
+105873.0,S. Nicholson,99,Clermont Foot,61,Ligue 1,2023,1,0,1,2,2.0
+106725.0,K. Lewis-Potter,55,Brentford,39,Premier League,2022,1,0,1,2,2.0
+113581.0,T. Coulibaly,172,VfB Stuttgart,78,Bundesliga,2021,1,0,1,2,2.0
+118956.0,L. Banda,867,Lecce,135,Serie A,2023,1,0,1,2,2.0
+119742.0,Juan Iglesias,546,Getafe,140,La Liga,2023,1,0,1,2,2.0
+120310.0,T. Ostrák,192,1.FC Köln,78,Bundesliga,2021,1,0,1,2,2.0
+39315.0,M. Knudsen,191,Holstein Kiel,78,Bundesliga,2024,1,0,1,2,2.0
+40392.0,M. Wieteska,99,Clermont Foot,61,Ligue 1,2022,1,0,1,2,2.0
+40533.0,Ł. Poręba,116,Lens,61,Ligue 1,2022,1,0,1,2,2.0
+40560.0,J. Kamiński,161,VfL Wolfsburg,78,Bundesliga,2022,1,0,1,2,2.0
+40560.0,J. Kamiński,161,VfL Wolfsburg,78,Bundesliga,2023,1,0,1,2,2.0
+40911.0,J. Moder,51,Brighton,39,Premier League,2021,1,0,1,2,2.0
+40984.0,T. Puchacz,191,Holstein Kiel,78,Bundesliga,2024,1,0,1,2,2.0
+714.0,N. Amiri,495,Genoa,135,Serie A,2021,1,0,1,2,2.0
+31436.0,F. Bonazzoli,504,Verona,135,Serie A,2023,1,0,1,2,2.0
+31493.0,F. Melegoni,495,Genoa,135,Serie A,2024,1,0,1,2,2.0
+31507.0,R. Sottil,502,Fiorentina,135,Serie A,2021,1,0,1,2,2.0
+1468.0,E. Nketiah,42,Arsenal,39,Premier League,2021,1,0,1,2,2.0
+1469.0,D. Welbeck,51,Brighton,39,Premier League,2024,1,0,1,2,2.0
+1557.0,Pau López,81,Marseille,61,Ligue 1,2021,1,0,1,2,2.0
+658.0,H. Aouar,80,Lyon,61,Ligue 1,2022,1,0,1,2,2.0
+664.0,Lucas Tousart,159,Hertha Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+656.0,Oumar Solet,494,Udinese,135,Serie A,2024,1,0,1,2,2.0
+1646.0,Lucas Paquetá,48,West Ham,39,Premier League,2022,1,0,1,2,2.0
+1650.0,Suso,536,Sevilla,140,La Liga,2022,1,0,1,2,2.0
+31099.0,N. Casale,504,Verona,135,Serie A,2021,1,0,1,2,2.0
+31146.0,S. Tonali,34,Newcastle,39,Premier League,2024,1,0,1,2,2.0
+31173.0,D. Frattesi,505,Inter,135,Serie A,2024,1,0,1,2,2.0
+31226.0,A. Buongiorno,503,Torino,135,Serie A,2021,1,0,1,2,2.0
+31390.0,Pasquale Mazzocchi,492,Napoli,135,Serie A,2023,1,0,1,2,2.0
+127631.0,V. Gendrey,867,Lecce,135,Serie A,2023,1,0,1,2,2.0
+127634.0,João Ferreira,494,Udinese,135,Serie A,2023,1,0,1,2,2.0
+127769.0,Gabriel Martinelli,42,Arsenal,39,Premier League,2024,1,0,1,2,2.0
+128287.0,Joris Chotard,82,Montpellier,61,Ligue 1,2022,1,0,1,2,2.0
+637.0,F. Nmecha,165,Borussia Dortmund,78,Bundesliga,2023,1,0,1,2,2.0
+641.0,O. Zinchenko,42,Arsenal,39,Premier League,2024,1,0,1,2,2.0
+643.0,Gabriel Jesus,42,Arsenal,39,Premier League,2022,1,0,1,2,2.0
+645.0,R. Sterling,42,Arsenal,39,Premier League,2024,1,0,1,2,2.0
+31615.0,G. Castrovilli,502,Fiorentina,135,Serie A,2022,1,0,1,2,2.0
+31799.0,A. Vacca,517,Venezia,135,Serie A,2021,1,0,1,2,2.0
+32893.0,Hiroki Ito,172,VfB Stuttgart,78,Bundesliga,2021,1,0,1,2,2.0
+1454.0,M. Guendouzi,81,Marseille,61,Ligue 1,2021,1,0,1,2,2.0
+1454.0,M. Guendouzi,487,Lazio,135,Serie A,2023,1,0,1,2,2.0
+122756.0,Sergio Ruiz Alonso,715,Granada CF,140,La Liga,2023,1,0,1,2,2.0
+125704.0,A. Lebeau,106,Stade Brestois 29,61,Ligue 1,2023,1,0,1,2,2.0
+126642.0,P. Wimmer,161,VfL Wolfsburg,78,Bundesliga,2024,1,0,1,2,2.0
+30784.0,N. Rovella,1579,Monza,135,Serie A,2022,1,0,1,2,2.0
+30791.0,G. Pandev,495,Genoa,135,Serie A,2021,1,0,1,2,2.0
+30810.0,R. Mandragora,503,Torino,135,Serie A,2021,1,0,1,2,2.0
+30816.0,S. Okaka,494,Udinese,135,Serie A,2021,1,0,1,2,2.0
+30866.0,M. Lazzari,487,Lazio,135,Serie A,2024,1,0,1,2,2.0
+30921.0,Paweł Dawidowicz,504,Verona,135,Serie A,2022,1,0,1,2,2.0
+30932.0,Liam Henderson,511,Empoli,135,Serie A,2024,1,0,1,2,2.0
+31003.0,S. Nwankwo,514,Salernitana,135,Serie A,2021,1,0,1,2,2.0
+1600.0,K. Tsimikas,40,Liverpool,39,Premier League,2023,1,0,1,2,2.0
+1605.0,Daniel Podence,39,Wolves,39,Premier League,2021,1,0,1,2,2.0
+1627.0,D. Calabria,489,AC Milan,135,Serie A,2021,1,0,1,2,2.0
+1631.0,R. Rodríguez,503,Torino,135,Serie A,2023,1,0,1,2,2.0
+1640.0,H. Çalhanoğlu,505,Inter,135,Serie A,2022,1,0,1,2,2.0
+1725.0,D. Ljubičić,192,1.FC Köln,78,Bundesliga,2023,1,0,1,2,2.0
+1748.0,L. Coulibaly,514,Salernitana,135,Serie A,2022,1,0,1,2,2.0
+1803.0,T. Chandler,169,Eintracht Frankfurt,78,Bundesliga,2023,1,0,1,2,2.0
+128581.0,Nico Melamed,540,Espanyol,140,La Liga,2022,1,0,1,2,2.0
+128772.0,D. Zima,503,Torino,135,Serie A,2021,1,0,1,2,2.0
+128793.0,D. Jurásek,167,1899 Hoffenheim,78,Bundesliga,2024,1,0,1,2,2.0
+31010.0,F. Dimarco,505,Inter,135,Serie A,2024,1,0,1,2,2.0
+31011.0,R. Gagliolo,514,Salernitana,135,Serie A,2021,1,0,1,2,2.0
+31024.0,José Machín,1579,Monza,135,Serie A,2022,1,0,1,2,2.0
+31054.0,Rade Krunić,489,AC Milan,135,Serie A,2022,1,0,1,2,2.0
+1585.0,Jesé,498,Sampdoria,135,Serie A,2022,1,0,1,2,2.0
+618.0,Danilo,496,Juventus,135,Serie A,2023,1,0,1,2,2.0
+628.0,Adrián Bernabé,523,Parma,135,Serie A,2024,1,0,1,2,2.0
+629.0,K. De Bruyne,50,Manchester City,39,Premier League,2022,1,0,1,2,2.0
+633.0,İ. Gündoğan,50,Manchester City,39,Premier League,2022,1,0,1,2,2.0
+634.0,David Silva,548,Real Sociedad,140,La Liga,2022,1,0,1,2,2.0
+128287.0,Joris Chotard,82,Montpellier,61,Ligue 1,2023,1,0,1,2,2.0
+128478.0,W. Cheddira,512,Frosinone,135,Serie A,2023,1,0,1,2,2.0
+128533.0,J. Leweling,172,VfB Stuttgart,78,Bundesliga,2023,1,0,1,2,2.0
+1697.0,Pablo Fornals,543,Real Betis,140,La Liga,2023,1,0,1,2,2.0
+1702.0,Alfonso Pedraza,533,Villarreal,140,La Liga,2024,1,0,1,2,2.0
+1705.0,Manu Trigueros,533,Villarreal,140,La Liga,2021,1,0,1,2,2.0
+1705.0,Manu Trigueros,533,Villarreal,140,La Liga,2022,1,0,1,2,2.0
+1709.0,K. Toko-Ekambi,94,Rennes,61,Ligue 1,2022,1,0,1,2,2.0
+30531.0,J. Boga,84,Nice,61,Ligue 1,2024,1,0,1,2,2.0
+30531.0,J. Boga,488,Sassuolo,135,Serie A,2021,1,0,1,2,2.0
+30535.0,S. Sensi,505,Inter,135,Serie A,2023,1,0,1,2,2.0
+550.0,K. Dolberg,84,Nice,61,Ligue 1,2021,1,0,1,2,2.0
+30708.0,S. Birindelli,1579,Monza,135,Serie A,2022,1,0,1,2,2.0
+30755.0,E. Vignato,500,Bologna,135,Serie A,2021,1,0,1,2,2.0
+30776.0,C. Romero,47,Tottenham,39,Premier League,2022,1,0,1,2,2.0
+30780.0,L. Mazzitelli,895,Como,135,Serie A,2024,1,0,1,2,2.0
+30782.0,I. Radovanović,514,Salernitana,135,Serie A,2021,1,0,1,2,2.0
+30784.0,N. Rovella,487,Lazio,135,Serie A,2023,1,0,1,2,2.0
+30784.0,N. Rovella,487,Lazio,135,Serie A,2024,1,0,1,2,2.0
+133609.0,Pedri,529,Barcelona,140,La Liga,2024,1,0,1,2,2.0
+135334.0,S. Bueno,547,Girona,140,La Liga,2022,1,0,1,2,2.0
+535.0,P. Schuurs,503,Torino,135,Serie A,2022,1,0,1,2,2.0
+537.0,J. Veltman,51,Brighton,39,Premier League,2021,1,0,1,2,2.0
+537.0,J. Veltman,51,Brighton,39,Premier League,2023,1,0,1,2,2.0
+539.0,D. de Wit,176,VfL Bochum,78,Bundesliga,2024,1,0,1,2,2.0
+545.0,N. Mazraoui,157,Bayern München,78,Bundesliga,2023,1,0,1,2,2.0
+547.0,D. van de Beek,547,Girona,140,La Liga,2024,1,0,1,2,2.0
+31010.0,F. Dimarco,505,Inter,135,Serie A,2022,1,0,1,2,2.0
+31010.0,F. Dimarco,505,Inter,135,Serie A,2023,1,0,1,2,2.0
+129670.0,N. Mbuku,1063,Saint Etienne,61,Ligue 1,2023,1,0,1,2,2.0
+129676.0,P. Yade,112,Metz,61,Ligue 1,2021,1,0,1,2,2.0
+129681.0,A. Rouault,96,Toulouse,61,Ligue 1,2022,1,0,1,2,2.0
+129682.0,A. Adli,168,Bayer Leverkusen,78,Bundesliga,2022,1,0,1,2,2.0
+130423.0,B. Gilmour,71,Norwich,39,Premier League,2021,1,0,1,2,2.0
+133110.0,T. Nianzou,157,Bayern München,78,Bundesliga,2021,1,0,1,2,2.0
+30506.0,D. Baselli,490,Cagliari,135,Serie A,2021,1,0,1,2,2.0
+30507.0,S. Meïté,520,Cremonese,135,Serie A,2022,1,0,1,2,2.0
+30509.0,A. Belotti,497,AS Roma,135,Serie A,2022,1,0,1,2,2.0
+30510.0,Álex Berenguer,531,Athletic Club,140,La Liga,2024,1,0,1,2,2.0
+30521.0,M. Demiral,499,Atalanta,135,Serie A,2021,1,0,1,2,2.0
+1821.0,F. Kostić,496,Juventus,135,Serie A,2022,1,0,1,2,2.0
+1826.0,S. Haller,165,Borussia Dortmund,78,Bundesliga,2023,1,0,1,2,2.0
+1828.0,Luka Jović,541,Real Madrid,140,La Liga,2021,1,0,1,2,2.0
+506.0,Niklas Süle,157,Bayern München,78,Bundesliga,2021,1,0,1,2,2.0
+507.0,Thiago Alcântara,40,Liverpool,39,Premier League,2021,1,0,1,2,2.0
+509.0,A. Davies,157,Bayern München,78,Bundesliga,2022,1,0,1,2,2.0
+30497.0,Bremer,503,Torino,135,Serie A,2021,1,0,1,2,2.0
+30501.0,Armando Izzo,1579,Monza,135,Serie A,2024,1,0,1,2,2.0
+30504.0,W. Singo,91,Monaco,61,Ligue 1,2023,1,0,1,2,2.0
+30504.0,W. Singo,503,Torino,135,Serie A,2021,1,0,1,2,2.0
+30505.0,M. Adopo,499,Atalanta,135,Serie A,2023,1,0,1,2,2.0
+575.0,Florentino Luís,546,Getafe,140,La Liga,2021,1,0,1,2,2.0
+136087.0,F. Parisi,502,Fiorentina,135,Serie A,2023,1,0,1,2,2.0
+136117.0,Rodrigo Riquelme,530,Atletico Madrid,140,La Liga,2024,1,0,1,2,2.0
+136723.0,N. Madueke,49,Chelsea,39,Premier League,2024,1,0,1,2,2.0
+137210.0,A. Stiller,167,1899 Hoffenheim,78,Bundesliga,2022,1,0,1,2,2.0
+138417.0,N. Patterson,45,Everton,39,Premier League,2023,1,0,1,2,2.0
+138780.0,Neco Williams,40,Liverpool,39,Premier League,2021,1,0,1,2,2.0
+138815.0,T. Lamptey,51,Brighton,39,Premier League,2021,1,0,1,2,2.0
+30544.0,G. Scamacca,499,Atalanta,135,Serie A,2023,1,0,1,2,2.0
+30554.0,L. Pellegrini,487,Lazio,135,Serie A,2024,1,0,1,2,2.0
+30558.0,N. Barella,505,Inter,135,Serie A,2021,1,0,1,2,2.0
+30611.0,L. Montipò,504,Verona,135,Serie A,2023,1,0,1,2,2.0
+560.0,S. Corchia,83,Nantes,61,Ligue 1,2022,1,0,1,2,2.0
+561.0,T. Ebuehi,511,Empoli,135,Serie A,2022,1,0,1,2,2.0
+561.0,T. Ebuehi,511,Empoli,135,Serie A,2023,1,0,1,2,2.0
+570.0,F. Cervi,538,Celta Vigo,140,La Liga,2023,1,0,1,2,2.0
+1946.0,L. Trossard,42,Arsenal,39,Premier League,2022,1,0,1,2,2.0
+2032.0,J. Strand Larsen,538,Celta Vigo,140,La Liga,2022,1,0,1,2,2.0
+2042.0,Sergi Gómez,540,Espanyol,140,La Liga,2021,1,0,1,2,2.0
+2047.0,Aleix Vidal,540,Espanyol,140,La Liga,2022,1,0,1,2,2.0
+2118.0,Răzvan Marin,511,Empoli,135,Serie A,2023,1,0,1,2,2.0
+2165.0,V. Mykolenko,45,Everton,39,Premier League,2024,1,0,1,2,2.0
+30396.0,C. Biraghi,502,Fiorentina,135,Serie A,2023,1,0,1,2,2.0
+30410.0,F. Chiesa,496,Juventus,135,Serie A,2021,1,0,1,2,2.0
+1938.0,R. Malinovskyi,499,Atalanta,135,Serie A,2022,1,0,1,2,2.0
+30435.0,D. Kulusevski,47,Tottenham,39,Premier League,2022,1,0,1,2,2.0
+30435.0,D. Kulusevski,496,Juventus,135,Serie A,2021,1,0,1,2,2.0
+30437.0,M. Barrow,500,Bologna,135,Serie A,2021,1,0,1,2,2.0
+30437.0,M. Barrow,500,Bologna,135,Serie A,2022,1,0,1,2,2.0
+30438.0,N. Cambiaghi,511,Empoli,135,Serie A,2022,1,0,1,2,2.0
+30438.0,N. Cambiaghi,511,Empoli,135,Serie A,2023,1,0,1,2,2.0
+30453.0,J. Jankto,490,Cagliari,135,Serie A,2023,1,0,1,2,2.0
+140947.0,I. Kaboré,1359,Luton,39,Premier League,2023,1,0,1,2,2.0
+144261.0,Carlos García-Die,724,Cadiz,140,La Liga,2022,1,0,1,2,2.0
+144732.0,T. Doyle,39,Wolves,39,Premier League,2024,1,0,1,2,2.0
+145059.0,M. Kwarteng,176,VfL Bochum,78,Bundesliga,2023,1,0,1,2,2.0
+1897.0,S. Mandanda,94,Rennes,61,Ligue 1,2022,1,0,1,2,2.0
+1904.0,B. Kamara,66,Aston Villa,39,Premier League,2023,1,0,1,2,2.0
+1914.0,M. Sanson,95,Strasbourg,61,Ligue 1,2022,1,0,1,2,2.0
+1930.0,J. Mæhle,499,Atalanta,135,Serie A,2022,1,0,1,2,2.0
+509.0,A. Davies,157,Bayern München,78,Bundesliga,2023,1,0,1,2,2.0
+530.0,M. Bakker,168,Bayer Leverkusen,78,Bundesliga,2021,1,0,1,2,2.0
+138816.0,I. Maatsen,66,Aston Villa,39,Premier League,2024,1,0,1,2,2.0
+138822.0,A. Broja,36,Fulham,39,Premier League,2023,1,0,1,2,2.0
+138908.0,E. Anderson,65,Nottingham Forest,39,Premier League,2024,1,0,1,2,2.0
+138935.0,C. Chukwuemeka,66,Aston Villa,39,Premier League,2021,1,0,1,2,2.0
+139001.0,Pablo Ibáñez,727,Osasuna,140,La Liga,2022,1,0,1,2,2.0
+139001.0,Pablo Ibáñez,727,Osasuna,140,La Liga,2023,1,0,1,2,2.0
+26342.0,L. Pfeiffer,172,VfB Stuttgart,78,Bundesliga,2022,1,0,1,2,2.0
+26342.0,L. Pfeiffer,181,SV Darmstadt 98,78,Bundesliga,2023,1,0,1,2,2.0
+26530.0,S. Schimmer,180,1. FC Heidenheim,78,Bundesliga,2023,1,0,1,2,2.0
+26828.0,G. Kyriakopoulos,1579,Monza,135,Serie A,2023,1,0,1,2,2.0
+26845.0,T. Douvikas,895,Como,135,Serie A,2024,1,0,1,2,2.0
+28744.0,Þ. Helgason,867,Lecce,135,Serie A,2024,1,0,1,2,2.0
+158121.0,I. Jakobs,91,Monaco,61,Ligue 1,2021,1,0,1,2,2.0
+158694.0,T. Livramento,41,Southampton,39,Premier League,2021,1,0,1,2,2.0
+157052.0,R. Calafiori,42,Arsenal,39,Premier League,2024,1,0,1,2,2.0
+157988.0,Sergio Carreira,538,Celta Vigo,140,La Liga,2024,1,0,1,2,2.0
+2202.0,H. Traoré,548,Real Sociedad,140,La Liga,2024,1,0,1,2,2.0
+2207.0,E. Camavinga,541,Real Madrid,140,La Liga,2022,1,0,1,2,2.0
+2214.0,Romain Del Castillo,106,Stade Brestois 29,61,Ligue 1,2021,1,0,1,2,2.0
+2280.0,César Azpilicueta,530,Atletico Madrid,140,La Liga,2023,1,0,1,2,2.0
+26302.0,Pablo Maffeo,798,Mallorca,140,La Liga,2022,1,0,1,2,2.0
+26307.0,D. Didavi,172,VfB Stuttgart,78,Bundesliga,2021,1,0,1,2,2.0
+452.0,Fernando,536,Sevilla,140,La Liga,2022,1,0,1,2,2.0
+483.0,K. Kvaratskhelia,492,Napoli,135,Serie A,2022,1,0,1,2,2.0
+152418.0,N. Ahamada,172,VfB Stuttgart,78,Bundesliga,2022,1,0,1,2,2.0
+152654.0,Jeremie Frimpong,168,Bayer Leverkusen,78,Bundesliga,2021,1,0,1,2,2.0
+152654.0,Jeremie Frimpong,168,Bayer Leverkusen,78,Bundesliga,2024,1,0,1,2,2.0
+152849.0,M. van de Ven,47,Tottenham,39,Premier League,2024,1,0,1,2,2.0
+153400.0,S. Greenwood,63,Leeds,39,Premier League,2021,1,0,1,2,2.0
+153459.0,N. Pyyhtiä,500,Bologna,135,Serie A,2022,1,0,1,2,2.0
+30417.0,Marco Carnesecchi,520,Cremonese,135,Serie A,2022,1,0,1,2,2.0
+30422.0,Robin Gosens,182,Union Berlin,78,Bundesliga,2023,1,0,1,2,2.0
+30425.0,Gianluca Mancini,497,AS Roma,135,Serie A,2022,1,0,1,2,2.0
+412.0,A. Harit,81,Marseille,61,Ligue 1,2023,1,0,1,2,2.0
+412.0,A. Harit,81,Marseille,61,Ligue 1,2024,1,0,1,2,2.0
+415.0,W. McKennie,496,Juventus,135,Serie A,2023,1,0,1,2,2.0
+416.0,S. Rudy,167,1899 Hoffenheim,78,Bundesliga,2022,1,0,1,2,2.0
+426.0,M. Uth,192,1.FC Köln,78,Bundesliga,2023,1,0,1,2,2.0
+2292.0,Ruben Loftus-Cheek,49,Chelsea,39,Premier League,2021,1,0,1,2,2.0
+2296.0,E. Hazard,541,Real Madrid,140,La Liga,2022,1,0,1,2,2.0
+2299.0,Pedro,487,Lazio,135,Serie A,2023,1,0,1,2,2.0
+25644.0,P. Herrmann,163,Borussia Mönchengladbach,78,Bundesliga,2021,1,0,1,2,2.0
+25646.0,A. Pléa,163,Borussia Mönchengladbach,78,Bundesliga,2021,1,0,1,2,2.0
+25819.0,F. Pick,180,1. FC Heidenheim,78,Bundesliga,2023,1,0,1,2,2.0
+25826.0,C. Kühlwetter,180,1. FC Heidenheim,78,Bundesliga,2023,1,0,1,2,2.0
+25919.0,G. Holtmann,176,VfL Bochum,78,Bundesliga,2021,1,0,1,2,2.0
+26297.0,T. Baumgartl,182,Union Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+26300.0,O. Kabak,167,1899 Hoffenheim,78,Bundesliga,2023,1,0,1,2,2.0
+2182.0,V. Tsyhankov,547,Girona,140,La Liga,2024,1,0,1,2,2.0
+2195.0,S. Boey,157,Bayern München,78,Bundesliga,2024,1,0,1,2,2.0
+2200.0,Gerzino Nyamsi,95,Strasbourg,61,Ligue 1,2022,1,0,1,2,2.0
+2202.0,H. Traoré,94,Rennes,61,Ligue 1,2022,1,0,1,2,2.0
+2289.0,Jorginho,42,Arsenal,39,Premier League,2023,1,0,1,2,2.0
+2290.0,N. Kanté,49,Chelsea,39,Premier League,2021,1,0,1,2,2.0
+161928.0,Alejandro Balde,529,Barcelona,140,La Liga,2023,1,0,1,2,2.0
+162016.0,Xavi Simons,173,RB Leipzig,78,Bundesliga,2024,1,0,1,2,2.0
+162026.0,Marvin Park,534,Las Palmas,140,La Liga,2023,1,0,1,2,2.0
+162032.0,Miguel Gutiérrez,547,Girona,140,La Liga,2023,1,0,1,2,2.0
+162058.0,Víctor Chust,724,Cadiz,140,La Liga,2023,1,0,1,2,2.0
+26171.0,P. Tietz,170,FC Augsburg,78,Bundesliga,2024,1,0,1,2,2.0
+26236.0,C. Günter,160,SC Freiburg,78,Bundesliga,2021,1,0,1,2,2.0
+26297.0,T. Baumgartl,182,Union Berlin,78,Bundesliga,2021,1,0,1,2,2.0
+158710.0,Victor Kristiansen,46,Leicester,39,Premier League,2024,1,0,1,2,2.0
+158710.0,Victor Kristiansen,500,Bologna,135,Serie A,2023,1,0,1,2,2.0
+161747.0,Guéla Doué,94,Rennes,61,Ligue 1,2023,1,0,1,2,2.0
+161875.0,Hugo González,532,Valencia,140,La Liga,2023,1,0,1,2,2.0
+161904.0,B. Barcola,80,Lyon,61,Ligue 1,2021,1,0,1,2,2.0
+161907.0,Malo Gusto,49,Chelsea,39,Premier League,2024,1,0,1,2,2.0
+161921.0,G. Reyna,165,Borussia Dortmund,78,Bundesliga,2021,1,0,1,2,2.0
+161928.0,Alejandro Balde,529,Barcelona,140,La Liga,2022,1,0,1,2,2.0
+25461.0,K. Stöger,163,Borussia Mönchengladbach,78,Bundesliga,2024,1,0,1,2,2.0
+25464.0,M. Ducksch,162,Werder Bremen,78,Bundesliga,2024,1,0,1,2,2.0
+25533.0,N. Schmidt,96,Toulouse,61,Ligue 1,2023,1,0,1,2,2.0
+25533.0,N. Schmidt,96,Toulouse,61,Ligue 1,2024,1,0,1,2,2.0
+25617.0,T. Tillman,178,SpVgg Greuther Furth,78,Bundesliga,2021,1,0,1,2,2.0
+25635.0,J. Hofmann,168,Bayer Leverkusen,78,Bundesliga,2023,1,0,1,2,2.0
+2284.0,Emerson,80,Lyon,61,Ligue 1,2021,1,0,1,2,2.0
+2286.0,D. Zappacosta,499,Atalanta,135,Serie A,2021,1,0,1,2,2.0
+162712.0,Óscar Mingueza,538,Celta Vigo,140,La Liga,2024,1,0,1,2,2.0
+162714.0,A. Onana,45,Everton,39,Premier League,2022,1,0,1,2,2.0
+2461.0,S. Rondón,45,Everton,39,Premier League,2021,1,0,1,2,2.0
+2468.0,G. Montiel,65,Nottingham Forest,39,Premier League,2023,1,0,1,2,2.0
+25414.0,J. Yeboah,517,Venezia,135,Serie A,2024,1,0,1,2,2.0
+25416.0,Wout Weghorst,33,Manchester United,39,Premier League,2022,1,0,1,2,2.0
+25452.0,N. Gießelmann,182,Union Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+25455.0,A. Barkok,164,FSV Mainz 05,78,Bundesliga,2022,1,0,1,2,2.0
+162127.0,Diego López,532,Valencia,140,La Liga,2024,1,0,1,2,2.0
+162266.0,L. da Cunha,84,Nice,61,Ligue 1,2021,1,0,1,2,2.0
+162266.0,L. da Cunha,895,Como,135,Serie A,2024,1,0,1,2,2.0
+162267.0,A. Truffert,94,Rennes,61,Ligue 1,2024,1,0,1,2,2.0
+162452.0,D. Rensch,497,AS Roma,135,Serie A,2024,1,0,1,2,2.0
+162465.0,Melvin Bard,84,Nice,61,Ligue 1,2023,1,0,1,2,2.0
+162475.0,Mika Mármol,534,Las Palmas,140,La Liga,2024,1,0,1,2,2.0
+162552.0,D. Scarlett,47,Tottenham,39,Premier League,2024,1,0,1,2,2.0
+25920.0,D. Latza,174,FC Schalke 04,78,Bundesliga,2022,1,0,1,2,2.0
+25922.0,L. Öztunalı,182,Union Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+25926.0,J. Burkardt,164,FSV Mainz 05,78,Bundesliga,2022,1,0,1,2,2.0
+162067.0,T. Pembélé,85,Paris Saint Germain,61,Ligue 1,2022,1,0,1,2,2.0
+162106.0,Y. Musah,489,AC Milan,135,Serie A,2023,1,0,1,2,2.0
+162123.0,I. Moriba,532,Valencia,140,La Liga,2022,1,0,1,2,2.0
+162126.0,Peque Fernández,536,Sevilla,140,La Liga,2024,1,0,1,2,2.0
+162127.0,Diego López,532,Valencia,140,La Liga,2023,1,0,1,2,2.0
+2360.0,D. Giannoulis,170,FC Augsburg,78,Bundesliga,2024,1,0,1,2,2.0
+2412.0,Felipe Anderson,487,Lazio,135,Serie A,2023,1,0,1,2,2.0
+2452.0,T. Rincón,498,Sampdoria,135,Serie A,2022,1,0,1,2,2.0
+2459.0,D. Machís,720,Valladolid,140,La Liga,2022,1,0,1,2,2.0
+2459.0,D. Machís,720,Valladolid,140,La Liga,2024,1,0,1,2,2.0
+385.0,Óliver Torres,536,Sevilla,140,La Liga,2022,1,0,1,2,2.0
+163338.0,S. Podgoreanu,515,Spezia,135,Serie A,2021,1,0,1,2,2.0
+167659.0,K. Olaigbe,94,Rennes,61,Ligue 1,2024,1,0,1,2,2.0
+378.0,Alex Telles,33,Manchester United,39,Premier League,2021,1,0,1,2,2.0
+25362.0,D. Selke,159,Hertha Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+25375.0,T. Asano,176,VfL Bochum,78,Bundesliga,2021,1,0,1,2,2.0
+25375.0,T. Asano,176,VfL Bochum,78,Bundesliga,2022,1,0,1,2,2.0
+25380.0,L. Maina,192,1.FC Köln,78,Bundesliga,2023,1,0,1,2,2.0
+25408.0,M. Arnold,161,VfL Wolfsburg,78,Bundesliga,2022,1,0,1,2,2.0
+25410.0,J. Guilavogui,164,FSV Mainz 05,78,Bundesliga,2023,1,0,1,2,2.0
+2360.0,D. Giannoulis,71,Norwich,39,Premier League,2021,1,0,1,2,2.0
+328.0,Fabián Ruiz,85,Paris Saint Germain,61,Ligue 1,2024,1,0,1,2,2.0
+329.0,P. Zieliński,492,Napoli,135,Serie A,2023,1,0,1,2,2.0
+329.0,P. Zieliński,505,Inter,135,Serie A,2024,1,0,1,2,2.0
+331.0,L. Insigne,492,Napoli,135,Serie A,2021,1,0,1,2,2.0
+349.0,A. Terzić,502,Fiorentina,135,Serie A,2021,1,0,1,2,2.0
+371.0,Felipe,65,Nottingham Forest,39,Premier League,2022,1,0,1,2,2.0
+372.0,Éder Militão,541,Real Madrid,140,La Liga,2024,1,0,1,2,2.0
+376.0,Diogo Leite,182,Union Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+162887.0,E. Millot,172,VfB Stuttgart,78,Bundesliga,2021,1,0,1,2,2.0
+162887.0,E. Millot,172,VfB Stuttgart,78,Bundesliga,2023,1,0,1,2,2.0
+162907.0,A. Zanoli,514,Salernitana,135,Serie A,2023,1,0,1,2,2.0
+162991.0,E. Matazo,91,Monaco,61,Ligue 1,2023,1,0,1,2,2.0
+163069.0,L. Netz,163,Borussia Mönchengladbach,78,Bundesliga,2023,1,0,1,2,2.0
+163069.0,L. Netz,163,Borussia Mönchengladbach,78,Bundesliga,2024,1,0,1,2,2.0
+163189.0,M. Thiaw,489,AC Milan,135,Serie A,2023,1,0,1,2,2.0
+319.0,S. Luperto,511,Empoli,135,Serie A,2021,1,0,1,2,2.0
+25345.0,K. Rekik,536,Sevilla,140,La Liga,2021,1,0,1,2,2.0
+25349.0,O. Duda,504,Verona,135,Serie A,2023,1,0,1,2,2.0
+25355.0,A. Maier,170,FC Augsburg,78,Bundesliga,2023,1,0,1,2,2.0
+178709.0,Y. Engelhardt,895,Como,135,Serie A,2024,1,0,1,2,2.0
+178769.0,Philipp Treu,186,FC St. Pauli,78,Bundesliga,2024,1,0,1,2,2.0
+179399.0,E. Tchato,82,Montpellier,61,Ligue 1,2022,1,0,1,2,2.0
+179401.0,S. Delaye,82,Montpellier,61,Ligue 1,2021,1,0,1,2,2.0
+180317.0,C. Bradley,40,Liverpool,39,Premier League,2023,1,0,1,2,2.0
+25268.0,L. Daschner,176,VfL Bochum,78,Bundesliga,2024,1,0,1,2,2.0
+25290.0,Jeffrey Gouweleeuw,170,FC Augsburg,78,Bundesliga,2022,1,0,1,2,2.0
+25299.0,F. Jensen,170,FC Augsburg,78,Bundesliga,2021,1,0,1,2,2.0
+25300.0,Rani Khedira,182,Union Berlin,78,Bundesliga,2024,1,0,1,2,2.0
+25303.0,J. Schmid,160,SC Freiburg,78,Bundesliga,2021,1,0,1,2,2.0
+25313.0,J. Beste,160,SC Freiburg,78,Bundesliga,2024,1,0,1,2,2.0
+25342.0,M. Mittelstädt,159,Hertha Berlin,78,Bundesliga,2021,1,0,1,2,2.0
+25342.0,M. Mittelstädt,172,VfB Stuttgart,78,Bundesliga,2024,1,0,1,2,2.0
+177665.0,A. Stach,167,1899 Hoffenheim,78,Bundesliga,2024,1,0,1,2,2.0
+177745.0,F. Alidou,169,Eintracht Frankfurt,78,Bundesliga,2022,1,0,1,2,2.0
+178077.0,K. Schade,55,Brentford,39,Premier League,2022,1,0,1,2,2.0
+178093.0,Y. Keitel,160,SC Freiburg,78,Bundesliga,2022,1,0,1,2,2.0
+178106.0,M. Pieringer,180,1. FC Heidenheim,78,Bundesliga,2023,1,0,1,2,2.0
+2614.0,N. Nández,490,Cagliari,135,Serie A,2021,1,0,1,2,2.0
+25161.0,P. Seguin,182,Union Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+25208.0,Paulo Otávio,161,VfL Wolfsburg,78,Bundesliga,2022,1,0,1,2,2.0
+174607.0,David Pereira da Costa,116,Lens,61,Ligue 1,2021,1,0,1,2,2.0
+174703.0,T. Le Bris,97,Lorient,61,Ligue 1,2023,1,0,1,2,2.0
+174915.0,Josué Casimir,111,Le Havre,61,Ligue 1,2023,1,0,1,2,2.0
+174918.0,Loïc Badé,94,Rennes,61,Ligue 1,2021,1,0,1,2,2.0
+174918.0,Loïc Badé,536,Sevilla,140,La Liga,2024,1,0,1,2,2.0
+174937.0,Y. Kechta,111,Le Havre,61,Ligue 1,2023,1,0,1,2,2.0
+177661.0,J. Justvan,181,SV Darmstadt 98,78,Bundesliga,2023,1,0,1,2,2.0
+177665.0,A. Stach,164,FSV Mainz 05,78,Bundesliga,2022,1,0,1,2,2.0
+24815.0,Christopher Antwi-Adjei,176,VfL Bochum,78,Bundesliga,2022,1,0,1,2,2.0
+24845.0,Julian Ryerson,165,Borussia Dortmund,78,Bundesliga,2024,1,0,1,2,2.0
+24848.0,C. Trimmel,182,Union Berlin,78,Bundesliga,2022,1,0,1,2,2.0
+24861.0,S. Polter,181,SV Darmstadt 98,78,Bundesliga,2023,1,0,1,2,2.0
+24897.0,M. Busch,180,1. FC Heidenheim,78,Bundesliga,2024,1,0,1,2,2.0
+24903.0,R. Andrich,168,Bayer Leverkusen,78,Bundesliga,2022,1,0,1,2,2.0
+24970.0,K. Schindler,192,1.FC Köln,78,Bundesliga,2021,1,0,1,2,2.0
+304.0,S. Mané,157,Bayern München,78,Bundesliga,2022,1,0,1,2,2.0
+2476.0,G. Rodríguez,543,Real Betis,140,La Liga,2021,1,0,1,2,2.0
+2483.0,D. Machado,116,Lens,61,Ligue 1,2021,1,0,1,2,2.0
+2483.0,D. Machado,116,Lens,61,Ligue 1,2022,1,0,1,2,2.0
+2490.0,J. Lerma,52,Crystal Palace,39,Premier League,2024,1,0,1,2,2.0
+2507.0,M. Almirón,34,Newcastle,39,Premier League,2023,1,0,1,2,2.0
+2522.0,A. Sanabria,503,Torino,135,Serie A,2024,1,0,1,2,2.0
+24803.0,F. Kainz,192,1.FC Köln,78,Bundesliga,2022,1,0,1,2,2.0
+24815.0,Christopher Antwi-Adjei,176,VfL Bochum,78,Bundesliga,2021,1,0,1,2,2.0
+296.0,James Milner,51,Brighton,39,Premier League,2023,1,0,1,2,2.0
+25008.0,J. Clauss,81,Marseille,61,Ligue 1,2023,1,0,1,2,2.0
+25008.0,J. Clauss,84,Nice,61,Ligue 1,2024,1,0,1,2,2.0
+25047.0,T. Kempe,181,SV Darmstadt 98,78,Bundesliga,2023,1,0,1,2,2.0
+25074.0,A. Losilla,176,VfL Bochum,78,Bundesliga,2022,1,0,1,2,2.0
+25084.0,S. Zoller,176,VfL Bochum,78,Bundesliga,2022,1,0,1,2,2.0
+25158.0,D. Raum,173,RB Leipzig,78,Bundesliga,2022,1,0,1,2,2.0
+2476.0,G. Rodríguez,48,West Ham,39,Premier League,2024,1,0,1,2,2.0
+180731.0,Lorenz Assignon,94,Rennes,61,Ligue 1,2023,1,0,1,2,2.0
+181701.0,Gerard Martín,529,Barcelona,140,La Liga,2024,1,0,1,2,2.0
+181734.0,Pep Chavarría,728,Rayo Vallecano,140,La Liga,2022,1,0,1,2,2.0
+288.0,Alberto Moreno,533,Villarreal,140,La Liga,2022,1,0,1,2,2.0
+290.0,Virgil van Dijk,40,Liverpool,39,Premier League,2023,1,0,1,2,2.0
+293.0,C. Jones,40,Liverpool,39,Premier League,2021,1,0,1,2,2.0
+293.0,C. Jones,40,Liverpool,39,Premier League,2023,1,0,1,2,2.0
+295.0,A. Lallana,41,Southampton,39,Premier League,2024,1,0,1,2,2.0
+24641.0,B. Zivzivadze,180,1. FC Heidenheim,78,Bundesliga,2024,1,0,1,2,2.0
+24794.0,Benno Schmitz,192,1.FC Köln,78,Bundesliga,2023,1,0,1,2,2.0
+24798.0,C. Führich,172,VfB Stuttgart,78,Bundesliga,2023,1,0,1,2,2.0
+2670.0,Iñigo Martínez,529,Barcelona,140,La Liga,2024,1,0,1,2,2.0
+2672.0,Iker Muniain,531,Athletic Club,140,La Liga,2022,1,0,1,2,2.0
+2679.0,Dyego Sousa,723,Almeria,140,La Liga,2022,1,0,1,2,2.0
+22229.0,J. Ikoné,502,Fiorentina,135,Serie A,2021,1,0,1,2,2.0
+22235.0,J. Bamba,538,Celta Vigo,140,La Liga,2023,1,0,1,2,2.0
+277.0,M. Diaby,168,Bayer Leverkusen,78,Bundesliga,2022,1,0,1,2,2.0
+280.0,Alisson Becker,40,Liverpool,39,Premier League,2022,1,0,1,2,2.0
+2777.0,I. Success,494,Udinese,135,Serie A,2021,1,0,1,2,2.0
+2777.0,I. Success,494,Udinese,135,Serie A,2022,1,0,1,2,2.0
+23637.0,Y. Zouaoui,111,Le Havre,61,Ligue 1,2024,1,0,1,2,2.0
+24147.0,M. Camara,106,Stade Brestois 29,61,Ligue 1,2023,1,0,1,2,2.0
+24245.0,G. Kalulu,97,Lorient,61,Ligue 1,2022,1,0,1,2,2.0
+24245.0,G. Kalulu,97,Lorient,61,Ligue 1,2023,1,0,1,2,2.0
+182671.0,Cantero,539,Levante,140,La Liga,2021,1,0,1,2,2.0
+182674.0,Jofre Carreras,540,Espanyol,140,La Liga,2021,1,0,1,2,2.0
+182772.0,Juanlu Sánchez,536,Sevilla,140,La Liga,2023,1,0,1,2,2.0
+183699.0,Urko González,540,Espanyol,140,La Liga,2024,1,0,1,2,2.0
+183799.0,Nico Williams,531,Athletic Club,140,La Liga,2022,1,0,1,2,2.0
+271.0,L. Paredes,85,Paris Saint Germain,61,Ligue 1,2022,1,0,1,2,2.0
+271.0,L. Paredes,497,AS Roma,135,Serie A,2024,1,0,1,2,2.0
+274.0,E. Cavani,33,Manchester United,39,Premier League,2021,1,0,1,2,2.0
+317.0,E. Hysaj,487,Lazio,135,Serie A,2022,1,0,1,2,2.0
+317.0,E. Hysaj,487,Lazio,135,Serie A,2024,1,0,1,2,2.0
+181808.0,F. Miretti,496,Juventus,135,Serie A,2022,1,0,1,2,2.0
+182201.0,T. Mitchell,52,Crystal Palace,39,Premier League,2024,1,0,1,2,2.0
+182434.0,D. Beljo,170,FC Augsburg,78,Bundesliga,2022,1,0,1,2,2.0
+182546.0,Jon Pacheco,548,Real Sociedad,140,La Liga,2023,1,0,1,2,2.0
+182563.0,Jon Morcillo,531,Athletic Club,140,La Liga,2022,1,0,1,2,2.0
+182621.0,Iker Muñoz,727,Osasuna,140,La Liga,2024,1,0,1,2,2.0
+22090.0,William Saliba,42,Arsenal,39,Premier League,2022,1,0,1,2,2.0
+22138.0,Christopher Jullien,82,Montpellier,61,Ligue 1,2022,1,0,1,2,2.0
+22147.0,M. Koné,163,Borussia Mönchengladbach,78,Bundesliga,2022,1,0,1,2,2.0
+22149.0,Ibrahim Sangaré,65,Nottingham Forest,39,Premier League,2024,1,0,1,2,2.0
+22177.0,I. Ganago,83,Nantes,61,Ligue 1,2022,1,0,1,2,2.0
+22222.0,Z. Çelik,497,AS Roma,135,Serie A,2022,1,0,1,2,2.0
+194682.0,D. Abiama,178,SpVgg Greuther Furth,78,Bundesliga,2021,1,0,1,2,2.0
+195103.0,João Gomes,39,Wolves,39,Premier League,2024,1,0,1,2,2.0
+190831.0,S. Doucouré,97,Lorient,61,Ligue 1,2022,1,0,1,2,2.0
+191189.0,C. Akpa,108,Auxerre,61,Ligue 1,2024,1,0,1,2,2.0
+191245.0,N. Kandil,95,Strasbourg,61,Ligue 1,2022,1,0,1,2,2.0
+191252.0,M. Bangré,96,Toulouse,61,Ligue 1,2023,1,0,1,2,2.0
+2807.0,R. Freuler,500,Bologna,135,Serie A,2024,1,0,1,2,2.0
+2817.0,N. Milenković,502,Fiorentina,135,Serie A,2022,1,0,1,2,2.0
+2822.0,D. Lazović,504,Verona,135,Serie A,2024,1,0,1,2,2.0
+2823.0,S. Lukić,36,Fulham,39,Premier League,2024,1,0,1,2,2.0
+2762.0,J. Brekalo,161,VfL Wolfsburg,78,Bundesliga,2021,1,0,1,2,2.0
+284.0,J. Gomez,40,Liverpool,39,Premier League,2023,1,0,1,2,2.0
+184226.0,Yéremy Pino,533,Villarreal,140,La Liga,2024,1,0,1,2,2.0
+185202.0,Juan Cruz,537,Leganes,140,La Liga,2024,1,0,1,2,2.0
+185477.0,Rodri,543,Real Betis,140,La Liga,2021,1,0,1,2,2.0
+187214.0,Carlos Vicente,542,Alaves,140,La Liga,2023,1,0,1,2,2.0
+187987.0,Ramon Terrats,533,Villarreal,140,La Liga,2023,1,0,1,2,2.0
+190686.0,S. Mara,95,Strasbourg,61,Ligue 1,2024,1,0,1,2,2.0
+22250.0,M. Simakan,173,RB Leipzig,78,Bundesliga,2023,1,0,1,2,2.0
+22257.0,D. Liénard,95,Strasbourg,61,Ligue 1,2021,1,0,1,2,2.0
+22258.0,Jonas Martin,106,Stade Brestois 29,61,Ligue 1,2023,1,0,1,2,2.0
+22260.0,Ibrahima Sissoko,95,Strasbourg,61,Ligue 1,2021,1,0,1,2,2.0
+22260.0,Ibrahima Sissoko,95,Strasbourg,61,Ligue 1,2022,1,0,1,2,2.0
+2733.0,J. Stryger Larsen,494,Udinese,135,Serie A,2021,1,0,1,2,2.0
+2737.0,M. Braithwaite,529,Barcelona,140,La Liga,2021,1,0,1,2,2.0
+2749.0,Jackson Irvine,186,FC St. Pauli,78,Bundesliga,2024,1,0,1,2,2.0
+21582.0,F. Mollet,83,Nantes,61,Ligue 1,2022,1,0,1,2,2.0
+21584.0,M. Ristić,82,Montpellier,61,Ligue 1,2021,1,0,1,2,2.0
+21585.0,J. Sambia,514,Salernitana,135,Serie A,2022,1,0,1,2,2.0
+21591.0,A. Delort,84,Nice,61,Ligue 1,2022,1,0,1,2,2.0
+2920.0,T. Castagne,36,Fulham,39,Premier League,2024,1,0,1,2,2.0
+2920.0,T. Castagne,46,Leicester,39,Premier League,2022,1,0,1,2,2.0
+2922.0,L. Dendoncker,39,Wolves,39,Premier League,2021,1,0,1,2,2.0
+2925.0,D. Praet,503,Torino,135,Serie A,2021,1,0,1,2,2.0
+21701.0,Valentin Rosier,537,Leganes,140,La Liga,2024,1,0,1,2,2.0
+22003.0,M. Cafaro,1063,Saint Etienne,61,Ligue 1,2023,1,0,1,2,2.0
+22006.0,T. Dingomé,110,Estac Troyes,61,Ligue 1,2021,1,0,1,2,2.0
+22016.0,R. Oudin,78,Bordeaux,61,Ligue 1,2021,1,0,1,2,2.0
+2790.0,J. Guðmunds­son,44,Burnley,39,Premier League,2023,1,0,1,2,2.0
+2799.0,A. Guðmundsson,495,Genoa,135,Serie A,2023,1,0,1,2,2.0
+2802.0,Yann Sommer,163,Borussia Mönchengladbach,78,Bundesliga,2021,1,0,1,2,2.0
+21580.0,P. Lasne,106,Stade Brestois 29,61,Ligue 1,2021,1,0,1,2,2.0
+199837.0,K. Sulemana,94,Rennes,61,Ligue 1,2021,1,0,1,2,2.0
+200811.0,L. Samele,488,Sassuolo,135,Serie A,2021,1,0,1,2,2.0
+202086.0,J. Sarmiento,51,Brighton,39,Premier League,2022,1,0,1,2,2.0
+202526.0,E. Dinkçi,160,SC Freiburg,78,Bundesliga,2024,1,0,1,2,2.0
+202526.0,E. Dinkçi,180,1. FC Heidenheim,78,Bundesliga,2023,1,0,1,2,2.0
+202736.0,P. Nebel,164,FSV Mainz 05,78,Bundesliga,2021,1,0,1,2,2.0
+2932.0,Jordan Pickford,45,Everton,39,Premier League,2022,1,0,1,2,2.0
+21649.0,E. Crivelli,1063,Saint Etienne,61,Ligue 1,2021,1,0,1,2,2.0
+195893.0,I. Touré,97,Lorient,61,Ligue 1,2023,1,0,1,2,2.0
+195923.0,José Ángel Carmona,546,Getafe,140,La Liga,2023,1,0,1,2,2.0
+195993.0,C. Alcaraz,496,Juventus,135,Serie A,2023,1,0,1,2,2.0
+197448.0,Yan Couto,547,Girona,140,La Liga,2022,1,0,1,2,2.0
+199042.0,Mario Maroto,720,Valladolid,140,La Liga,2024,1,0,1,2,2.0
+199089.0,Lorenzo Lucca,494,Udinese,135,Serie A,2023,1,0,1,2,2.0
+199824.0,Rubén Sánchez,540,Espanyol,140,La Liga,2022,1,0,1,2,2.0
+199837.0,K. Sulemana,41,Southampton,39,Premier League,2024,1,0,1,2,2.0
+21387.0,T. Monconduit,97,Lorient,61,Ligue 1,2021,1,0,1,2,2.0
+21443.0,T. Savanier,82,Montpellier,61,Ligue 1,2024,1,0,1,2,2.0
+21568.0,R. Aguilar,91,Monaco,61,Ligue 1,2021,1,0,1,2,2.0
+21570.0,N. Cozza,82,Montpellier,61,Ligue 1,2021,1,0,1,2,2.0
+21570.0,N. Cozza,82,Montpellier,61,Ligue 1,2022,1,0,1,2,2.0
+264.0,T. Meunier,165,Borussia Dortmund,78,Bundesliga,2021,1,0,1,2,2.0
+237129.0,P. Sarr,47,Tottenham,39,Premier League,2022,1,0,1,2,2.0
+260898.0,N. Remberg,191,Holstein Kiel,78,Bundesliga,2024,1,0,1,2,2.0
+3033.0,C. Bakambu,81,Marseille,61,Ligue 1,2022,1,0,1,2,2.0
+21101.0,S. Moutoussamy,83,Nantes,61,Ligue 1,2022,1,0,1,2,2.0
+21102.0,V. Rongier,81,Marseille,61,Ligue 1,2022,1,0,1,2,2.0
+21138.0,R. Aït-Nouri,39,Wolves,39,Premier League,2021,1,0,1,2,2.0
+21145.0,P. Capelle,77,Angers,61,Ligue 1,2021,1,0,1,2,2.0
+21146.0,A. Fulgini,116,Lens,61,Ligue 1,2023,1,0,1,2,2.0
+21152.0,J. Reine-Adélaïde,110,Estac Troyes,61,Ligue 1,2022,1,0,1,2,2.0
+21383.0,E. Pieters,44,Burnley,39,Premier League,2021,1,0,1,2,2.0
+240.0,Pablo Rosario,84,Nice,61,Ligue 1,2022,1,0,1,2,2.0
+243.0,Z. Aboukhlal,96,Toulouse,61,Ligue 1,2022,1,0,1,2,2.0
+256.0,Dani Alves,529,Barcelona,140,La Liga,2021,1,0,1,2,2.0
+258.0,Juan Bernat,533,Villarreal,140,La Liga,2024,1,0,1,2,2.0
+259.0,Thiago Silva,49,Chelsea,39,Premier League,2022,1,0,1,2,2.0
+261.0,T. Kehrer,91,Monaco,61,Ligue 1,2023,1,0,1,2,2.0
+3009.0,Karol Linetty,503,Torino,135,Serie A,2021,1,0,1,2,2.0
+3014.0,S. Żurkowski,502,Fiorentina,135,Serie A,2022,1,0,1,2,2.0
+202844.0,N. Weißhaupt,160,SC Freiburg,78,Bundesliga,2022,1,0,1,2,2.0
+202854.0,M. Röhl,160,SC Freiburg,78,Bundesliga,2022,1,0,1,2,2.0
+203007.0,R. Reitz,163,Borussia Mönchengladbach,78,Bundesliga,2024,1,0,1,2,2.0
+203474.0,N. Zalewski,497,AS Roma,135,Serie A,2023,1,0,1,2,2.0
+203474.0,N. Zalewski,505,Inter,135,Serie A,2024,1,0,1,2,2.0
+226803.0,S. Nanasi,95,Strasbourg,61,Ligue 1,2024,1,0,1,2,2.0
+236955.0,A. Sarr,504,Verona,135,Serie A,2024,1,0,1,2,2.0
+240.0,Pablo Rosario,84,Nice,61,Ligue 1,2021,1,0,1,2,2.0
+2945.0,D. Bronn,112,Metz,61,Ligue 1,2021,1,0,1,2,2.0
+2990.0,I. Gueye,45,Everton,39,Premier League,2024,1,0,1,2,2.0
+2991.0,C. Kouyaté,52,Crystal Palace,39,Premier League,2021,1,0,1,2,2.0
+3001.0,R. Gumny,170,FC Augsburg,78,Bundesliga,2022,1,0,1,2,2.0
+3008.0,M. Klich,63,Leeds,39,Premier League,2021,1,0,1,2,2.0
+207.0,I. Perišić,47,Tottenham,39,Premier League,2023,1,0,1,2,2.0
+226.0,D. Dumfries,505,Inter,135,Serie A,2021,1,0,1,2,2.0
+270509.0,A. Diouf,116,Lens,61,Ligue 1,2024,1,0,1,2,2.0
+20833.0,L. Leroy,82,Montpellier,61,Ligue 1,2023,1,0,1,2,2.0
+20925.0,V. Marchetti,98,Ajaccio,61,Ligue 1,2022,1,0,1,2,2.0
+20971.0,A. Coeff,108,Auxerre,61,Ligue 1,2022,1,0,1,2,2.0
+21004.0,Lucien Agoumé,536,Sevilla,140,La Liga,2024,1,0,1,2,2.0
+21012.0,H. Sakhi,108,Auxerre,61,Ligue 1,2022,1,0,1,2,2.0
+21088.0,N. Pallois,83,Nantes,61,Ligue 1,2024,1,0,1,2,2.0
+21097.0,Andrei Girotto,83,Nantes,61,Ligue 1,2021,1,0,1,2,2.0
+2938.0,J. Ward-Prowse,65,Nottingham Forest,39,Premier League,2024,1,0,1,2,2.0
+268572.0,E. Michut,85,Paris Saint Germain,61,Ligue 1,2021,1,0,1,2,2.0
+193.0,D. D'Ambrosio,505,Inter,135,Serie A,2022,1,0,1,2,2.0
+199.0,Š. Vrsaljko,530,Atletico Madrid,140,La Liga,2021,1,0,1,2,2.0
+200.0,Gabriele Zappa,490,Cagliari,135,Serie A,2023,1,0,1,2,2.0
+203.0,R. Gagliardini,1579,Monza,135,Serie A,2023,1,0,1,2,2.0
+207.0,I. Perišić,47,Tottenham,39,Premier League,2022,1,0,1,2,2.0
+20773.0,J. Berthomier,99,Clermont Foot,61,Ligue 1,2021,1,0,1,2,2.0
+20776.0,J. Gastien,99,Clermont Foot,61,Ligue 1,2021,1,0,1,2,2.0
+263482.0,Nuno Mendes,85,Paris Saint Germain,61,Ligue 1,2022,1,0,1,2,2.0
+263482.0,Nuno Mendes,85,Paris Saint Germain,61,Ligue 1,2024,1,0,1,2,2.0
+264383.0,Warren Kamanzi,96,Toulouse,61,Ligue 1,2023,1,0,1,2,2.0
+264383.0,Warren Kamanzi,96,Toulouse,61,Ligue 1,2024,1,0,1,2,2.0
+264470.0,Raúl Moro,487,Lazio,135,Serie A,2021,1,0,1,2,2.0
+264472.0,Filippo Terracciano,504,Verona,135,Serie A,2023,1,0,1,2,2.0
+265386.0,D. Javorček,191,Holstein Kiel,78,Bundesliga,2024,1,0,1,2,2.0
+265884.0,P. Aaronson,169,Eintracht Frankfurt,78,Bundesliga,2023,1,0,1,2,2.0
+280339.0,A. Sieb,164,FSV Mainz 05,78,Bundesliga,2024,1,0,1,2,2.0
+281408.0,Vítinha,495,Genoa,135,Serie A,2024,1,0,1,2,2.0
+281495.0,T. Kristensen,494,Udinese,135,Serie A,2023,1,0,1,2,2.0
+282549.0,J. Mwanga,111,Le Havre,61,Ligue 1,2024,1,0,1,2,2.0
+283668.0,Arnau Martínez,547,Girona,140,La Liga,2023,1,0,1,2,2.0
+283668.0,Arnau Martínez,547,Girona,140,La Liga,2024,1,0,1,2,2.0
+284230.0,R. Lewis,50,Manchester City,39,Premier League,2024,1,0,1,2,2.0
+284242.0,O. Forson,33,Manchester United,39,Premier League,2023,1,0,1,2,2.0
+20639.0,Fabien Lemoine,97,Lorient,61,Ligue 1,2021,1,0,1,2,2.0
+20665.0,J. Bellegarde,39,Wolves,39,Premier League,2024,1,0,1,2,2.0
+20677.0,G. Kyei,99,Clermont Foot,61,Ligue 1,2023,1,0,1,2,2.0
+20692.0,H. Abdelli,77,Angers,61,Ligue 1,2024,1,0,1,2,2.0
+20696.0,P. Gueye,81,Marseille,61,Ligue 1,2021,1,0,1,2,2.0
+20732.0,G. Perrin,108,Auxerre,61,Ligue 1,2024,1,0,1,2,2.0
+20734.0,J. Tell,99,Clermont Foot,61,Ligue 1,2021,1,0,1,2,2.0
+280334.0,G. Vidović,157,Bayern München,78,Bundesliga,2022,1,0,1,2,2.0
+278392.0,C. Cresswell,96,Toulouse,61,Ligue 1,2024,1,0,1,2,2.0
+3334.0,Youssouf Koné,110,Estac Troyes,61,Ligue 1,2021,1,0,1,2,2.0
+3339.0,C. Doucouré,52,Crystal Palace,39,Premier League,2022,1,0,1,2,2.0
+3339.0,C. Doucouré,116,Lens,61,Ligue 1,2021,1,0,1,2,2.0
+3406.0,Frank Anguissa,492,Napoli,135,Serie A,2021,1,0,1,2,2.0
+3406.0,Frank Anguissa,492,Napoli,135,Serie A,2022,1,0,1,2,2.0
+20600.0,Romain Perraud,84,Nice,61,Ligue 1,2023,1,0,1,2,2.0
+20633.0,J. Cabot,77,Angers,61,Ligue 1,2021,1,0,1,2,2.0
+272460.0,Q. Merlin,83,Nantes,61,Ligue 1,2022,1,0,1,2,2.0
+274267.0,B. Locko,93,Reims,61,Ligue 1,2021,1,0,1,2,2.0
+274312.0,M. Cho,84,Nice,61,Ligue 1,2024,1,0,1,2,2.0
+274328.0,S. Sow,95,Strasbourg,61,Ligue 1,2023,1,0,1,2,2.0
+275776.0,K. Asllani,505,Inter,135,Serie A,2024,1,0,1,2,2.0
+276184.0,M. Sarr,95,Strasbourg,61,Ligue 1,2024,1,0,1,2,2.0
+276670.0,F. Chaïbi,96,Toulouse,61,Ligue 1,2023,1,0,1,2,2.0
+278095.0,J. Rowe,71,Norwich,39,Premier League,2021,1,0,1,2,2.0
+6168.0,Omar Alderete,546,Getafe,140,La Liga,2022,1,0,1,2,2.0
+6231.0,Facundo Medina,116,Lens,61,Ligue 1,2022,1,0,1,2,2.0
+19495.0,Nathan Collins,55,Brentford,39,Premier League,2023,1,0,1,2,2.0
+19545.0,R. James,49,Chelsea,39,Premier League,2023,1,0,1,2,2.0
+175.0,E. Dier,47,Tottenham,39,Premier League,2022,1,0,1,2,2.0
+178.0,Lucas Moura,47,Tottenham,39,Premier League,2021,1,0,1,2,2.0
+182.0,Harry Winks,46,Leicester,39,Premier League,2024,1,0,1,2,2.0
+284500.0,Tim Iroegbunam,45,Everton,39,Premier League,2024,1,0,1,2,2.0
+3173.0,I. Bennacer,81,Marseille,61,Ligue 1,2024,1,0,1,2,2.0
+3173.0,I. Bennacer,489,AC Milan,135,Serie A,2023,1,0,1,2,2.0
+3177.0,F. El Melali,77,Angers,61,Ligue 1,2024,1,0,1,2,2.0
+3237.0,I. Traoré,77,Angers,61,Ligue 1,2021,1,0,1,2,2.0
+3333.0,M. Haïdara,116,Lens,61,Ligue 1,2023,1,0,1,2,2.0
+6002.0,E. Palacios,168,Bayer Leverkusen,78,Bundesliga,2022,1,0,1,2,2.0
+6002.0,E. Palacios,168,Bayer Leverkusen,78,Bundesliga,2024,1,0,1,2,2.0
+6065.0,Lucas Robertone,723,Almeria,140,La Liga,2022,1,0,1,2,2.0
+20110.0,S. Baptiste,55,Brentford,39,Premier League,2022,1,0,1,2,2.0
+20203.0,Tom Lockyer,1359,Luton,39,Premier League,2023,1,0,1,2,2.0
+20520.0,I. Balliu,728,Rayo Vallecano,140,La Liga,2023,1,0,1,2,2.0
+20521.0,T. Delaine,95,Strasbourg,61,Ligue 1,2023,1,0,1,2,2.0
+20542.0,D. Léon,108,Auxerre,61,Ligue 1,2024,1,0,1,2,2.0
+20554.0,H. Belkebla,77,Angers,61,Ligue 1,2024,1,0,1,2,2.0
+20558.0,Hugo Magnetti,106,Stade Brestois 29,61,Ligue 1,2022,1,0,1,2,2.0
+3084.0,Tino Kadewere,83,Nantes,61,Ligue 1,2024,1,0,1,2,2.0
+163.0,S. Aurier,65,Nottingham Forest,39,Premier League,2023,1,0,1,2,2.0
+163.0,S. Aurier,533,Villarreal,140,La Liga,2021,1,0,1,2,2.0
+164.0,B. Davies,47,Tottenham,39,Premier League,2021,1,0,1,2,2.0
+169.0,K. Trippier,34,Newcastle,39,Premier League,2022,1,0,1,2,2.0
+169.0,K. Trippier,34,Newcastle,39,Premier League,2024,1,0,1,2,2.0
+174.0,C. Eriksen,33,Manchester United,39,Premier League,2022,1,0,1,2,2.0
+174.0,C. Eriksen,33,Manchester United,39,Premier League,2023,1,0,1,2,2.0
+19959.0,B. White,42,Arsenal,39,Premier League,2022,1,0,1,2,2.0
+19480.0,H. Reed,36,Fulham,39,Premier League,2023,1,0,1,2,2.0
+3428.0,J. Ayew,52,Crystal Palace,39,Premier League,2021,1,0,1,2,2.0
+288769.0,T. Baldanzi,497,AS Roma,135,Serie A,2024,1,0,1,2,2.0
+289304.0,Antoine Joujou,111,Le Havre,61,Ligue 1,2023,1,0,1,2,2.0
+289304.0,Antoine Joujou,111,Le Havre,61,Ligue 1,2024,1,0,1,2,2.0
+289444.0,L. Blanco,797,Elche,140,La Liga,2022,1,0,1,2,2.0
+289555.0,L. Mouton,1063,Saint Etienne,61,Ligue 1,2024,1,0,1,2,2.0
+289761.0,G. Scalvini,499,Atalanta,135,Serie A,2023,1,0,1,2,2.0
+7649.0,D. Nemeth,186,FC St. Pauli,78,Bundesliga,2024,1,0,1,2,2.0
+19331.0,Connor Roberts,44,Burnley,39,Premier League,2023,1,0,1,2,2.0
+19346.0,R. Henry,55,Brentford,39,Premier League,2022,1,0,1,2,2.0
+19352.0,Sergi Canós,532,Valencia,140,La Liga,2024,1,0,1,2,2.0
+19361.0,S. Benrahma,48,West Ham,39,Premier League,2021,1,0,1,2,2.0
+19363.0,M. Forss,55,Brentford,39,Premier League,2021,1,0,1,2,2.0
+19364.0,N. Maupay,55,Brentford,39,Premier League,2023,1,0,1,2,2.0
+19480.0,H. Reed,36,Fulham,39,Premier League,2022,1,0,1,2,2.0
+288102.0,A. Wharton,52,Crystal Palace,39,Premier League,2023,1,0,1,2,2.0
+6931.0,L. Cacace,511,Empoli,135,Serie A,2023,1,0,1,2,2.0
+6931.0,L. Cacace,511,Empoli,135,Serie A,2024,1,0,1,2,2.0
+7106.0,K. Yeboah,495,Genoa,135,Serie A,2021,1,0,1,2,2.0
+7318.0,A. Dedić,81,Marseille,61,Ligue 1,2024,1,0,1,2,2.0
+7334.0,K. Adeyemi,165,Borussia Dortmund,78,Bundesliga,2023,1,0,1,2,2.0
+7334.0,K. Adeyemi,165,Borussia Dortmund,78,Bundesliga,2024,1,0,1,2,2.0
+7591.0,S. Lovrić,494,Udinese,135,Serie A,2024,1,0,1,2,2.0
+284797.0,Dango Ouattara,35,Bournemouth,39,Premier League,2023,1,0,1,2,2.0
+284797.0,Dango Ouattara,97,Lorient,61,Ligue 1,2022,1,0,1,2,2.0
+285909.0,Pablo Torre,547,Girona,140,La Liga,2023,1,0,1,2,2.0
+286458.0,J. Devenny,52,Crystal Palace,39,Premier League,2024,1,0,1,2,2.0
+286601.0,O. El Hilali,540,Espanyol,140,La Liga,2024,1,0,1,2,2.0
+286894.0,J. Gittens,165,Borussia Dortmund,78,Bundesliga,2023,1,0,1,2,2.0
+287680.0,Maroan Sannadi,531,Athletic Club,140,La Liga,2024,1,0,1,2,2.0
+288074.0,Alberto Marí,532,Valencia,140,La Liga,2023,1,0,1,2,2.0
+19147.0,C. Dawson,39,Wolves,39,Premier League,2023,1,0,1,2,2.0
+19163.0,J. Murphy,34,Newcastle,39,Premier League,2024,1,0,1,2,2.0
+19169.0,J. Rodríguez,44,Burnley,39,Premier League,2021,1,0,1,2,2.0
+19172.0,Ørjan Nyland,173,RB Leipzig,78,Bundesliga,2022,1,0,1,2,2.0
+19187.0,J. Grealish,50,Manchester City,39,Premier League,2021,1,0,1,2,2.0
+19191.0,J. McGinn,66,Aston Villa,39,Premier League,2022,1,0,1,2,2.0
+7722.0,S. Kalajdzic,172,VfB Stuttgart,78,Bundesliga,2022,1,0,1,2,2.0
+7754.0,Mohamed Camara,91,Monaco,61,Ligue 1,2022,1,0,1,2,2.0
+19278.0,Famara Diédhiou,715,Granada CF,140,La Liga,2023,1,0,1,2,2.0
+19305.0,R. Yates,65,Nottingham Forest,39,Premier League,2022,1,0,1,2,2.0
+6231.0,Facundo Medina,116,Lens,61,Ligue 1,2023,1,0,1,2,2.0
+6383.0,Martín Payero,494,Udinese,135,Serie A,2024,1,0,1,2,2.0
+6420.0,M. Retegui,495,Genoa,135,Serie A,2023,1,0,1,2,2.0
+6503.0,N. Molina,530,Atletico Madrid,140,La Liga,2024,1,0,1,2,2.0
+6610.0,Marcos Senesi,35,Bournemouth,39,Premier League,2023,1,0,1,2,2.0
+19139.0,T. Roberts,63,Leeds,39,Premier League,2021,1,0,1,2,2.0
+8681.0,N. Alioui,111,Le Havre,61,Ligue 1,2023,1,0,1,2,2.0
+19192.0,J. Ramsey,66,Aston Villa,39,Premier League,2024,1,0,1,2,2.0
+19194.0,T. Abraham,489,AC Milan,135,Serie A,2024,1,0,1,2,2.0
+19195.0,A. El Ghazi,66,Aston Villa,39,Premier League,2021,1,0,1,2,2.0
+19209.0,Fikayo Tomori,489,AC Milan,135,Serie A,2022,1,0,1,2,2.0
+19221.0,H. Wilson,36,Fulham,39,Premier League,2023,1,0,1,2,2.0
+19250.0,B. Brahimi,77,Angers,61,Ligue 1,2021,1,0,1,2,2.0
+19263.0,L. Kelly,35,Bournemouth,39,Premier League,2022,1,0,1,2,2.0
+290740.0,I. Akhomach,533,Villarreal,140,La Liga,2023,1,0,1,2,2.0
+291649.0,Vanderson,91,Monaco,61,Ligue 1,2022,1,0,1,2,2.0
+292218.0,M. Ljubičić,182,Union Berlin,78,Bundesliga,2024,1,0,1,2,2.0
+295793.0,Marc Pubill,539,Levante,140,La Liga,2021,1,0,1,2,2.0
+296560.0,Jackson Tchatchoua,504,Verona,135,Serie A,2023,1,0,1,2,2.0
+296667.0,Gavi,529,Barcelona,140,La Liga,2023,1,0,1,2,2.0
+297311.0,Kike Salas,536,Sevilla,140,La Liga,2022,1,0,1,2,2.0
+298006.0,N. Mbamba,168,Bayer Leverkusen,78,Bundesliga,2023,1,0,1,2,2.0
+19035.0,H. Elliott,40,Liverpool,39,Premier League,2024,1,0,1,2,2.0
+19073.0,B. Godfrey,45,Everton,39,Premier League,2022,1,0,1,2,2.0
+19090.0,George Baldock,62,Sheffield Utd,39,Premier League,2023,1,0,1,2,2.0
+19116.0,L. Ayling,63,Leeds,39,Premier League,2022,1,0,1,2,2.0
+19119.0,L. Davis,57,Ipswich,39,Premier League,2024,1,0,1,2,2.0
+143.0,Carles Aleñá,546,Getafe,140,La Liga,2022,1,0,1,2,2.0
+143.0,Carles Aleñá,546,Getafe,140,La Liga,2023,1,0,1,2,2.0
+153.0,O. Dembélé,85,Paris Saint Germain,61,Ligue 1,2023,1,0,1,2,2.0
+10097.0,Éderson,514,Salernitana,135,Serie A,2021,1,0,1,2,2.0
+10225.0,João Victor,83,Nantes,61,Ligue 1,2022,1,0,1,2,2.0
+10238.0,Carlos Augusto,505,Inter,135,Serie A,2023,1,0,1,2,2.0
+18965.0,Martín Montoya,543,Real Betis,140,La Liga,2021,1,0,1,2,2.0
+18973.0,S. March,51,Brighton,39,Premier League,2022,1,0,1,2,2.0
+18973.0,S. March,51,Brighton,39,Premier League,2023,1,0,1,2,2.0
+19016.0,C. Chambers,66,Aston Villa,39,Premier League,2023,1,0,1,2,2.0
+19027.0,N. Kebano,36,Fulham,39,Premier League,2022,1,0,1,2,2.0
+314511.0,A. Nusa,173,RB Leipzig,78,Bundesliga,2024,1,0,1,2,2.0
+315026.0,Y. Kallon,495,Genoa,135,Serie A,2021,1,0,1,2,2.0
+122.0,Jordi Mboula,504,Verona,135,Serie A,2023,1,0,1,2,2.0
+130.0,Nélson Semedo,39,Wolves,39,Premier League,2023,1,0,1,2,2.0
+134.0,Juan Miranda,543,Real Betis,140,La Liga,2021,1,0,1,2,2.0
+134.0,Juan Miranda,543,Real Betis,140,La Liga,2022,1,0,1,2,2.0
+138.0,J. Todibo,84,Nice,61,Ligue 1,2023,1,0,1,2,2.0
+10097.0,Éderson,499,Atalanta,135,Serie A,2022,1,0,1,2,2.0
+8474.0,T. De Smet,93,Reims,61,Ligue 1,2022,1,0,1,2,2.0
+8518.0,M. Sylla,720,Valladolid,140,La Liga,2024,1,0,1,2,2.0
+8586.0,Mërgim Vojvoda,503,Torino,135,Serie A,2022,1,0,1,2,2.0
+8586.0,Mërgim Vojvoda,503,Torino,135,Serie A,2023,1,0,1,2,2.0
+309364.0,Coba,546,Getafe,140,La Liga,2024,1,0,1,2,2.0
+311334.0,F. Buonanotte,51,Brighton,39,Premier League,2022,1,0,1,2,2.0
+312985.0,S. Vignato,1579,Monza,135,Serie A,2022,1,0,1,2,2.0
+313937.0,Antoine Mendy,84,Nice,61,Ligue 1,2022,1,0,1,2,2.0
+18872.0,Lewis Cook,35,Bournemouth,39,Premier League,2023,1,0,1,2,2.0
+18895.0,Florian Lejeune,728,Rayo Vallecano,140,La Liga,2024,1,0,1,2,2.0
+10316.0,Caio Henrique,91,Monaco,61,Ligue 1,2022,1,0,1,2,2.0
+10375.0,Iago,170,FC Augsburg,78,Bundesliga,2021,1,0,1,2,2.0
+10375.0,Iago,170,FC Augsburg,78,Bundesliga,2023,1,0,1,2,2.0
+11421.0,G. Suazo,96,Toulouse,61,Ligue 1,2022,1,0,1,2,2.0
+11421.0,G. Suazo,96,Toulouse,61,Ligue 1,2023,1,0,1,2,2.0
+11421.0,G. Suazo,96,Toulouse,61,Ligue 1,2024,1,0,1,2,2.0
+18961.0,Dan Burn,34,Newcastle,39,Premier League,2024,1,0,1,2,2.0
+8845.0,Daan Heymans,517,Venezia,135,Serie A,2021,1,0,1,2,2.0
+9971.0,Antony,33,Manchester United,39,Premier League,2022,1,0,1,2,2.0
+9975.0,Brenner,494,Udinese,135,Serie A,2024,1,0,1,2,2.0
+10009.0,Rodrygo,541,Real Madrid,140,La Liga,2021,1,0,1,2,2.0
+18854.0,A. Townsend,1359,Luton,39,Premier League,2023,1,0,1,2,2.0
+18867.0,Diego Rico,546,Getafe,140,La Liga,2023,1,0,1,2,2.0
+18869.0,A. Smith,35,Bournemouth,39,Premier League,2023,1,0,1,2,2.0
+328033.0,A. Pavlović,157,Bayern München,78,Bundesliga,2023,1,0,1,2,2.0
+328046.0,I. Koné,94,Rennes,61,Ligue 1,2024,1,0,1,2,2.0
+18902.0,Kenedy,720,Valladolid,140,La Liga,2022,1,0,1,2,2.0
+18906.0,Ayoze Pérez,46,Leicester,39,Premier League,2022,1,0,1,2,2.0
+18918.0,C. Taylor,44,Burnley,39,Premier League,2021,1,0,1,2,2.0
+18929.0,D. McNeil,45,Everton,39,Premier League,2024,1,0,1,2,2.0
+18944.0,Maya Yoshida,498,Sampdoria,135,Serie A,2021,1,0,1,2,2.0
+18955.0,D. Ings,48,West Ham,39,Premier League,2022,1,0,1,2,2.0
+319572.0,V. Barco,95,Strasbourg,61,Ligue 1,2024,1,0,1,2,2.0
+319919.0,O. El Azzouzi,500,Bologna,135,Serie A,2023,1,0,1,2,2.0
+323935.0,G. Simeone,530,Atletico Madrid,140,La Liga,2024,1,0,1,2,2.0
+325346.0,G. Restes,96,Toulouse,61,Ligue 1,2024,1,0,1,2,2.0
+326068.0,K. Doumbia,93,Reims,61,Ligue 1,2022,1,0,1,2,2.0
+327646.0,L. Ullrich,163,Borussia Mönchengladbach,78,Bundesliga,2024,1,0,1,2,2.0
+327763.0,R. Burnete,867,Lecce,135,Serie A,2023,1,0,1,2,2.0
+327895.0,P. Wanner,180,1. FC Heidenheim,78,Bundesliga,2024,1,0,1,2,2.0
+18.0,J. Sancho,165,Borussia Dortmund,78,Bundesliga,2023,1,0,1,2,2.0
+17.0,C. Pulišić,49,Chelsea,39,Premier League,2022,1,0,1,2,2.0
+439817.0,A. Ali Abdallah,95,Strasbourg,61,Ligue 1,2023,1,0,1,2,2.0
+443141.0,K. Maussi Martins,1579,Monza,135,Serie A,2024,1,0,1,2,2.0
+8.0,Raphaël Guerreiro,157,Bayern München,78,Bundesliga,2024,1,0,1,2,2.0
+16.0,M. Götze,169,Eintracht Frankfurt,78,Bundesliga,2023,1,0,1,2,2.0
+9.0,A. Hakimi,85,Paris Saint Germain,61,Ligue 1,2022,1,0,1,2,2.0
+352375.0,Arthur,168,Bayer Leverkusen,78,Bundesliga,2023,1,0,1,2,2.0
+347265.0,B. Domínguez,500,Bologna,135,Serie A,2024,1,0,1,2,2.0
+45.0,T. Lemar,530,Atletico Madrid,140,La Liga,2022,1,0,1,2,2.0
+48.0,Saúl Ñíguez,530,Atletico Madrid,140,La Liga,2022,1,0,1,2,2.0
+49.0,T. Partey,42,Arsenal,39,Premier League,2021,1,0,1,2,2.0
+381122.0,T. Dago,79,Lille,61,Ligue 1,2023,1,0,1,2,2.0
+23.0,Sergio Gómez,548,Real Sociedad,140,La Liga,2024,1,0,1,2,2.0
+23.0,Sergio Gómez,50,Manchester City,39,Premier League,2023,1,0,1,2,2.0
+19.0,Julian Weigl,163,Borussia Mönchengladbach,78,Bundesliga,2023,1,0,1,2,2.0
+109.0,A. Golovin,91,Monaco,61,Ligue 1,2021,1,0,1,2,2.0
+114.0,Adrien Silva,498,Sampdoria,135,Serie A,2021,1,0,1,2,2.0
+340077.0,M. Fernandez-Pardo,79,Lille,61,Ligue 1,2024,1,0,1,2,2.0
+340700.0,Jacopo Fazzini,511,Empoli,135,Serie A,2023,1,0,1,2,2.0
+342022.0,M. Kayode,502,Fiorentina,135,Serie A,2023,1,0,1,2,2.0
+342177.0,N. Weiper,164,FSV Mainz 05,78,Bundesliga,2024,1,0,1,2,2.0
+343287.0,Dailon Livramento,504,Verona,135,Serie A,2024,1,0,1,2,2.0
+343317.0,S. Ngoura,111,Le Havre,61,Ligue 1,2023,1,0,1,2,2.0
+18771.0,Ricardo Pereira,46,Leicester,39,Premier League,2021,1,0,1,2,2.0
+15797.0,J. Cajuste,492,Napoli,135,Serie A,2023,1,0,1,2,2.0
+15799.0,F. Onyeka,55,Brentford,39,Premier League,2022,1,0,1,2,2.0
+15874.0,A. Jung,162,Werder Bremen,78,Bundesliga,2022,1,0,1,2,2.0
+15881.0,Morten Frendrup,495,Genoa,135,Serie A,2023,1,0,1,2,2.0
+15884.0,J. Lindstrøm,169,Eintracht Frankfurt,78,Bundesliga,2022,1,0,1,2,2.0
+15908.0,M. Damsgaard,55,Brentford,39,Premier League,2023,1,0,1,2,2.0
+102.0,D. Sidibé,96,Toulouse,61,Ligue 1,2024,1,0,1,2,2.0
+47519.0,Pedro Porro,47,Tottenham,39,Premier League,2024,1,0,1,2,2.0
+47520.0,Portu,546,Getafe,140,La Liga,2022,1,0,1,2,2.0
+47522.0,Douglas Luiz,66,Aston Villa,39,Premier League,2021,1,0,1,2,2.0
+47533.0,Alejandro Catena,727,Osasuna,140,La Liga,2024,1,0,1,2,2.0
+47533.0,Alejandro Catena,728,Rayo Vallecano,140,La Liga,2021,1,0,1,2,2.0
+47541.0,Santi Comesaña,728,Rayo Vallecano,140,La Liga,2022,1,0,1,2,2.0
+881.0,H. Nicolussi,517,Venezia,135,Serie A,2024,1,0,1,2,2.0
+882.0,David de Gea,502,Fiorentina,135,Serie A,2024,1,0,1,2,2.0
+918.0,José Gayà,532,Valencia,140,La Liga,2024,1,0,1,2,2.0
+924.0,F. Coquelin,83,Nantes,61,Ligue 1,2024,1,0,1,2,2.0
+927.0,Lee Kang-In,85,Paris Saint Germain,61,Ligue 1,2023,1,0,1,2,2.0
+47492.0,Toni Villa,547,Girona,140,La Liga,2022,1,0,1,2,2.0
+47494.0,Miguel de la Fuente,542,Alaves,140,La Liga,2021,1,0,1,2,2.0
+47496.0,Óscar Plano,720,Valladolid,140,La Liga,2022,1,0,1,2,2.0
+47514.0,Valery,547,Girona,140,La Liga,2022,1,0,1,2,2.0
+47519.0,Pedro Porro,47,Tottenham,39,Premier League,2023,1,0,1,2,2.0
+899.0,Andreas Pereira,36,Fulham,39,Premier League,2023,1,0,1,2,2.0
+47543.0,Álvaro García,728,Rayo Vallecano,140,La Liga,2021,1,0,1,2,2.0
+47543.0,Álvaro García,728,Rayo Vallecano,140,La Liga,2022,1,0,1,2,2.0
+47551.0,Raúl de Tomás,728,Rayo Vallecano,140,La Liga,2023,1,0,1,2,2.0
+47566.0,Javi Galán,530,Atletico Madrid,140,La Liga,2024,1,0,1,2,2.0
+47566.0,Javi Galán,538,Celta Vigo,140,La Liga,2021,1,0,1,2,2.0
+47696.0,A. Bernhardsson,191,Holstein Kiel,78,Bundesliga,2024,1,0,1,2,2.0
+48047.0,J. Karlström,494,Udinese,135,Serie A,2024,1,0,1,2,2.0
+367636.0,J. Jacquet,99,Clermont Foot,61,Ligue 1,2023,1,0,1,2,2.0
+374058.0,L. Camara,112,Metz,61,Ligue 1,2023,1,0,1,2,2.0
+380690.0,M. Moore,47,Tottenham,39,Premier League,2024,1,0,1,2,2.0
+892.0,C. Smalling,497,AS Roma,135,Serie A,2022,1,0,1,2,2.0
+894.0,Ashley Young,45,Everton,39,Premier League,2024,1,0,1,2,2.0
+894.0,Ashley Young,66,Aston Villa,39,Premier League,2021,1,0,1,2,2.0
+898.0,Ander Herrera,531,Athletic Club,140,La Liga,2023,1,0,1,2,2.0
+899.0,Andreas Pereira,36,Fulham,39,Premier League,2022,1,0,1,2,2.0

--- a/fetch_clutch_data.py
+++ b/fetch_clutch_data.py
@@ -99,10 +99,22 @@ async def fetch_events_async(
                 e["league"] = league
                 e["league_id"] = league_id
                 e["season"] = season
-                # Flatten team info so it is retained in the exported CSV.
-                team = e.get("team", {})
+
+                team = e.pop("team", {})
                 e["team_id"] = team.get("id")
                 e["team_name"] = team.get("name")
+                e["team_logo"] = team.get("logo")
+
+                player = e.pop("player", {})
+                e["player_id"] = player.get("id")
+                e["player_name"] = player.get("name")
+                e["player_photo"] = player.get("photo")
+
+                assist = e.pop("assist", {})
+                e["assist_id"] = assist.get("id")
+                e["assist_name"] = assist.get("name")
+                e["assist_photo"] = assist.get("photo")
+
                 events.append(e)
 
         tasks = [asyncio.create_task(_get(fid)) for fid in fixture_ids]
@@ -139,9 +151,18 @@ def main(use_async: bool = False) -> None:
                             e["league"] = league_name
                             e["league_id"] = league_id
                             e["season"] = season
-                            team = e.get("team", {})
+                            team = e.pop("team", {})
                             e["team_id"] = team.get("id")
                             e["team_name"] = team.get("name")
+                            e["team_logo"] = team.get("logo")
+                            player = e.pop("player", {})
+                            e["player_id"] = player.get("id")
+                            e["player_name"] = player.get("name")
+                            e["player_photo"] = player.get("photo")
+                            assist = e.pop("assist", {})
+                            e["assist_id"] = assist.get("id")
+                            e["assist_name"] = assist.get("name")
+                            e["assist_photo"] = assist.get("photo")
                             all_events.append(e)
                         time.sleep(THROTTLE)
                     except Exception as ex:

--- a/init_db.py
+++ b/init_db.py
@@ -1,0 +1,237 @@
+"""Create an SQLite database from the available CSV files.
+
+This script reads `events_raw.csv` and `clutch_summary.csv` and
+normalizes the data into separate tables for leagues, teams, players, and
+events.  The resulting database is saved as `clutch.db` in the project
+root.
+"""
+from __future__ import annotations
+
+import csv
+import sqlite3
+from pathlib import Path
+from typing import Dict
+
+DB_PATH = Path("clutch.db")
+EVENTS_CSV = Path("events_raw.csv")
+SUMMARY_CSV = Path("clutch_summary.csv")
+
+# Known league identifiers from the API in case the CSV lacks them
+LEAGUE_IDS = {
+    "Premier League": 39,
+    "La Liga": 140,
+    "Ligue 1": 61,
+    "Bundesliga": 78,
+    "Serie A": 135,
+}
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create empty tables in the SQLite database."""
+    cur = conn.cursor()
+
+    # Core lookup tables
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS leagues (
+            id INTEGER PRIMARY KEY,
+            name TEXT UNIQUE
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS teams (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            logo TEXT,
+            league_id INTEGER,
+            FOREIGN KEY (league_id) REFERENCES leagues(id)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS players (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            image TEXT
+        )
+        """
+    )
+
+    # Events table linking to leagues, teams and players
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            type TEXT,
+            detail TEXT,
+            comments TEXT,
+            fixture_id INTEGER,
+            league_id INTEGER,
+            season INTEGER,
+            time_elapsed INTEGER,
+            time_extra INTEGER,
+            team_id INTEGER,
+            player_id INTEGER,
+            assist_id INTEGER,
+            FOREIGN KEY (league_id) REFERENCES leagues(id),
+            FOREIGN KEY (team_id) REFERENCES teams(id),
+            FOREIGN KEY (player_id) REFERENCES players(id),
+            FOREIGN KEY (assist_id) REFERENCES players(id)
+        )
+        """
+    )
+
+    # Summary table derived from clutch_summary.csv
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS clutch_summary (
+            player_id INTEGER,
+            player_name TEXT,
+            team_id INTEGER,
+            team_name TEXT,
+            league_id INTEGER,
+            league TEXT,
+            year INTEGER,
+            clutch_matches INTEGER,
+            clutch_goal INTEGER,
+            clutch_assist INTEGER,
+            clutch_score INTEGER,
+            score_per_match REAL,
+            FOREIGN KEY (player_id) REFERENCES players(id),
+            FOREIGN KEY (team_id) REFERENCES teams(id),
+            FOREIGN KEY (league_id) REFERENCES leagues(id)
+        )
+        """
+    )
+
+    conn.commit()
+
+
+def load_events(conn: sqlite3.Connection) -> None:
+    """Populate the database with event data from EVENTS_CSV."""
+    cur = conn.cursor()
+    league_cache: Dict[int, int] = {}
+
+    with EVENTS_CSV.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            league_name = row["league"]
+            # Determine API league ID, falling back to known constants
+            league_id = row.get("league_id") or LEAGUE_IDS.get(league_name)
+            if league_id is None:
+                raise ValueError(f"Unknown league id for {league_name}")
+            league_id = int(league_id)
+
+            # Insert league if unseen
+            if league_id not in league_cache:
+                cur.execute(
+                    "INSERT OR IGNORE INTO leagues(id, name) VALUES (?, ?)",
+                    (league_id, league_name),
+                )
+                league_cache[league_id] = league_id
+
+            # Insert team
+            team_id = int(row.get("team.id") or row.get("team_id"))
+            cur.execute(
+                "INSERT OR IGNORE INTO teams(id, name, logo, league_id) VALUES (?, ?, ?, ?)",
+                (team_id, row.get("team.name") or row.get("team_name"), row.get("team.logo") or row.get("team_logo"), league_id),
+            )
+
+            # Insert players (main player and assister, if any)
+            player_id = row.get("player.id") or row.get("player_id")
+            player_name = row.get("player.name") or row.get("player_name")
+            player_img = row.get("player.photo") or row.get("player_photo")
+            if player_id and player_name:
+                cur.execute(
+                    "INSERT OR IGNORE INTO players(id, name, image) VALUES (?, ?, ?)",
+                    (int(player_id), player_name, player_img),
+                )
+            assist_id = row.get("assist.id") or row.get("assist_id")
+            assist_name = row.get("assist.name") or row.get("assist_name")
+            assist_img = row.get("assist.photo") or row.get("assist_photo")
+            if assist_id and assist_name:
+                # assist IDs are sometimes stored as floats in the CSV
+                cur.execute(
+                    "INSERT OR IGNORE INTO players(id, name, image) VALUES (?, ?, ?)",
+                    (int(float(assist_id)), assist_name, assist_img),
+                )
+
+            # Insert event row
+            cur.execute(
+                """
+                INSERT INTO events(
+                    type, detail, comments, fixture_id, league_id, season,
+                    time_elapsed, time_extra, team_id, player_id, assist_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row["type"],
+                    row["detail"],
+                    row.get("comments"),
+                    int(row["fixture_id"]),
+                    league_id,
+                    int(row["season"]),
+                    int(row["time.elapsed"]) if row["time.elapsed"] else None,
+                    int(float(row["time.extra"])) if row["time.extra"] else None,
+                    team_id,
+                    int(player_id) if player_id else None,
+                    int(float(assist_id)) if assist_id else None,
+                ),
+            )
+
+    conn.commit()
+
+
+def load_summary(conn: sqlite3.Connection) -> None:
+    """Populate the clutch_summary table from SUMMARY_CSV."""
+    cur = conn.cursor()
+
+    with SUMMARY_CSV.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = [
+            (
+                int(float(r.get("player_id"))) if r.get("player_id") else None,
+                r.get("player_name"),
+                int(float(r.get("team_id"))) if r.get("team_id") else None,
+                r.get("team_name"),
+                int(float(r.get("league_id"))) if r.get("league_id") else None,
+                r.get("league"),
+                int(r["year"]),
+                int(r["Clutch_Matches"]),
+                int(r["Clutch_Goal"]),
+                int(r["Clutch_Assist"]),
+                int(r["Clutch_Score"]),
+                float(r["Score_per_Match"]),
+            )
+            for r in reader
+        ]
+    cur.executemany(
+        """
+        INSERT INTO clutch_summary(
+            player_id, player_name, team_id, team_name, league_id, league,
+            year, clutch_matches, clutch_goal, clutch_assist, clutch_score,
+            score_per_match
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        rows,
+    )
+    conn.commit()
+
+
+def main() -> None:
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+
+    conn = sqlite3.connect(DB_PATH)
+    create_tables(conn)
+    load_events(conn)
+    load_summary(conn)
+    conn.close()
+    print(f"✅ Created database at {DB_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/process_clutch.py
+++ b/process_clutch.py
@@ -1,75 +1,153 @@
+"""Generate clutch statistics from the SQLite events database.
+
+This script reads goal events from ``clutch.db`` and computes late-game
+goals and assists (minute >= 76).  Results are written to both a CSV file
+and the ``clutch_summary`` table inside the same database.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
 import pandas as pd
 
-df = pd.read_csv("events_raw.csv")
-print("Total events:", df.shape[0])
+DB_PATH = Path("clutch.db")
 
-# Step 1: Normalize fields
-required_cols = { 'player.name', 'league', 'season', 'team.name'}
-missing = [c for c in required_cols if c not in df.columns]
-if 'team.name' not in df.columns and 'team.name' not in df.columns:
-    missing.append('team_name')
-if missing:
-    raise ValueError(f"Missing columns in raw data: {missing}")
 
-df['minute'] = df['time.elapsed']
-df['player_name'] = df['player.name']
-df['team_name'] = df['team_name'] if 'team_name' in df.columns else df['team.name']
-df['team_id'] = df['team_id'] if 'team_id' in df.columns else df['team.id']
+def load_clutch_events(conn: sqlite3.Connection) -> pd.DataFrame:
+    """Return goal events with joined metadata needed for clutch stats."""
+    query = """
+        SELECT e.fixture_id,
+               e.league_id,
+               l.name   AS league,
+               e.season,
+               t.id     AS team_id,
+               t.name   AS team_name,
+               p.id     AS player_id,
+               p.name   AS player_name,
+               e.time_elapsed,
+               a.id     AS assist_id,
+               a.name   AS assist_name
+        FROM events e
+        JOIN leagues l ON e.league_id = l.id
+        JOIN teams   t ON e.team_id = t.id
+        JOIN players p ON e.player_id = p.id
+        LEFT JOIN players a ON e.assist_id = a.id
+        WHERE e.type = 'Goal'
+          AND e.detail IN ('Normal Goal', 'Penalty', 'Own Goal')
+          AND e.time_elapsed >= 76
+    """
+    return pd.read_sql_query(query, conn)
 
-# Step 2: Filter for clutch-relevant events
-goals = df[(df['type'] == 'Goal') & (df['detail'].isin(['Normal Goal', 'Penalty', 'Own Goal']))]
-assists = df[df['detail'] == 'Assist']
 
-print("Goals found:", goals.shape[0])
-print("Assists found:", assists.shape[0])
+def main() -> None:
+    conn = sqlite3.connect(DB_PATH)
+    df = load_clutch_events(conn)
+    print("Clutch goal events:", df.shape[0])
 
-# Step 3: Filter to clutch time (minute >= 76)
-goals = goals[goals['minute'] >= 76]
-assists = assists[assists['minute'] >= 76]
+    # Scoring players
+    goals = df[
+        [
+            "player_id",
+            "player_name",
+            "team_id",
+            "team_name",
+            "league_id",
+            "league",
+            "season",
+            "fixture_id",
+        ]
+    ].copy()
+    goals["Clutch_Goal"] = 1
+    goals["Clutch_Assist"] = 0
 
-print("Clutch goals:", goals.shape[0])
-print("Clutch assists:", assists.shape[0])
-
-# Step 4: Tag & merge
-goals['Clutch_Goal'] = 1
-goals['Clutch_Assist'] = 0
-
-assists['Clutch_Goal'] = 0
-assists['Clutch_Assist'] = 1
-
-clutch_df = pd.concat([goals, assists])
-# Preserve both league name and ID so downstream consumers can show readable
-# options yet still filter by the underlying identifier if needed.
-clutch_df = clutch_df[
-    [
-        'player_name',
-        'team_name',
-        'fixture_id',
-        'league',
-        'season',
-        'Clutch_Goal',
-        'Clutch_Assist',
-    ]
-]
-
-# Step 5: Group and summarize
-summary = (
-    clutch_df.groupby(['player_name', 'team_name', 'league', 'season'])
-    .agg(
-        {
-            'fixture_id': 'nunique',
-            'Clutch_Goal': 'sum',
-            'Clutch_Assist': 'sum',
-        }
+    # Assisting players (if any)
+    assists = df[df["assist_name"].notnull()][
+        [
+            "assist_id",
+            "assist_name",
+            "team_id",
+            "team_name",
+            "league_id",
+            "league",
+            "season",
+            "fixture_id",
+        ]
+    ].copy()
+    assists.rename(
+        columns={"assist_id": "player_id", "assist_name": "player_name"},
+        inplace=True,
     )
-    .rename(columns={'fixture_id': 'Clutch_Matches'})
-    .reset_index()
-)
+    assists["Clutch_Goal"] = 0
+    assists["Clutch_Assist"] = 1
 
-summary.rename(columns={'season': 'year'}, inplace=True)
-summary['Clutch_Score'] = summary['Clutch_Goal'] * 3 + summary['Clutch_Assist'] * 2
-summary['Score_per_Match'] = summary['Clutch_Score'] / summary['Clutch_Matches']
-summary = summary.sort_values('Clutch_Score', ascending=False)
+    clutch_df = pd.concat([goals, assists], ignore_index=True)
 
-summary.to_csv("clutch_summary.csv", index=False)
-print("✅ clutch_summary.csv generated with", summary.shape[0], "rows")
+    summary = (
+        clutch_df.groupby(
+            [
+                "player_id",
+                "player_name",
+                "team_id",
+                "team_name",
+                "league_id",
+                "league",
+                "season",
+            ]
+        )
+        .agg(
+            {
+                "fixture_id": "nunique",
+                "Clutch_Goal": "sum",
+                "Clutch_Assist": "sum",
+            }
+        )
+        .rename(columns={"fixture_id": "Clutch_Matches"})
+        .reset_index()
+    )
+
+    summary.rename(columns={"season": "year"}, inplace=True)
+    summary["Clutch_Score"] = summary["Clutch_Goal"] * 3 + summary["Clutch_Assist"] * 2
+    summary["Score_per_Match"] = summary["Clutch_Score"] / summary["Clutch_Matches"]
+    summary = summary.sort_values("Clutch_Score", ascending=False)
+
+    summary.to_csv("clutch_summary.csv", index=False)
+
+    cur = conn.cursor()
+    cur.execute("DELETE FROM clutch_summary")
+    cur.executemany(
+        """
+        INSERT INTO clutch_summary(
+            player_id, player_name, team_id, team_name, league_id, league,
+            year, clutch_matches, clutch_goal, clutch_assist,
+            clutch_score, score_per_match
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                int(row.player_id),
+                row.player_name,
+                int(row.team_id),
+                row.team_name,
+                int(row.league_id),
+                row.league,
+                int(row.year),
+                int(row.Clutch_Matches),
+                int(row.Clutch_Goal),
+                int(row.Clutch_Assist),
+                int(row.Clutch_Score),
+                float(row.Score_per_Match),
+            )
+            for row in summary.itertuples(index=False)
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    print("✅ clutch_summary table updated with", summary.shape[0], "rows")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Include API league IDs and player photos in the SQLite schema
- Flatten API responses to store team/player IDs and images in events
- Compute clutch summaries keyed by player_id and league_id
- Remove generated `clutch.db` from source control and parse float IDs when loading summaries

## Testing
- `python init_db.py`
- `python process_clutch.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7cd71a2483229ece7d3257ef0fb7