### PR TITLE
Strip squad numbers and punctuation from player names

### DIFF
--- a/process_clutch.py
+++ b/process_clutch.py
@@ -86,7 +86,9 @@ def main() -> None:
 
     # Clean player names that may include leading squad numbers or extra whitespace
     clutch_df["player_name"] = (
-        clutch_df["player_name"].str.replace(r"^\d+\s*", "", regex=True).str.strip()
+        clutch_df["player_name"]
+        .str.replace(r"^\d+[\s.-]*", "", regex=True)
+        .str.strip()
     )
 
     summary = (


### PR DESCRIPTION
## Summary
- clean player names by removing leading digits and punctuation
- regenerate clutch summary data

## Testing
- `python process_clutch.py`
- `sqlite3 clutch.db "SELECT COUNT(*) FROM clutch_summary WHERE substr(player_name,1,1) BETWEEN '0' AND '9';"`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abcfe8f2e48322bbea6bdb2178fd0c